### PR TITLE
On job fail set lastFinishedAt equal to failedAt

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -166,7 +166,9 @@ Job.prototype.fail = function(reason) {
   }
   this.attrs.failReason = reason;
   this.attrs.failCount = (this.attrs.failCount || 0) + 1;
-  this.attrs.failedAt = new Date();
+  var now = new Date();
+  this.attrs.failedAt = now;
+  this.attrs.lastFinishedAt = now;
   return this;
 };
 
@@ -185,7 +187,7 @@ Job.prototype.run = function(cb) {
           self.fail(err);
         }
 
-        self.attrs.lastFinishedAt = new Date();
+        if (!err) self.attrs.lastFinishedAt = new Date();
         self.attrs.lockedAt = null;
         self.save(function(saveErr, job) {
           cb && cb(err || saveErr, job);

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -779,6 +779,10 @@ describe("agenda", function() {
         job.fail('test');
         expect(job.attrs.failedAt).to.be.a(Date);
       });
+      it('sets the failedAt time equal to lastFinishedAt time', function() {
+        job.fail('test');
+        expect(job.attrs.failedAt).to.be.equal(job.attrs.lastFinishedAt);
+      });
     });
 
     describe('enable', function() {


### PR DESCRIPTION
I think it's better to set those to the same datetime when it fails because I noticed it could be different by 1 or 2 milliseconds with the current code.

For example Agendash shows wrong informations If the job fails and Agenda sets lastFinishedAt different from failedAt (by only 1 millisecond) Agendash shows it as completed instead failed due to its way to get failed jobs (equality between lastFinishedAt and failedAt):

```
failed: {$and: [
          '$lastFinishedAt',
          '$failedAt',
          {$eq: ['$lastFinishedAt', '$failedAt']}
        ]},
```

This patch fixes that behaviour.