### PR TITLE
Update mongoskin to 1.3

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -28,6 +28,10 @@ Agenda.prototype.mongo = function(db) {
 
 Agenda.prototype.database = function(url, collection) {
   collection = collection || 'agendaJobs';
+  if (!url.match(/^mongodb:\/\/.*/)) {
+    url = 'mongodb://' + url;
+  }
+
   this._db = mongo.db(url, {w: 0}).collection(collection);
   return this;
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "human-interval": "~0.1.3",
     "date.js": "~0.1.1",
-    "mongoskin": "~0.6.0",
+    "mongoskin": "~1.3.2",
     "cron": "~1.0.1"
   },
   "devDependencies": {

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -1,6 +1,6 @@
 var mongoCfg = 'localhost:27017/agenda-test',
     expect = require('expect.js'),
-    mongo = require('mongoskin').db(mongoCfg, {w: 0}),
+    mongo = require('mongoskin').db('mongodb://' + mongoCfg, {w: 0}),
     Agenda = require('../index.js'),
     jobs = new Agenda({
       defaultConcurrency: 5,
@@ -22,12 +22,12 @@ describe('Agenda', function() {
   describe('configuration methods', function() {
     describe('database', function() {
       it('sets the database', function() {
-        jobs.database(mongoCfg);
-        expect(jobs._db.skinDb._dbconn.databaseName).to.be('agenda-test');
+        jobs.database('localhost:27017/agenda-test-new');
+        expect(jobs._db._skin_db._connect_args[0]).to.contain('agenda-test-new');
       });
       it('sets the collection', function() {
         jobs.database(mongoCfg, 'myJobs');
-        expect(jobs._db.collectionName).to.be('myJobs');
+        expect(jobs._db._collection_args[0]).to.be('myJobs');
       });
       it('returns itself', function() {
         expect(jobs.database(mongoCfg)).to.be(jobs);


### PR DESCRIPTION
Mongoskin dep is pretty outdated, I needed the update because the old `mongo.db()` didn't accept a connection url representing a replset e.g `mongodb://user:pass@1.acme.org:123,2.acme.org:1234/dbname`

Tests are passing, although this could break users who are passing older mongoskin objects straight to agenda
