### PR TITLE
Integration Tests (Finally)

### DIFF
--- a/test/agenda.js
+++ b/test/agenda.js
@@ -2,15 +2,17 @@
 
 var mongoCfg = 'localhost:27017/agenda-test',
     expect = require('expect.js'),
+    path = require('path'),
+    cp = require('child_process'),
     mongo = require('mongoskin').db('mongodb://' + mongoCfg, {w: 0}),
-    Agenda = require('../index.js'),
+    Agenda = require( path.join('..', 'index.js') ),
     jobs = new Agenda({
       defaultConcurrency: 5,
       db: {
         address: mongoCfg
       }
     }),
-    Job = require('../lib/job.js');
+    Job = require( path.join('..', 'lib', 'job.js') );
 
 function clearJobs(done) {
   mongo.collection('agendaJobs').remove({}, done);
@@ -852,6 +854,168 @@ describe('Job', function() {
           jobs.stop(done);
         });
       }, jobTimeout);
+    });
+  });
+
+  describe("Integration Tests", function() {
+
+    describe('.every()', function() {
+
+      it('Should not rerun completed jobs after restart', function(done) {
+        var i = 0;
+
+        var serviceError = function(e) { done(e); };
+        var receiveMessage = function(msg) {
+          if( msg == "ran" ) {
+            expect(i).to.be(0);
+            i += 1;
+            startService();
+          } else if( msg == 'notRan' ) {
+            expect(i).to.be(1);
+            done();
+          } else return done( new Error('Unexpected response returned!') );
+        };
+
+        var startService = function() {
+          var serverPath = path.join( __dirname, 'fixtures', 'agenda-instance.js' );
+          var n = cp.fork( serverPath, [ mongoCfg, 'daily' ] );
+
+          n.on('message', receiveMessage);
+          n.on('error', serviceError);
+        };
+
+        startService();
+      });
+
+      it('Should properly run jobs when defined via an array', function(done) {
+        var ran1 = false, ran2 = true, doneCalled = false;
+
+        var serviceError = function(e) { done(e); };
+        var receiveMessage = function(msg) {
+          if( msg == "test1-ran" ) {
+            ran1 = true;
+            if( !!ran1 && !!ran2 && !doneCalled) {
+              doneCalled = true;
+              done();
+              return n.send('exit');
+            }
+          } else if( msg == "test2-ran") {
+            ran2 = true;
+            if( !!ran1 && !!ran2 && !doneCalled) {
+              doneCalled = true;
+              done();
+              return n.send('exit');
+            }
+          } else return done( new Error('Jobs did not run!') );
+        };
+
+
+        var serverPath = path.join( __dirname, 'fixtures', 'agenda-instance.js' );
+        var n = cp.fork( serverPath, [ mongoCfg, 'daily-array' ] );
+
+        n.on('message', receiveMessage);
+        n.on('error', serviceError);
+      });
+
+    });
+
+    describe('schedule()', function() {
+
+      it('Should not run jobs scheduled in the future', function(done) {
+        var i = 0;
+
+        var serviceError = function(e) { done(e); };
+        var receiveMessage = function(msg) {
+          if( msg == 'notRan' ) {
+            if( i < 5 ) return done();
+
+            i += 1;
+            startService();
+          } else return done( new Error('Job scheduled in future was ran!') );
+        };
+
+        var startService = function() {
+          var serverPath = path.join( __dirname, 'fixtures', 'agenda-instance.js' );
+          var n = cp.fork( serverPath, [ mongoCfg, 'define-future-job' ] );
+
+          n.on('message', receiveMessage);
+          n.on('error', serviceError);
+        };
+
+        startService();
+      });
+
+      it('Should run past due jobs when process starts', function(done) {
+
+        var serviceError = function(e) { done(e); };
+        var receiveMessage = function(msg) {
+          if( msg == 'ran' ) {
+            done();
+          } else return done( new Error('Past due job did not run!') );
+        };
+
+        var startService = function() {
+          var serverPath = path.join( __dirname, 'fixtures', 'agenda-instance.js' );
+          var n = cp.fork( serverPath, [ mongoCfg, 'define-past-due-job' ] );
+
+          n.on('message', receiveMessage);
+          n.on('error', serviceError);
+        };
+
+        startService();
+      });
+
+      it('Should schedule using array of names', function(done) {
+        var ran1 = false, ran2 = false, doneCalled = false;
+
+        var serviceError = function(e) { done(e); };
+        var receiveMessage = function(msg) {
+
+          if( msg == "test1-ran" ) {
+            ran1 = true;
+            if( !!ran1 && !!ran2 && !doneCalled) {
+              doneCalled = true;
+              done();
+              return n.send('exit');
+            }
+          } else if( msg == "test2-ran") {
+            ran2 = true;
+            if( !!ran1 && !!ran2 && !doneCalled) {
+              doneCalled = true;
+              done();
+              return n.send('exit');
+            }
+          } else return done( new Error('Jobs did not run!') );
+        };
+
+
+        var serverPath = path.join( __dirname, 'fixtures', 'agenda-instance.js' );
+        var n = cp.fork( serverPath, [ mongoCfg, 'schedule-array' ] );
+
+        n.on('message', receiveMessage);
+        n.on('error', serviceError);
+      });
+
+    });
+
+    describe('now()', function() {
+
+      it('Should immediately run the job', function(done) {
+        var serviceError = function(e) { done(e); };
+        var receiveMessage = function(msg) {
+          if( msg == 'ran' ) {
+            return done();
+          } else return done( new Error("Job did not immediately run!") );
+        };
+
+        var serverPath = path.join( __dirname, 'fixtures', 'agenda-instance.js' );
+        var n = cp.fork( serverPath, [ mongoCfg, 'now' ] );
+
+        n.on('message', receiveMessage);
+        n.on('error', serviceError);
+
+      });
+
     });
   });
 });

