### PR TITLE
Allow every and schedule to take array of job names

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -83,20 +83,52 @@ Agenda.prototype.define = function(name, options, processor) {
   };
 };
 
-Agenda.prototype.every = function(interval, name, data) {
-  var job;
-  job = this.create(name, data);
-  job.attrs.type = 'single';
-  job.repeatEvery(interval);
-  job.save();
-  return job;
+Agenda.prototype.every = function(interval, names, data) {
+  var self = this;
+
+  if (typeof names === 'string') {
+    return createJob(interval, names, data);
+  } else if (names instanceof Array) {
+    return createJobs(interval, names, data);
+  }
+
+  function createJob(interval, name, data) {
+    var job;
+    job = self.create(name, data);
+    job.attrs.type = 'single';
+    job.repeatEvery(interval);
+    job.save();
+    return job;
+  }
+
+  function createJobs(interval, names, data) {
+    return names.map(function (name) {
+      return createJob(interval, name, data);
+    });
+  }
 };
 
-Agenda.prototype.schedule = function(when, name, data) {
-  var job = this.create(name, data);
-  job.schedule(when);
-  job.save();
-  return job;
+Agenda.prototype.schedule = function(when, names, data) {
+  var self = this;
+
+  if (typeof names === 'string') {
+    return createJob(when, names, data);
+  } else if (names instanceof Array) {
+    return createJobs(when, names, data);
+  }
+
+  function createJob(when, name, data) {
+    var job = self.create(name, data);
+    job.schedule(when);
+    job.save();
+    return job;
+  }
+
+  function createJobs(when, names, data) {
+    return names.map(function (name) {
+      return createJob(when, name, data);
+    });
+  }
 };
 
 Agenda.prototype.now = function(name, data) {

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -131,6 +131,11 @@ describe('Agenda', function() {
           expect(jobs.every('5 seconds', 'send email').agenda).to.be(jobs);
         });
       });
+      describe('with array of names specified', function () {
+        it('returns array of jobs', function () {
+          expect(jobs.every('5 minutes', ['send email', 'some job'])).to.be.an('array');
+        });
+      });
     });
 
     describe('schedule', function() {
@@ -141,6 +146,11 @@ describe('Agenda', function() {
         it('sets the schedule', function() {
           var fiveish = (new Date()).valueOf() + 250000;
           expect(jobs.schedule('in 5 minutes', 'send email').attrs.nextRunAt.valueOf()).to.be.greaterThan(fiveish);
+        });
+      });
+      describe('with array of names specified', function () {
+        it('returns array of jobs', function () {
+          expect(jobs.schedule('5 minutes', ['send email', 'some job'])).to.be.an('array');
         });
       });
     });


### PR DESCRIPTION
Just seen that for my case,

``` js
agenga.every('5 minutes', ['job1', 'job2', 'job3']);
```

is a bit better than,

``` js
agenda.every('5 minutes', 'job1');
agenda.every('5 minutes', 'job2');
agenda.every('5 minutes', 'job3');
```

I understand it's interface change and there are a lot of reasons to reject it. But if you see this is OK and merge upstream I'll update documentation as well :)
