### PR TITLE
Add test for bug #358, switch to cron-parser and remove cron

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -3,7 +3,7 @@
  * None
  */
 
-var humanInterval = require('human-interval'), CronTime = require('cron').CronTime, date = require('date.js'),
+var humanInterval = require('human-interval'), CronTime = require('cron-parser').CronTime, date = require('date.js'),
     moment = require('moment-timezone'), debug = require('debug')('agenda:job');
 
 var Job = module.exports = function Job(args) {

--- a/lib/job.js
+++ b/lib/job.js
@@ -74,14 +74,6 @@ Job.prototype.computeNextRunAt = function() {
   }
   return this;
 
-  function dateForTimezone(d) {
-    d = moment(d);
-    if (timezone) {
-        d.tz(timezone);
-    }
-    return d;
-  }
-
   /**
    * Internal method that computes the interval
    * @returns {undefined}
@@ -90,13 +82,15 @@ Job.prototype.computeNextRunAt = function() {
 
     debug('[%s:%s] computing next run via interval [%s]', this.attrs.name, this.attrs._id, interval);
     var lastRun = this.attrs.lastRunAt || new Date();
-    lastRun = dateForTimezone(lastRun);
+    var cronOptions = { currentDate: lastRun };
+    if (timezone) cronOptions.tz = timezone;
     try {
-      var cronTime = new CronTime(interval);
-      var nextDate = cronTime._getNextDateFrom(lastRun);
+      var cronTime = cronParser.parseExpression(interval, cronOptions);
+      var nextDate = cronTime.next()._date.toDate();
       if (nextDate.valueOf() === lastRun.valueOf()) {
         // Handle cronTime giving back the same date for the next run time
-        nextDate = cronTime._getNextDateFrom(dateForTimezone(new Date(lastRun.valueOf() + 1000)));
+        cronOptions.currentDate = new Date(lastRun.valueOf() + 1000);
+        nextDate = cronParser.parseExpression(interval, cronOptions);
       }
       this.attrs.nextRunAt = nextDate;
       debug('[%s:%s] nextRunAt set to [%s]', this.attrs.name, this.attrs._id, this.attrs.nextRunAt.toISOString());

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/agenda/agenda/issues"
   },
   "dependencies": {
-    "cron": "~1.1.0",
+    "cron-parser": "^2.4.1",
     "date.js": "~0.3.1",
     "human-interval": "~0.1.3",
     "moment-timezone": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -262,11 +262,12 @@ coveralls@^2.13.1:
     minimist "1.2.0"
     request "2.79.0"
 
-cron@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/cron/-/cron-1.1.1.tgz#02719d4ef480dfc8ee24d81a3603460ba39013ce"
+cron-parser@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-2.4.1.tgz#022befce1af293e4d3144ff04c2cbd2edb491271"
   dependencies:
-    moment-timezone "~0.5.5"
+    is-nan "^1.2.1"
+    moment-timezone "^0.5.0"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -312,6 +313,13 @@ debug@~0.7.2:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+define-properties@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
 
 del@^2.0.2:
   version "2.2.2"
@@ -646,7 +654,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.3, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -681,6 +689,12 @@ is-my-json-valid@^2.12.4:
     generate-object-property "^1.1.0"
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
+
+is-nan@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.2.1.tgz#9faf65b6fb6db24b7f5c0628475ea71f988401e2"
+  dependencies:
+    define-properties "^1.1.1"
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -941,7 +955,7 @@ mocha@^3.4.2:
     mkdirp "0.5.1"
     supports-color "3.1.2"
 
-moment-timezone@^0.5.0, moment-timezone@~0.5.5:
+moment-timezone@^0.5.0:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.13.tgz#99ce5c7d827262eb0f1f702044177f60745d7b90"
   dependencies:
@@ -990,7 +1004,7 @@ object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
-object-keys@^1.0.6:
+object-keys@^1.0.6, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
@@ -1071,7 +1085,7 @@ qs@~6.3.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
 
-readable-stream@2.2.7:
+readable-stream@2.2.7, readable-stream@^2.2.2:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.7.tgz#07057acbe2467b22042d36f98c5ad507054e95b1"
   dependencies:
@@ -1081,18 +1095,6 @@ readable-stream@2.2.7:
     isarray "~1.0.0"
     process-nextick-args "~1.0.6"
     string_decoder "~1.0.0"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.2.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
 request@2.79.0:
@@ -1171,7 +1173,7 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
@@ -1218,7 +1220,7 @@ string-width@^2.0.0, string-width@^2.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string_decoder@~1.0.0, string_decoder@~1.0.3:
+string_decoder@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
   dependencies:


### PR DESCRIPTION
This closes bug #358 which is in fact, still a bug. In the docs for `node-cron`, it specifically says that the months are range `0-11` but the standard UNIX way to parse cron is `1-12`.

I have added a test that confirms this is still an issue and the test now passes.

Previously lib parsing: https://github.com/kelektiv/node-cron#cron-ranges
New lib parsing: https://github.com/harrisiirak/cron-parser#supported-format
Standard UNIX Cron: https://en.wikipedia.org/wiki/Cron

```
* * * * * *
| | | | | | 
| | | | | +-- Year              (range: 1900-3000)
| | | | +---- Day of the Week   (range: 1-7, 1 standing for Monday)
| | | +------ Month of the Year (range: 1-12)
| | +-------- Day of the Month  (range: 1-31)
| +---------- Hour              (range: 0-23)
+------------ Minute            (range: 0-59)
```

Hopefully not too many people are using `cron` to schedule jobs, as the month parsing is currently broken in the standards sense.