### PR TITLE
Remove Node.js v0.10 and 0.11 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 services: mongodb
 sudo: required
 node_js:
-  - "0.11"
-  - "0.10"
   - "4"
   - "5"
   - "6"


### PR DESCRIPTION
As they've reached [End-of-Life](https://github.com/nodejs/LTS).

This came up at https://github.com/agenda/agenda/pull/448#issuecomment-310489598