### PR TITLE
removing modella dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
     "url": "https://github.com/rschmukler/agenda/issues"
   },
   "dependencies": {
-    "modella": "~0.1.7",
-    "modella-mongo": "~0.1.4",
     "human-interval": "0.1.1",
     "date.js": "~0.1.1",
     "mongoskin": "~0.6.0"


### PR DESCRIPTION
Looks like modella isn't used. Safe to remove? It uses monk, which has a very old version of mongodb listed as a dependency, which will bloat upstream npm shrinkwraps:

```
"modella-mongo": {
      "version": "0.1.4",
      "from": "modella-mongo@~0.1.4",
      "dependencies": {
        "batch": {
          "version": "0.2.1",
          "from": "batch@~0.2.1"
        },
        "monk": {
          "version": "0.7.1",
          "from": "monk@~0.7.0",
          "dependencies": {
            "mongoskin": {
              "version": "0.4.4",
              "from": "mongoskin@0.4.4",
              "dependencies": {
                "mongodb": {
                  "version": "1.1.11",
```
