### PR TITLE
Added agenda.cancel funtion

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Takes a `number` which specifies the default lock lifetime in milliseconds. By
 default it is 10 minutes. This can be overridden by specifying the
 `lockLifetime` option to a defined job.
 
-A job will unlock if it is finished (ie. `done` is called) before the `lockLifetime`. 
+A job will unlock if it is finished (ie. `done` is called) before the `lockLifetime`.
 The lock is useful if the job crashes or times out.
 
 ```js
@@ -355,6 +355,17 @@ agenda.jobs({name: 'printAnalyticsReport'}, function(err, jobs) {
   // Work with jobs (see below)
 });
 ```
+
+### cancel(mongoskin query, cb)
+
+Cancels any jobs matching the passed mongoskin query, and removes them from the database.
+
+```js
+agenda.cancel({name: 'printAnalyticsReport'}, function(err, numRemoved) {
+});
+```
+
+This functionality can also be achieved by first retrieving all the jobs from the database using `agenda.jobs()`, looping through the resulting array and calling `job.remove()` on each. It is however preferable to use `agenda.cancel()` for this use case, as this ensures the operation is atomic.
 
 ### purge(cb)
 

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -106,7 +106,7 @@ Agenda.prototype.every = function(interval, names, data) {
 
   if (typeof names === 'string') {
     return createJob(interval, names, data);
-  } else if (names instanceof Array) {
+  } else if (Array.isArray(names)) {
     return createJobs(interval, names, data);
   }
 
@@ -131,7 +131,7 @@ Agenda.prototype.schedule = function(when, names, data) {
 
   if (typeof names === 'string') {
     return createJob(when, names, data);
-  } else if (names instanceof Array) {
+  } else if (Array.isArray(names)) {
     return createJobs(when, names, data);
   }
 
@@ -154,6 +154,10 @@ Agenda.prototype.now = function(name, data) {
   job.schedule(new Date());
   job.save();
   return job;
+};
+
+Agenda.prototype.cancel = function(query, cb) {
+  return this._db.remove(query, cb);
 };
 
 Agenda.prototype.saveJob = function(job, cb) {


### PR DESCRIPTION
I had a use case for cancelling jobs while they were scheduled, so I added a new method which does that. The syntax is the same as for `agenda.jobs`.

Really, this is just an atomic version of:

``` js
agenda.jobs({name: 'someJob'}, function(err, jobs) {
  jobs.forEach(function(job) {
    job.remove();
  }
}
```

Oh, and I also changed a couple of the array checks to be more consistent with ES5.
