### PR TITLE
Assured `props.nextRunAt` and `now` are numbers so they can be compared.

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -102,6 +102,11 @@ Agenda.prototype.schedule = function(when, name, data) {
 Agenda.prototype.saveJob = function(job, cb) {
   var fn = cb;
   var props = getJobProperties(job);
+  
+  if(props.nextRunAt){ // assure nextRunAt is a number so it can be compared with "now"  -RR
+    props.nextRunAt=(new Date(props.nextRunAt)).getTime();
+  }
+  
   if(props.type == 'single')
     this._db.findAndModify({name: props.name, type: 'single'}, {}, {$set: props}, {upsert: true, new: true}, processDbResult);
   else {
@@ -147,7 +152,9 @@ Agenda.prototype.stop = function() {
 function processJobs() {
   var definitions = this._definitions,
       self = this;
-  var now = new Date();
+      
+  var now = (new Date()).getTime(); // make sure now is a number -RR
+  
   this.jobs({nextRunAt: {$lte: now}}, {sort: {'priority': -1}}, function(err, jobs) {
     if(err) throw(err);
     else fillJobQueue();


### PR DESCRIPTION
In my simple testing, it appeared that dates used to determine if a job was ready to run were being compared inconsistently. Refactored to assure we always use numbers for compares.
