### PR TITLE
Add Node.js 7 and 8 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ node_js:
   - "4"
   - "5"
   - "6"
+  - "7"
+  - "8"
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: "7"
+    - node_js: "8"
 script: make test-once
 before_script:
   - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ node_js:
   - "6"
   - "7"
   - "8"
-matrix:
-  fast_finish: true
-  allow_failures:
-    - node_js: "7"
-    - node_js: "8"
 script: make test-once
 before_script:
   - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10


### PR DESCRIPTION
Tests with Node.js 7 and 8

Travis Docs:
- [Fast Finishing](https://docs.travis-ci.com/user/customizing-the-build/#Fast-Finishing)
- [Rows that are Allowed to Fail](https://docs.travis-ci.com/user/customizing-the-build/#Rows-that-are-Allowed-to-Fail)