### PR TITLE
fix $setOnInsert with empty obj cause mongodb 2.6 complain

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -154,12 +154,19 @@ Agenda.prototype.saveJob = function(job, cb) {
 
   if(props.type == 'single') {
     var now = new Date(),
-        protect = {};
+        protect = {},
+        update;
     if(props.nextRunAt && props.nextRunAt <= now) {
       protect.nextRunAt = props.nextRunAt;
       delete props.nextRunAt;
     }
-    this._db.findAndModify({name: props.name, type: 'single'}, {}, { $set: props, $setOnInsert: protect }, {upsert: true, new: true}, processDbResult);
+
+    update = { $set: props };
+    if (Object.keys(protect).length > 0) {
+      update.$setOnInsert = protect;
+    }
+
+    this._db.findAndModify({name: props.name, type: 'single'}, {}, update, {upsert: true, new: true}, processDbResult);
   } else {
     if(job.attrs._id) {
       this._db.findAndModify({_id: job.attrs._id}, {}, {$set: props}, {new: true}, processDbResult);


### PR DESCRIPTION
With the new mongodb 2.6, `$setOnInsert` with empty object will cause this error:

```
findAndModifyFailed failed: {
    "errmsg" : "exception: '$setOnInsert' is empty. You must specify a field like so: {$mod: {<field>: ...}}",
    "code" : 9,
    "ok" : 0
}
```

So I use it only when its content is not empty.
