### PR TITLE
Re-add tests for those who use the `npat` option.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-test/
 Makefile
 .travis.yml
 History.md


### PR DESCRIPTION
Whelp, seems I broke the build for some users.  I guess I was a 
little over-zealous here!

Some users have npm run tests automatically after installing. This
PR removes the tests from .npmignore, thus allow them to install
and test happily.

Fixes #106

If accepted, make sure to republish!  Thanks!
