### PR TITLE
Fail the job if repeat interval is wrong

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -19,7 +19,7 @@ var Job = module.exports = function Job(args) {
       attrs[key] = args[key];
     }
   }
-  
+
   // Set defaults if undefined
   attrs.nextRunAt = attrs.nextRunAt || new Date();
   attrs.type = attrs.type || 'once';
@@ -59,6 +59,11 @@ Job.prototype.computeNextRunAt = function() {
     } catch(e) {
       // Nope, humanInterval then!
       this.attrs.nextRunAt = lastRun.valueOf() + humanInterval(interval);
+    } finally {
+      if (isNaN(this.attrs.nextRunAt)) {
+        this.attrs.nextRunAt = undefined;
+        this.fail('failed to calculate nextRunAt due to invalid repeat interval');
+      }
     }
   } else {
     this.attrs.nextRunAt = undefined;

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -289,6 +289,21 @@ describe('Job', function() {
       expect(job.attrs.nextRunAt.valueOf()).to.be(now.valueOf() + 60000);
     });
 
+    describe('when repeat interval is invalid', function () {
+      beforeEach(function () {
+        job.repeatEvery('week');
+        job.computeNextRunAt();
+      });
+
+      it('sets nextRunAt to undefined', function () {
+        expect(job.attrs.nextRunAt).to.be(undefined);
+      });
+
+      it('fails the job', function () {
+        expect(job.attrs.failReason).to.equal('failed to calculate nextRunAt due to invalid repeat interval');
+      });
+    });
+
   });
 
   describe('remove', function() {


### PR DESCRIPTION
I've scheduled my few jobs in that way,

``` js
    // emails
    agenda.schedule('friday at 4pm', 'send weekly pulse developers').repeatEvery('week').save();
    agenda.schedule('saturday at 6am', 'send weekly pulse users').repeatEvery('week').save();
```

It worked fine, but next week I've noticed that jobs didn't start and no emails were sent. I've checked db and noticed that `nextRunAt` were set to `NaN` for both of jobs. I wrote the test that cleanly reproduce the situation, but after debugging it was clear it's not a bug in `agenga` or `human-interval`.. it just don't understand `week` and in my code it should be changed to `1 week` (maybe `human-interval` should be changed a little to accept `week` as well)..

But I wasn't completely happy with situation. It will be better if job fail in case of `nextRunAt` cannot be calculated. So, in db I will see `failReason` and spend less time for debugging.

I pack up PR that does that.
