### PR TITLE
Fix .every() running when using cron strings.

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -122,6 +122,7 @@ Agenda.prototype.every = function(interval, names, data) {
     job = self.create(name, data);
     job.attrs.type = 'single';
     job.repeatEvery(interval);
+    job.computeNextRunAt();
     job.save();
     return job;
   }

--- a/lib/job.js
+++ b/lib/job.js
@@ -72,7 +72,11 @@ Job.prototype.computeNextRunAt = function() {
     } catch(e) {
       // Nope, humanInterval then!
       try {
-        this.attrs.nextRunAt = lastRun.valueOf() + humanInterval(interval);
+        if( !this.attrs.lastRunAt && humanInterval(interval) ) {
+          this.attrs.nextRunAt = lastRun.valueOf();
+        } else {
+          this.attrs.nextRunAt = lastRun.valueOf() + humanInterval(interval);
+        }
       } catch(e) { }
     } finally {
       if (isNaN(this.attrs.nextRunAt)) {


### PR DESCRIPTION
The .every() method wasn't setting the nextRunAt correctly,
defaulting to Date.now() when it was first set up.  After the
initial run the dates would be set correctly.

This fix computes the nextRunAt correctly using
Job.prototype.computeNextRunAt().  I also had to alter that method
a little, scheduling the job to run immediately if supplied a human
interval.

Fixes rschmukler/agenda#100.
