### PR TITLE
README to mention creating index for fields used by .unique()

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,8 @@ job.unique({'data.type': 'active', 'data.userId': '123', nextRunAt(date)});
 job.save();
 ```
 
+*IMPORTANT:* To avoid high CPU usage by MongoDB, Make sure to create an index on the used fields, like: `data.type` and `data.userId` for the example above.
+
 ### fail(reason)
 
 Sets `job.attrs.failedAt` to `now`, and sets `job.attrs.failReason`


### PR DESCRIPTION
Hi,

Based on this issue: https://github.com/rschmukler/agenda/issues/232
Just thought modifying the README file to mention the need of creating index for fields used by `.unique()` method would be useful for many people.

Thanks.