### PR TITLE
Child job execution with next support

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -149,6 +149,26 @@ Agenda.prototype.jobs = function( query, cb ){
 };
 
 
+Agenda.prototype.childJobsComplete = function( parentid, completingid, cb ){
+  var self = this;
+  this._collection.findAndModify(
+    {
+      _id: parentid,
+      childJobsLastRun: { $exists: false }
+    },
+    [], // sort
+    {
+      $set: {
+        childJobsCompleteAt: new Date(),
+        childJobsLastRun: completingid
+      }
+    },
+    { new: false },
+    cb
+  );
+};
+
+
 Agenda.prototype.purge = function(cb) {
   var definedNames = Object.keys(this._definitions);
   this.cancel( {name: {$not: {$in: definedNames}}}, cb );   // NF refactored 21/04/2015

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -165,7 +165,8 @@ Agenda.prototype.childJobsComplete = function( parentid, completingid, cb ){
   this._collection.findAndModify(
     {
       _id: parentid,
-      childJobsLastRun: { $exists: false }
+      childJobsLastRun: { $exists: false },
+      disabled: { $ne: true }
     },
     [], // sort
     {

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -149,6 +149,17 @@ Agenda.prototype.jobs = function( query, cb ){
 };
 
 
+/**
+ * Called by Job.run() only if all child jobs are complete for a given parent.  By calling findAndModify, the parent job is locked in terms of marking completion status.
+ *
+ * @param  {string}   parentid     Parent job id
+ * @param  {string}   completingid Child job id to record which child was the last to execute
+ * @param  {Function} cb           Callback
+ *
+ * @return {undefined}                undefined
+ *
+ * @caller client code, Agenda.purge(), Job.remove()
+ */
 Agenda.prototype.childJobsComplete = function( parentid, completingid, cb ){
   var self = this;
   this._collection.findAndModify(
@@ -279,6 +290,31 @@ Agenda.prototype.now = function(name, data, cb) {
   job.schedule(new Date());
   job.save(cb);
   return job;
+};
+
+/**
+ * Immediately executes a child job, linking it to a parent.  When all child jobs for a given parent finish, if the `next` parameter is provided, then that job is then subsequently executed.
+ *
+ * @param  {string}   name Name of the new child job
+ * @param  {Function} next (*Optional) Next job name to execute only after all child jobs complete
+ * @param  {Job}      job  Parent job
+ * @param  {Object}   data (*Optional) Data to be passed to child job
+ * @param  {Function} cb   (*Optional) Callback
+ *
+ * @return {Function}        If no callback param provided, a `task` for use with async.parallel is provided
+ */
+Agenda.prototype.child = function( name, next, job, data, cb ) {
+  var self = this
+  data = data || {}
+  data.parent = job.attrs.name
+  data.parentid = job.attrs._id
+  data.next = next
+  if( !! cb )
+    self.now( name, data, cb )
+  else
+    return function( done ) {
+      self.now( name, data, done )
+    }
 };
 
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -167,6 +167,47 @@ Job.prototype.run = function(cb) {
     self.attrs.lastRunAt = new Date();
     self.computeNextRunAt();
     self.save(function() {
+
+      var checkForJobDependencyChaining = function( job ) {
+        var d = job.attrs.data
+        var id = job.attrs._id
+        if( ! d ) return
+        if( ! d.next ) return
+
+        // does job have a parent and a next? > If so, check for all siblings done
+        if( !! d.parent && !! d.parentid ) {
+
+          // check to see if there are any unfinished jobs with the same parent id
+          agenda.jobs({
+            _id: { $ne: id },
+            'data.parentid': d.parentid,
+            lastFinishedAt: { $exists: false }
+          }, function( err, jobs ) {
+            if( !! err ) throw new Error( err )
+
+            // if unfinished jobs other than itself, then exit ( we have to wait )
+            if( !! jobs.length ) return
+
+            // if all child jobs finished ( current state at this line )
+            // .. we then perform a findAndModify ( lock ) on the parent
+            // .. also make sure findAndModify excludes records w/ childJobsLastRun set
+            agenda.childJobsComplete( d.parentid, id, function( err, job ) {
+              if( !! err ) throw new Error( err )
+
+              // If couldn't obtain the lock, exit ( somebody else got it )
+              if( ! job ) return
+
+              // at this point, we have the proper `completed` lock for this one child
+              agenda.now( d.next )
+
+            })
+          })
+
+        } else {
+          agenda.now( d.next )
+        }
+      }
+
       var jobCallback = function(err) {
         if (err) {
           self.fail(err);
@@ -183,6 +224,7 @@ Job.prototype.run = function(cb) {
           cb && cb(err || saveErr, job);
           agenda.emit('complete', self);
           agenda.emit('complete:' + self.attrs.name, self);
+          checkForJobDependencyChaining( self )
         });
       };
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -195,7 +195,7 @@ Job.prototype.run = function(cb) {
               if( !! err ) throw new Error( err )
 
               // If couldn't obtain the lock, exit ( somebody else got it )
-              if( ! job ) return
+              if( ! job.value ) return
 
               // at this point, we have the proper `completed` lock for this one child
               agenda.now( d.next )


### PR DESCRIPTION
Needed this for one of my projects.  Haven't had time to update the README with how to use, examples, etc., but a small snippet is listed below.  Thanks for your work on Agenda!

```
jobs.setup = function( job, done ) {

    async.parallel( [
        self.queue.child( 'setup_ensureEnvironmentConfigured', 'download', job ),
        self.queue.child( 'setup_ensurePrerequisiteDataPresent', 'download', job )
    ], done )

}
```

In this example, "download" is executed when all child jobs are complete.  Performance impact is incurred only when a parentid and a next value on a job is present and, in that case, on completion of the child job it checks the DB to see if all other child jobs are finished ( other than itself ).

This is all "now" centric of course, but is useful when scheduling / currently executing a "graph" of related jobs with dependency mappings.  Can also simply provide a "next" job name for chaining if desired and not use child jobs, which is mainly useful only for segmenting tasks and/or dynamic chaining of jobs depending on conditions.

Thanks for your time
