### PR TITLE
Create database indexes when initializing Agenda instance

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -37,6 +37,13 @@ Agenda.prototype.database = function(url, collection) {
   }
 
   this._db = mongo.db(url, {w: 0}).collection(collection);
+
+  ignoreErrors = function(){};
+  this._db.ensureIndex("nextRunAt", ignoreErrors)
+          .ensureIndex("lockedAt", ignoreErrors)
+          .ensureIndex("name", ignoreErrors)
+          .ensureIndex("priority", ignoreErrors);
+
   return this;
 };
 


### PR DESCRIPTION
Here's a PR for my fix to #82.  Adding useful error handling would require refactoring the database() call to asynchronous, so I just left error handling as a no-op.  I think this should be safe since errors during index creation should only be related to connection string problems, and index creation failure isn't critical (other than for solving this issue)
