### PR TITLE
add eslint to deps, update eslint rules and fix linting issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,11 +15,11 @@ rules:
     new-cap: 0
     radix: 2
     quotes: 0
-    space-after-function-name: [2, "never"]
-    space-after-keywords: [2, "always"]
-    spaced-line-comment: [2, "always", { exceptions: ["-"]}]
+    space-before-function-paren: [2, "never"]
+    keyword-spacing: [2, { "after": true }]
+    spaced-comment: [2, "always", { exceptions: ["-"]}]
     strict: [2, "never"]
-    valid-jsdoc: [2, { prefer: { "return": "returns"}}]
+    valid-jsdoc: [1, { prefer: { "return": "returns"}}]
     wrap-iife: 2
     comma-dangle: 0
     no-mixed-requires: [0, false]

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -38,7 +38,7 @@ var Agenda = module.exports = function(config, cb) {
   this._runningJobs = [];
   this._lockedJobs = [];
   this._jobQueue = [];
-  this._defaultLockLifetime = config.defaultLockLifetime || 10 * 60 * 1000; //10 minute default lockLifetime
+  this._defaultLockLifetime = config.defaultLockLifetime || 10 * 60 * 1000; // 10 minute default lockLifetime
 
   this._isLockingOnTheFly = false;
   this._jobsToLock = [];
@@ -49,17 +49,22 @@ var Agenda = module.exports = function(config, cb) {
   }
 };
 
-utils.inherits(Agenda, Emitter);    // Job uses emit() to fire job events client can use.
+utils.inherits(Agenda, Emitter); // Job uses emit() to fire job events client can use.
 
 // Configuration Methods
 
 Agenda.prototype.mongo = function( mdb, collection, cb ){
   this._mdb = mdb;
-  this.db_init(collection, cb);   // NF 20/04/2015
+  this.db_init(collection, cb); // NF 20/04/2015
   return this;
 };
 
