### PR TITLE
Fix calling constructor with database object

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -18,7 +18,7 @@ var Agenda = module.exports = function(config) {
   if(config.db)
     this.database(config.db.address, config.db.collection);
   else if(config.mongo)
-    this._db =  config.mongo;
+    this.database(config.mongo, config.collection);
 };
 
 utils.inherits(Agenda, Emitter);

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -51,6 +51,10 @@ describe('Agenda', function() {
       it('sets a mongoskin database', function(){
         jobs.database(mongo);
         expect(jobs._db._skin_db._connect_args[0]).to.contain('agenda-test');
+      });
+      it('is constructed with a mongoskin database', function(){
+        var agenda = new Agenda({mongo: mongo});
+        expect(jobs._db._skin_db._connect_args[0]).to.contain('agenda-test');
       })
     });
 


### PR DESCRIPTION
In my project, I'm passing in a database object rather than a url string. This results in an error because the MongoSkin db instance doesn't have the collection methods (e.g. findAndModify). Before this pull request I would need to pass in a collection, not a database. This pull request ensures that the defaults are maintained when a database object is used in the Agenda constructor.
