### PR TITLE
Optimize findAndModify

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -39,6 +39,7 @@ var Agenda = module.exports = function(config, cb) {
   this._lockedJobs = [];
   this._jobQueue = [];
   this._defaultLockLifetime = config.defaultLockLifetime || 10 * 60 * 1000; //10 minute default lockLifetime
+  this._notLocked = new Date(1);
 
   this._isLockingOnTheFly = false;
   this._jobsToLock = [];
@@ -337,6 +338,8 @@ Agenda.prototype.saveJob = function(job, cb) {
     if (Object.keys(protect).length > 0) {
       update.$setOnInsert = protect;
     }
+    update.$setOnInsert = update.$setOnInsert || {};
+    update.$setOnInsert.lockedAt = this._notLocked;
     // Try an upsert.
     this._collection.findAndModify({name: props.name, type: 'single'}, {}, update, {upsert: true, new: true}, processDbResult);
   } else if (unique) {
@@ -344,8 +347,11 @@ Agenda.prototype.saveJob = function(job, cb) {
     query.name = props.name;
     if( uniqueOpts && uniqueOpts.insertOnly )
       update = { $setOnInsert: props };
+    update.$setOnInsert = update.$setOnInsert || {};
+    update.$setOnInsert.lockedAt = this._notLocked;
     this._collection.findAndModify(query, {}, update, {upsert: true, new: true}, processDbResult);
   } else {
+    props.lockedAt = this._notLocked;
     this._collection.insertOne(props, processDbResult);    // NF updated 22/04/2015
   }
 
@@ -412,13 +418,7 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
     cb(new Error( 'No MongoDB Connection'));
   } else {
     this._collection.findAndModify(
-      {
-        $or: [
-          {name: jobName, lockedAt: null, nextRunAt: {$lte: this._nextScanAt}, disabled: { $ne: true }},
-          {name: jobName, lockedAt: {$exists: false}, nextRunAt: {$lte: this._nextScanAt}, disabled: { $ne: true }},
-          {name: jobName, lockedAt: {$lte: lockDeadline}, nextRunAt: {$lte: this._nextScanAt}, disabled: { $ne: true }}
-        ]
-      },
+      {name: jobName, lockedAt: {$lte: lockDeadline}, nextRunAt: {$lte: this._nextScanAt}, disabled: { $ne: true }},
       {'priority': -1},  // sort
       {$set: {lockedAt: now}},  // Doc
       {'new': true},  // options
@@ -452,7 +452,7 @@ Agenda.prototype._unlockJobs = function(done) {
   var jobIds = this._lockedJobs.map(function (job) {
     return job.attrs._id;
   });
-  this._collection.updateMany({_id: { $in: jobIds } }, { $set: { lockedAt: null } }, done);    // NF refactored .update() 22/04/2015
+  this._collection.updateMany({_id: { $in: jobIds } }, { $set: { lockedAt: this._notLocked } }, done);    // NF refactored .update() 22/04/2015
 };
 
 function processJobs(extraJob) {
@@ -539,7 +539,7 @@ function processJobs(extraJob) {
       return;
     }
 
-    self._collection.findAndModify({ _id: job.attrs._id, lockedAt: null, disabled: { $ne: true } }, {}, { $set: { lockedAt: now } }, { new: true }, function(err, resp) {
+    self._collection.findAndModify({ _id: job.attrs._id, lockedAt: self._notLocked, disabled: { $ne: true } }, {}, { $set: { lockedAt: now } }, { new: true }, function(err, resp) {
       if (resp.value) {
         var job = createJob(self, resp.value);
 

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -317,6 +317,7 @@ Agenda.prototype.saveJob = function(job, cb) {
   var id = job.attrs._id;
   var unique = job.attrs.unique;
   var uniqueOpts = job.attrs.uniqueOpts;
+  var disabled = job.attrs.disabled || false;
 
   delete props._id;
   delete props.unique;
@@ -340,6 +341,7 @@ Agenda.prototype.saveJob = function(job, cb) {
     }
     update.$setOnInsert = update.$setOnInsert || {};
     update.$setOnInsert.lockedAt = this._notLocked;
+    update.$setOnInsert.disabled = disabled;
     // Try an upsert.
     this._collection.findAndModify({name: props.name, type: 'single'}, {}, update, {upsert: true, new: true}, processDbResult);
   } else if (unique) {
@@ -349,9 +351,11 @@ Agenda.prototype.saveJob = function(job, cb) {
       update = { $setOnInsert: props };
     update.$setOnInsert = update.$setOnInsert || {};
     update.$setOnInsert.lockedAt = this._notLocked;
+    update.$setOnInsert.disabled = disabled;
     this._collection.findAndModify(query, {}, update, {upsert: true, new: true}, processDbResult);
   } else {
     props.lockedAt = this._notLocked;
+    props.disabled = disabled;
     this._collection.insertOne(props, processDbResult);    // NF updated 22/04/2015
   }
 
@@ -418,7 +422,7 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
     cb(new Error( 'No MongoDB Connection'));
   } else {
     this._collection.findAndModify(
-      {name: jobName, lockedAt: {$lte: lockDeadline}, nextRunAt: {$lte: this._nextScanAt}, disabled: { $ne: true }},
+      {name: jobName, lockedAt: {$lte: lockDeadline}, nextRunAt: {$lte: this._nextScanAt}, disabled: false},
       {'priority': -1},  // sort
       {$set: {lockedAt: now}},  // Doc
       {'new': true},  // options
@@ -539,7 +543,7 @@ function processJobs(extraJob) {
       return;
     }
 
-    self._collection.findAndModify({ _id: job.attrs._id, lockedAt: self._notLocked, disabled: { $ne: true } }, {}, { $set: { lockedAt: now } }, { new: true }, function(err, resp) {
+    self._collection.findAndModify({ _id: job.attrs._id, lockedAt: self._notLocked, disabled: false }, {}, { $set: { lockedAt: now } }, { new: true }, function(err, resp) {
       if (resp.value) {
         var job = createJob(self, resp.value);
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -185,7 +185,7 @@ Job.prototype.run = function(cb) {
         }
 
         self.attrs.lastFinishedAt = new Date();
-        self.attrs.lockedAt = null;
+        self.attrs.lockedAt = agenda._notLocked;
         self.save(function(saveErr, job) {
           cb && cb(err || saveErr, job);
           if (err) {
@@ -222,7 +222,8 @@ Job.prototype.run = function(cb) {
 Job.prototype.isRunning = function() {
   if (!this.attrs.lastRunAt) return false;
   if (!this.attrs.lastFinishedAt) return true;
-  if (this.attrs.lockedAt && this.attrs.lastRunAt.getTime() > this.attrs.lastFinishedAt.getTime()) {
+  var isLocked = (this.attrs.lockedAt.getTime() !== this._notLocked.getTime());
+  if (isLocked && this.attrs.lastRunAt.getTime() > this.attrs.lastFinishedAt.getTime()) {
     return true;
   }
   return false;

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -895,7 +895,7 @@ describe("agenda", function() {
         setTimeout(function() {
           jobs.stop(function(err, res) {
             jobs._collection.findOne({name: 'longRunningJob'}, function(err, job) {
-              expect(job.lockedAt).to.be(null);
+              expect(job.lockedAt).to.eql(jobs._notLocked);
               done();
             });
           });


### PR DESCRIPTION
Since findAndModify locks the db during search, the following optimizations should minimize the impact:
- Remove `$or` to prevent the optimizer from using the wrong index.
- Use `disabled: false` instead of `disabled: {$ne: true}` becasue `$ne` can't use a B-tree index.

This is a breaking change, so you may want to keep this in mind for version 1.0 to help prevent `ClientCursor::staticYield can't unlock b/c of recursive lock` errors.