-/** Connect to the spec'd MongoDB server and database.
+/**
+ * Connect to the spec'd MongoDB server and database.
+ * @param {String} url MongoDB server URL
+ * @param {String} collection
+ * @param {Object} options
+ * @param {Function} cb
  *  Notes:
  *    - If `url` inludes auth details then `options` must specify: { 'uri_decode_auth': true }. This does Auth on the specified
  *      database, not the Admin database. If you are using Auth on the Admin DB and not on the Agenda DB, then you need to
@@ -75,7 +80,7 @@ Agenda.prototype.database = function(url, collection, options, cb) {
   options = options || {};
   var self = this;
 
-  MongoClient.connect(url, options, function ( error, db ){
+  MongoClient.connect(url, options, function( error, db ){
     if (error) {
       if (cb) {
         cb(error, null);
@@ -100,19 +105,18 @@ Agenda.prototype.db_init = function( collection, cb ){
   this._collection = this._mdb.collection(collection || 'agendaJobs');
   var self = this;
   this._collection.createIndexes([{
-                                  "key": {"name" : 1, "priority" : -1, "lockedAt" : 1, "nextRunAt" : 1, "disabled" : 1},
-                                  "name": "findAndLockNextJobIndex1"
-                                }, {
-                                  "key": {"name" : 1, "lockedAt" : 1, "priority" : -1, "nextRunAt" : 1, "disabled" : 1},
-                                  "name": "findAndLockNextJobIndex2"
-                                }],
-                                function( err, result ){
-                                  handleLegacyCreateIndex(err, result, self, cb)
-                                });
+    "key": {"name" : 1, "priority" : -1, "lockedAt" : 1, "nextRunAt" : 1, "disabled" : 1},
+    "name": "findAndLockNextJobIndex1"
+  }, {
+    "key": {"name" : 1, "lockedAt" : 1, "priority" : -1, "nextRunAt" : 1, "disabled" : 1},
+    "name": "findAndLockNextJobIndex2"
+  }], function( err, result ){
+    handleLegacyCreateIndex(err, result, self, cb)
+  });
 };
 
 function handleLegacyCreateIndex(err, result, self, cb){
-  if(err && err.message !== 'no such cmd: createIndexes'){
+  if (err && err.message !== 'no such cmd: createIndexes'){
     self.emit('error', err);
   } else {
     // Looks like a mongo.version < 2.4.x
@@ -152,12 +156,12 @@ Agenda.prototype.defaultConcurrency = function(num) {
   return this;
 };
 
-Agenda.prototype.lockLimit = function (num) {
+Agenda.prototype.lockLimit = function(num) {
   this._lockLimit = num;
   return this;
 };
 
-Agenda.prototype.defaultLockLimit = function (num) {
+Agenda.prototype.defaultLockLimit = function(num) {
   this._defaultLockLimit = num;
   return this;
 };
@@ -182,7 +186,7 @@ Agenda.prototype.jobs = function( query, cb ){
   var self = this;
   this._collection.find( query ).toArray( function( error, result ){
     var jobs;
-    if( !error ){
+    if ( !error ){
       jobs = result.map( createJob.bind( null, self ) );
     }
     cb( error, jobs );
@@ -241,7 +245,7 @@ Agenda.prototype.every = function(interval, names, data, options, cb) {
     var results = [];
     var pending = names.length;
     var errored = false;
-    return names.map(function (name, i) {
+    return names.map(function(name, i) {
       return createJob(interval, name, data, options, function(err, result) {
         if (err) {
           if (!errored) cb(err);
@@ -282,7 +286,7 @@ Agenda.prototype.schedule = function(when, names, data, cb) {
     var results = [];
     var pending = names.length;
     var errored = false;
-    return names.map(function (name, i) {
+    return names.map(function(name, i) {
       return createJob(when, name, data, function(err, result) {
         if (err) {
           if (!errored) cb(err);
@@ -357,7 +361,7 @@ Agenda.prototype.saveJob = function(job, cb) {
   } else if (unique) {
     var query = job.attrs.unique;
     query.name = props.name;
-    if( uniqueOpts && uniqueOpts.insertOnly )
+    if ( uniqueOpts && uniqueOpts.insertOnly )
       update = { $setOnInsert: props };
     this._collection.findOneAndUpdate(query, update, {upsert: true, returnOriginal: false}, processDbResult);
   } else {
@@ -412,6 +416,7 @@ Agenda.prototype.stop = function(cb) {
 /**
  * Find and lock jobs
  * @param {String} jobName
+ * @param {Object} definition
  * @param {Function} cb
  * @protected
  *  @caller jobQueueFilling() only
@@ -437,7 +442,7 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
       },
       {$set: {lockedAt: now}},  // Doc
       {returnOriginal: false, 'priority': -1},  // options & sort
-      function (err, result) {
+      function(err, result) {
         var job;
         if (!err && result.value) {
           job = createJob(self, result.value);
@@ -453,7 +458,7 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
  * Create Job object from data
  * @param {Object} agenda
  * @param {Object} jobData
- * @return {Job}
+ * @returns {Job}
  * @private
  */
 function createJob(agenda, jobData) {
@@ -464,7 +469,7 @@ function createJob(agenda, jobData) {
 // Refactored to Agenda method. NF 22/04/2015
 // @caller Agenda.stop() only. Could be moved into stop(). NF
 Agenda.prototype._unlockJobs = function(done) {
-  var jobIds = this._lockedJobs.map(function (job) {
+  var jobIds = this._lockedJobs.map(function(job) {
     return job.attrs._id;
   });
   this._collection.updateMany({_id: { $in: jobIds } }, { $set: { lockedAt: null } }, done);    // NF refactored .update() 22/04/2015
@@ -482,7 +487,9 @@ function processJobs(extraJob) {
 
   if (!extraJob) {
     for (jobName in definitions) {
-      jobQueueFilling(jobName);
+      if ({}.hasOwnProperty.call(definitions, jobName)) {
+        jobQueueFilling(jobName);
+      }
     }
   } else if (definitions[extraJob.attrs.name]) {
     self._jobsToLock.push(extraJob);
@@ -499,11 +506,11 @@ function processJobs(extraJob) {
     var shouldLock = true;
     var jobDefinition = definitions[name];
 
-    if(self._lockLimit && self._lockLimit <= self._lockedJobs.length) {
+    if (self._lockLimit && self._lockLimit <= self._lockedJobs.length) {
       shouldLock = false;
     }
 
-    if(jobDefinition.lockLimit && jobDefinition.lockLimit <= jobDefinition.locked) {
+    if (jobDefinition.lockLimit && jobDefinition.lockLimit <= jobDefinition.locked) {
       shouldLock = false;
     }
 
@@ -518,28 +525,28 @@ function processJobs(extraJob) {
     jobs.forEach(function(job) {
       var jobIndex, start, loopCondition, endCondition, inc;
 
-      if(inFront) {
+      if (inFront) {
         start = jobQueue.length ? jobQueue.length - 1 : 0;
         inc = -1;
-        loopCondition = function () {
+        loopCondition = function() {
           return jobIndex >= 0;
         };
-        endCondition = function (queuedJob) {
+        endCondition = function(queuedJob) {
           return !queuedJob || queuedJob.attrs.priority < job.attrs.priority;
         };
       } else {
         start = 0;
         inc = 1;
-        loopCondition = function () {
+        loopCondition = function() {
           return jobIndex < jobQueue.length;
         };
-        endCondition = function (queuedJob) {
+        endCondition = function(queuedJob) {
           return queuedJob.attrs.priority >= job.attrs.priority;
         };
       }
 
-      for(jobIndex = start; loopCondition(); jobIndex += inc) {
-        if(endCondition(jobQueue[jobIndex])) break;
+      for (jobIndex = start; loopCondition(); jobIndex += inc) {
+        if (endCondition(jobQueue[jobIndex])) break;
       }
 
       // insert the job to the queue at its prioritized position for processing
@@ -548,11 +555,11 @@ function processJobs(extraJob) {
   }
 
   function lockOnTheFly() {
-    if(self._isLockingOnTheFly) {
+    if (self._isLockingOnTheFly) {
       return;
     }
 
-    if(!self._jobsToLock.length) {
+    if (!self._jobsToLock.length) {
       self._isLockingOnTheFly = false;
       return;
     }
@@ -565,7 +572,7 @@ function processJobs(extraJob) {
     // If locking limits have been hit, stop locking on the fly.
     // Jobs that were waiting to be locked will be picked up during a
     // future locking interval.
-    if(!shouldLock(job.attrs.name)) {
+    if (!shouldLock(job.attrs.name)) {
       self._jobsToLock = [];
       self._isLockingOnTheFly = false;
       return;
@@ -597,7 +604,7 @@ function processJobs(extraJob) {
   }
 
   function jobQueueFilling(name) {
-    if(!shouldLock(name)) {
+    if (!shouldLock(name)) {
       return;
     }
 
@@ -628,9 +635,9 @@ function processJobs(extraJob) {
 
     // Get the next job that is not blocked by concurrency
     var next;
-    for(next = jobQueue.length - 1; next > 0; next -= 1) {
+    for (next = jobQueue.length - 1; next > 0; next -= 1) {
       var def = definitions[jobQueue[next].attrs.name];
-      if(def.concurrency > def.running) break;
+      if (def.concurrency > def.running) break;
     }
 
     var job = jobQueue.splice(next, 1)[0],
@@ -670,10 +677,10 @@ function processJobs(extraJob) {
   }
 
   function processJobResult(err, job) {
-    if (err && !job) throw(err)
+    if (err && !job) throw (err)
     var name = job.attrs.name;
 
-    if (self._runningJobs.indexOf(job) == -1) throw("callback already called - job " + name + " already marked complete");
+    if (self._runningJobs.indexOf(job) == -1) throw ("callback already called - job " + name + " already marked complete");
 
     self._runningJobs.splice(self._runningJobs.indexOf(job), 1);
     if (definitions[name].running > 0) definitions[name].running--;

--- a/lib/job.js
+++ b/lib/job.js
@@ -71,9 +71,11 @@ Job.prototype.computeNextRunAt = function() {
   }
   return this;
 
-  function dateForTimezone (d) {
+  function dateForTimezone(d) {
     d = moment(d);
-    if(timezone) d.tz(timezone);
+    if (timezone) {
+        d.tz(timezone);
+    }
     return d;
   }
 
@@ -161,7 +163,7 @@ Job.prototype.priority = function(priority) {
 };
 
 Job.prototype.fail = function(reason) {
-  if(reason instanceof Error) {
+  if (reason instanceof Error) {
     reason = reason.message;
   }
   this.attrs.failReason = reason;
@@ -175,7 +177,7 @@ Job.prototype.run = function(cb) {
       agenda = self.agenda,
       definition = agenda._definitions[self.attrs.name];
 
-  var setImmediate = setImmediate || process.nextTick;
+  var setImmediate = setImmediate || process.nextTick; // eslint-disable-line no-use-before-define
   setImmediate(function() {
     self.attrs.lastRunAt = new Date();
     self.computeNextRunAt();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Light weight job scheduler for Node.js",
   "main": "index.js",
   "scripts": {
-    "test": "mocha",
+    "test": "eslint lib/* index.js && mocha --reporter spec --timeout 3500",
     "blanket": {
       "pattern": "lib",
       "data-cover-never": "node_modules"
@@ -37,6 +37,7 @@
   "devDependencies": {
     "blanket": "^1.2.3",
     "coveralls": "^2.13.1",
+    "eslint": "^4.2.0",
     "expect.js": "^0.3.1",
     "mocha": "^3.4.2",
     "mocha-lcov-reporter": "^1.3.0",


### PR DESCRIPTION
This fixes up all the linting issues we have and just leaves 21 warnings for jsdoc. I've also added eslint to the npm test script since most people are likely to run `yarn test` or `npm test` over using a make file which should mean more people are checking for issues before committing.

This covers the eslint issue in https://github.com/agenda/agenda/pull/464

PING: @agenda/maintainers 