### PR TITLE
Fix findOneAndUpdate sort option and add test coverage...

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -436,7 +436,7 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
         ]
       },
       {$set: {lockedAt: now}},  // Doc
-      {returnOriginal: false, 'priority': -1},  // options & sort
+      {returnOriginal: false, sort: {priority: -1}},  // options
       function (err, result) {
         var job;
         if (!err && result.value) {


### PR DESCRIPTION
…for priority running order.

It looks like the existing indexes meant documents were returned in the correct priority order anyway, but it's better to fix this so the sort order is guaranteed.