### PR TITLE
use global.setImmediate instead of the hoisted variable

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -175,7 +175,7 @@ Job.prototype.run = function(cb) {
       agenda = self.agenda,
       definition = agenda._definitions[self.attrs.name];
 
-  var setImmediate = setImmediate || process.nextTick;
+  var setImmediate = global.setImmediate || process.nextTick;
   setImmediate(function() {
     self.attrs.lastRunAt = new Date();
     self.computeNextRunAt();


### PR DESCRIPTION
`var setImmediate = setImmediate || process.nextTick;`

This declaration shadows `setImmediate`, if available, from the global scope and uses the hoisted local variable instead of the global one. Since the hoisted variable `setImmediate` is `undefined`, we invariably end up using `process.nextTick` even when `setImmediate` is available.

Had the local variable `setImmediate` been named something else, it would've thrown a `ReferenceError` if `setImmediate` wasn't available.

`var defer = setImmediate || process.nextTick; //ReferenceError`
