### PR TITLE
New jobs are not or incorrectly saved.

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -101,9 +101,12 @@ Agenda.prototype.saveJob = function(job, cb) {
   if(props.type == 'single')
     this._db.findAndModify({name: props.name, type: 'single'}, {}, {$set: props}, {upsert: true, new: true}, processDbResult);
   else {
-    var query = {};
-    if(job.attrs._id) query._id = job.attrs._id;
-    this._db.findAndModify(query, {$set: props}, {upsert: true, new: true}, processDbResult);
+    if(job.attrs._id) {
+      this._db.findAndModify({_id: job.attrs._id}, {}, {$set: props}, {upsert: true}, processDbResult);
+    }
+    else {
+      this._db.insert(props, processDbResult);
+    }
   }
 
   function processDbResult(err, res) {


### PR DESCRIPTION
```
var job = agenda.create('myJobHandler', {});
job.repeatEvery('10 minutes');
job.save();
```

Expected:
Job is added to the agendaJobs collection.

Actual:
An existing job is updated with `attrs` from the created job (data corruption). The new job will _not_ be inserted.

Cause:
Since new jobs don’t have an `_id`, `findAndModify` executes with an empty query and thus updates the first job found. If there are no jobs yet, `findAndModify` throws: `exception: upsert mode requires query field`.

Fix:
Use `findAndModify` only if the job has an `_id`, use `insert` otherwise.