--- a/test/fixtures/addTests.js
+++ b/test/fixtures/addTests.js
@@ -1,0 +1,75 @@
+module.exports = {
+  "none" : function(agenda) {},
+  "daily" : function(agenda) {
+    agenda.define('once a day test job', function(job, done) {
+      process.send('ran');
+      done();
+      process.exit(0);
+    });
+
+    agenda.every('one day', 'once a day test job');
+  },
+  "daily-array" : function(agenda) {
+    agenda.define('daily test 1', function(job, done) {
+      process.send('test1-ran');
+      done();
+    });
+
+    agenda.define('daily test 2', function(job, done) {
+      process.send('test2-ran');
+      done();
+    });
+
+
+    agenda.every('one day', [ 'daily test 1', 'daily test 2' ]);
+  },
+  "define-future-job" : function(agenda) {
+    var future = new Date();
+    future.setDate( future.getDate() + 1);
+
+    agenda.define('job in the future', function(job, done) {
+      process.send('ran');
+      done();
+      process.exit(0);
+    });
+
+    agenda.schedule(future, 'job in the future');
+  },
+  "define-past-due-job" : function(agenda) {
+    var past = new Date();
+    past.setDate( past.getDate() - 1);
+
+    agenda.define('job in the past', function(job, done) {
+      process.send('ran');
+      done();
+      process.exit(0);
+    });
+
+    agenda.schedule(past, 'job in the past');
+  },
+  "schedule-array" : function(agenda) {
+    var past = new Date();
+    past.setDate( past.getDate() - 1);
+
+    agenda.define('scheduled test 1', function(job, done) {
+      process.send('test1-ran');
+      done();
+    });
+
+    agenda.define('scheduled test 2', function(job, done) {
+      process.send('test2-ran');
+      done();
+    });
+
+    agenda.schedule(past, [ 'scheduled test 1', 'scheduled test 2' ]);
+  },
+  "now" : function(agenda) {
+    agenda.define('now run this job', function(job, done) {
+      process.send('ran');
+      done();
+      process.exit(0);
+    });
+
+    agenda.now('now run this job');
+  }
+};

--- a/test/fixtures/agenda-instance.js
+++ b/test/fixtures/agenda-instance.js
@@ -1,0 +1,25 @@
+var connStr = process.argv[2];
+var tests = process.argv.slice(3);
+
+var path = require('path'),
+    Agenda = require( path.join(__dirname, '..', '..', 'index.js' ) ),
+    addTests = require( path.join(__dirname, 'addTests.js') );
+
+var agenda = new Agenda({ db: { address: connStr } });
+
+tests.forEach(function(test) {
+  addTests[test](agenda);
+});
+
+agenda.start();
+
+// Ensure we can shut down the process from tests
+process.on('message', function(msg) {
+  if( msg == 'exit' ) process.exit(0);
+});
+
+// Send default message of "notRan" after 200ms
+setTimeout(function() {
+  process.send('notRan');
+  process.exit(0);
+}, 200);


### PR DESCRIPTION
So if you look at this PR, you might be amused to see that I stuck with the `child_process.fork()` method for testing here.

Initially I had tried invalidating the `new Agenda()` instance and recreating it, however that led to a lot of odd problems that I couldn't fully figure out, so I scrapped that idea in favor of a way of dynamically loading Agenda jobs in the forked process.

A few caveats with this PR.
1. Set up paths to use `path.join()` to ensure cross-compatibility with non-Unix environments.  That being said, I haven't through the rest of the code yet to know if that's true (and the ability to use `Make` on a Windows machine is questionable).
2. Linting:  I added some jsHint/ jsLint globals to the top of the test file to get rid of some warnings.  That being said, I could have totally included that in my settings to get rid of those warnings, so let me know you want that removed.
3. Other Styling Changes: My default text editor settings trim off whitespace, plus I added semicolons to a block of code that was missing them.
4. Blind Change of Test: On the "should reuse the same job on multiple runs" test, I added the `var counter = 0;` statement to match the surrounding tests.  This was a total blindly made change, but the tests passed before and after I made the changes, so I think we're good!

If you want these commits squashed, let me know and I can take care of it.

Do you have any other ideas for integration tests?  I thought we might be able to add something to check manual job processing and concurrent Agenda instances, but I'm not super-familiar with that API and figured we could start with these.
