### PR TITLE
Modify query conditions in _findAndLockNextJob to better utilize inde…

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -382,10 +382,13 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
   } else {
     this._collection.findAndModify(
       {
+        name: jobName,
+        disabled: { $ne: true },
+        nextRunAt: {$lte: this._nextScanAt},      
         $or: [
-          {name: jobName, lockedAt: null, nextRunAt: {$lte: this._nextScanAt}, disabled: { $ne: true }},
-          {name: jobName, lockedAt: {$exists: false}, nextRunAt: {$lte: this._nextScanAt}, disabled: { $ne: true }},
-          {name: jobName, lockedAt: {$lte: lockDeadline}, nextRunAt: {$lte: this._nextScanAt}, disabled: { $ne: true }}
+          {lockedAt: null},
+          {lockedAt: {$exists: false}},
+          {lockedAt: {$lte: lockDeadline}}
         ]
       },
       {'priority': -1},     // sort


### PR DESCRIPTION
Mongo was still subject to recursive locks under heavy usage - issue #104 

This modification resolves it by modifying the findAndLockNextJob query conditions so that common criteria are no longer subject to $or condition.
