### PR TITLE
addJobWorker in example was pushing to webWorkers

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ function addWebWorker() {
 }
 
 function addJobWorker() {
-    webWorkers.push(cluster.fork({job: 1}).id);
+    jobWorkers.push(cluster.fork({job: 1}).id);
 }
 
 function removeWebWorker(id) {


### PR DESCRIPTION
I fixed the example of spawning/forking processes so calling addJobWorker would push to jobWorkers instead of webWorkers.
