### PR TITLE
Added .npmignore for test/ build scripts.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+test/
+Makefile
+.travis.yml
+History.md


### PR DESCRIPTION
Added an ignore file so that tests, Travis file, and the Makefile
are not included when installing agenda via npm.

According to `dmn` this is a larger pain than some realize!
https://github.com/inikulin/dmn

I saw the above repo and wasn't sure if this was in place or not, 
so I figured I should add it!
