### PR TITLE
Optimize find and modify

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -38,6 +38,7 @@ var Agenda = module.exports = function(config, cb) {
   this._lockedJobs = [];
   this._jobQueue = [];
   this._defaultLockLifetime = config.defaultLockLifetime || 10 * 60 * 1000; // 10 minute default lockLifetime
+  this._notLocked = new Date(1);
 
   this._isLockingOnTheFly = false;
   this._jobsToLock = [];
@@ -514,6 +515,7 @@ Agenda.prototype.saveJob = function(job, cb) {
   var id = job.attrs._id;
   var unique = job.attrs.unique;
   var uniqueOpts = job.attrs.uniqueOpts;
+  var disabled = job.attrs.disabled || false;
 
   // Store job as JSON and remove props we don't want to store from object
   var props = job.toJSON();
@@ -556,8 +558,11 @@ Agenda.prototype.saveJob = function(job, cb) {
       update.$setOnInsert = protect;
     }
 
+    update.$setOnInsert = update.$setOnInsert || {};
+    update.$setOnInsert.lockedAt = this._notLocked;
+    update.$setOnInsert.disabled = disabled;
+
     // Try an upsert
-    // NOTE: 'single' again, not exactly sure what it means
     debug('calling findOneAndUpdate() with job name and type of "single" as query');
     this._collection.findOneAndUpdate(
       { name: props.name, type: 'single' },
@@ -575,11 +580,18 @@ Agenda.prototype.saveJob = function(job, cb) {
       update = { $setOnInsert: props };
     }
 
+    update.$setOnInsert = update.$setOnInsert || {};
+    update.$setOnInsert.lockedAt = this._notLocked;
+    update.$setOnInsert.disabled = disabled;
+
     // Use the 'unique' query object to find an existing job or create a new one
     debug('calling findOneAndUpdate() with unique object as query: \n%O', query);
     this._collection.findOneAndUpdate(query, update, { upsert: true, returnOriginal: false }, processDbResult);
 
   } else {
+
+    props.lockedAt = this._notLocked;
+    props.disabled = disabled;
 
     // If all else fails, the job does not exist yet so we just insert it into MongoDB
     debug('using default behavior, inserting new job via insertOne() with props that were set: \n%O', props);
@@ -688,38 +700,12 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
     debug('missing MongoDB connection, not attempting to find and lock a job');
     cb(new Error('No MongoDB Connection'));
   } else {
-
-    /**
-    * Query used to find job to run
-    * @type {{$or: [*]}}
-    */
-    var JOB_PROCESS_WHERE_QUERY = {
-      $or: [
-          { name: jobName, lockedAt: null, nextRunAt: { $lte: this._nextScanAt }, disabled: { $ne: true } },
-          { name:        jobName,
-              lockedAt:  { $exists: false },
-              nextRunAt: { $lte: this._nextScanAt },
-              disabled:  { $ne: true }
-          },
-          { name: jobName, lockedAt: { $lte: lockDeadline }, disabled: { $ne: true } }
-      ]
-    };
-
-    /**
-    * Query used to set a job as locked
-    * @type {{$set: {lockedAt: Date}}}
-    */
-    var JOB_PROCESS_SET_QUERY = { $set: { lockedAt: now } };
-
-    /**
-    * Query used to affect what gets returned
-    * @type {{returnOriginal: boolean, priority: number}}
-    */
-    var JOB_RETURN_QUERY = { returnOriginal: false, 'priority': -1 };
-
     // Find ONE and ONLY ONE job and set the 'lockedAt' time so that job begins to be processed
-    this._collection.findOneAndUpdate(JOB_PROCESS_WHERE_QUERY, JOB_PROCESS_SET_QUERY, JOB_RETURN_QUERY,
-        function(err, result) {
+    this._collection.findOneAndUpdate(
+      {name: jobName, lockedAt: {$lte: lockDeadline}, nextRunAt: {$lte: this._nextScanAt}, disabled: false},
+      {$set: {lockedAt: now}},
+      {returnOriginal: false, 'priority': -1},  // options & sort
+      function (err, result) {
         var job;
         if (!err && result.value) {
           debug('found a job available to lock, creating a new job on Agenda with id [%s]', result.value._id);
@@ -759,8 +745,9 @@ Agenda.prototype._unlockJobs = function(done) {
   var jobIds = this._lockedJobs.map(function(job) {
     return job.attrs._id;
   });
+
   debug('about to unlock jobs with ids: %O', jobIds);
-  this._collection.updateMany({_id: { $in: jobIds } }, { $set: { lockedAt: null } }, done);
+  this._collection.updateMany({_id: { $in: jobIds } }, { $set: { lockedAt: this._notLocked } }, done);
 };
 
 /**
@@ -904,9 +891,9 @@ function processJobs(extraJob) {
     // Query to run against collection to see if we need to lock it
     var criteria = {
       _id: job.attrs._id,
-      lockedAt: null,
+      lockedAt: self._notLocked,
       nextRunAt: job.attrs.nextRunAt,
-      disabled: { $ne: true }
+      disabled: false
     };
 
     // Update / options for the MongoDB query

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -117,7 +117,7 @@ Agenda.prototype.db_init = function( collection, cb ){
   var self = this;
   debug('attempting index creation');
   this._collection.createIndexes([{
-    "key": {"name" : 1, "disabled" : 1, "lockedAt" : 1, "priority" : -1, "nextRunAt" : 1, "lastFinishedAt": 1},
+    "key": {"name" : 1, "disabled" : 1, "priority" : -1, "lockedAt" : 1, "nextRunAt" : 1, "lastFinishedAt": 1},
     "name": "findAndLockNextJobIndex1"
   }], function( err, result ){
     if (err) {
@@ -145,7 +145,7 @@ function handleLegacyCreateIndex(err, result, self, cb){
     // Looks like a mongo.version < 2.4.x
     err = null;
     self._collection.ensureIndex(
-        {"name": 1, "disabled": 1, "lockedAt": 1, "priority": -1, "nextRunAt": 1, "lastFinishedAt": 1},
+        {"name": 1, "disabled": 1, "priority": -1, "lockedAt": 1, "nextRunAt": 1, "lastFinishedAt": 1},
         {name: "findAndLockNextJobIndex1"}
     );
     self.emit('ready');

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -117,11 +117,8 @@ Agenda.prototype.db_init = function( collection, cb ){
   var self = this;
   debug('attempting index creation');
   this._collection.createIndexes([{
-    "key": {"name" : 1, "priority" : -1, "lockedAt" : 1, "nextRunAt" : 1, "disabled" : 1},
+    "key": {"name" : 1, "disabled" : 1, "lockedAt" : 1, "priority" : -1, "nextRunAt" : 1},
     "name": "findAndLockNextJobIndex1"
-  }, {
-    "key": {"name" : 1, "lockedAt" : 1, "priority" : -1, "nextRunAt" : 1, "disabled" : 1},
-    "name": "findAndLockNextJobIndex2"
   }], function( err, result ){
     if (err) {
       debug('index creation failed, attempting legacy index creation next');
@@ -148,12 +145,8 @@ function handleLegacyCreateIndex(err, result, self, cb){
     // Looks like a mongo.version < 2.4.x
     err = null;
     self._collection.ensureIndex(
-        {"name": 1, "priority": -1, "lockedAt": 1, "nextRunAt": 1, "disabled": 1},
+        {"name": 1, "disabled": 1, "lockedAt": 1, "priority": -1, "nextRunAt": 1},
         {name: "findAndLockNextJobIndex1"}
-    );
-    self._collection.ensureIndex(
-        {"name": 1, "lockedAt": 1, "priority": -1, "nextRunAt": 1, "disabled": 1},
-        {name: "findAndLockNextJobIndex2"}
     );
     self.emit('ready');
   }
@@ -708,7 +701,7 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
   } else {
     // Find ONE and ONLY ONE job and set the 'lockedAt' time so that job begins to be processed
     this._collection.findOneAndUpdate(
-      {name: jobName, lockedAt: {$lte: lockDeadline}, nextRunAt: {$lte: this._nextScanAt}, disabled: false},
+      {name: jobName, disabled: false, lockedAt: {$lte: lockDeadline}, nextRunAt: {$lte: this._nextScanAt}},
       {$set: {lockedAt: now}},
       {returnOriginal: false, 'priority': -1},  // options & sort
       function (err, result) {

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -701,9 +701,9 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
   } else {
 
     /**
-    * Queries used to find a job to run
-    * The 1st query finds unlocked/expired jobs that are due to run by the next process tick
-    * The 2nd query finds expired jobs that have not yet finished once
+    * Query used to find a job to run
+    * The 1st clause matches unlocked or expired jobs that are due to run by the next process tick
+    * The 2nd clause matches unlocked or expired one-time jobs that have not yet finished
     * @type {{$or: [*]}}
     */
     var JOB_PROCESS_WHERE_QUERY = {
@@ -717,7 +717,8 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
         {
           name: jobName,
           disabled: false,
-          lockedAt: { $gt: this._notLocked, $lte: lockDeadline },
+          lockedAt: { $lte: lockDeadline },
+          nextRunAt: null,
           lastFinishedAt: null
         }
       ]

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -117,7 +117,7 @@ Agenda.prototype.db_init = function( collection, cb ){
   var self = this;
   debug('attempting index creation');
   this._collection.createIndexes([{
-    "key": {"name" : 1, "disabled" : 1, "lockedAt" : 1, "priority" : -1, "nextRunAt" : 1},
+    "key": {"name" : 1, "disabled" : 1, "lockedAt" : 1, "priority" : -1, "nextRunAt" : 1, "lastFinishedAt": 1},
     "name": "findAndLockNextJobIndex1"
   }], function( err, result ){
     if (err) {
@@ -145,7 +145,7 @@ function handleLegacyCreateIndex(err, result, self, cb){
     // Looks like a mongo.version < 2.4.x
     err = null;
     self._collection.ensureIndex(
-        {"name": 1, "disabled": 1, "lockedAt": 1, "priority": -1, "nextRunAt": 1},
+        {"name": 1, "disabled": 1, "lockedAt": 1, "priority": -1, "nextRunAt": 1, "lastFinishedAt": 1},
         {name: "findAndLockNextJobIndex1"}
     );
     self.emit('ready');
@@ -699,12 +699,45 @@ Agenda.prototype._findAndLockNextJob = function(jobName, definition, cb) {
     debug('missing MongoDB connection, not attempting to find and lock a job');
     cb(new Error('No MongoDB Connection'));
   } else {
+
+    /**
+    * Queries used to find a job to run
+    * The 1st query finds unlocked/expired jobs that are due to run by the next process tick
+    * The 2nd query finds expired jobs that have not yet finished once
+    * @type {{$or: [*]}}
+    */
+    var JOB_PROCESS_WHERE_QUERY = {
+      $or: [
+        {
+          name: jobName,
+          disabled: false,
+          lockedAt: { $lte: lockDeadline },
+          nextRunAt: { $lte: this._nextScanAt }
+        },
+        {
+          name: jobName,
+          disabled: false,
+          lockedAt: { $gt: this._notLocked, $lte: lockDeadline },
+          lastFinishedAt: null
+        }
+      ]
+    };
+
+    /**
+    * Query used to set a job as locked
+    * @type {{$set: {lockedAt: Date}}}
+    */
+    var JOB_PROCESS_SET_QUERY = { $set: { lockedAt: now } };
+
+    /**
+    * Query used to affect what gets returned
+    * @type {{returnOriginal: boolean, priority: number}}
+    */
+    var JOB_RETURN_QUERY = { returnOriginal: false, 'priority': -1 };
+
     // Find ONE and ONLY ONE job and set the 'lockedAt' time so that job begins to be processed
-    this._collection.findOneAndUpdate(
-      {name: jobName, disabled: false, lockedAt: {$lte: lockDeadline}, nextRunAt: {$lte: this._nextScanAt}},
-      {$set: {lockedAt: now}},
-      {returnOriginal: false, 'priority': -1},  // options & sort
-      function (err, result) {
+    this._collection.findOneAndUpdate(JOB_PROCESS_WHERE_QUERY, JOB_PROCESS_SET_QUERY, JOB_RETURN_QUERY,
+      function(err, result) {
         var job;
         if (!err && result.value) {
           debug('found a job available to lock, creating a new job on Agenda with id [%s]', result.value._id);

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -560,7 +560,10 @@ Agenda.prototype.saveJob = function(job, cb) {
 
     update.$setOnInsert = update.$setOnInsert || {};
     update.$setOnInsert.lockedAt = this._notLocked;
-    update.$setOnInsert.disabled = disabled;
+
+    if (!props.hasOwnProperty('disabled')) {
+      update.$setOnInsert.disabled = disabled;
+    }
 
     // Try an upsert
     debug('calling findOneAndUpdate() with job name and type of "single" as query');
@@ -582,7 +585,10 @@ Agenda.prototype.saveJob = function(job, cb) {
 
     update.$setOnInsert = update.$setOnInsert || {};
     update.$setOnInsert.lockedAt = this._notLocked;
-    update.$setOnInsert.disabled = disabled;
+
+    if (!props.hasOwnProperty('disabled')) {
+      update.$setOnInsert.disabled = disabled;
+    }
 
     // Use the 'unique' query object to find an existing job or create a new one
     debug('calling findOneAndUpdate() with unique object as query: \n%O', query);

--- a/lib/job.js
+++ b/lib/job.js
@@ -256,7 +256,7 @@ Job.prototype.run = function(cb) {
         }
 
         if (!err) self.attrs.lastFinishedAt = new Date();
-        self.attrs.lockedAt = null;
+        self.attrs.lockedAt = agenda._notLocked;
         debug('[%s:%s] job finished at [%s] and was unlocked', self.attrs.name, self.attrs._id, self.attrs.lastFinishedAt);
 
         self.save(function(saveErr, job) {
@@ -310,7 +310,8 @@ Job.prototype.run = function(cb) {
 Job.prototype.isRunning = function() {
   if (!this.attrs.lastRunAt) return false;
   if (!this.attrs.lastFinishedAt) return true;
-  if (this.attrs.lockedAt && this.attrs.lastRunAt.getTime() > this.attrs.lastFinishedAt.getTime()) {
+  var isLocked = (this.attrs.lockedAt.getTime() !== this._notLocked.getTime());
+  if (isLocked && this.attrs.lastRunAt.getTime() > this.attrs.lastFinishedAt.getTime()) {
     return true;
   }
   return false;

--- a/lib/job.js
+++ b/lib/job.js
@@ -27,6 +27,7 @@ var Job = module.exports = function Job(args) {
   // Set defaults if undefined
   // NOTE: What is the difference between 'once' here and 'single' in agenda.js?
   attrs.nextRunAt = attrs.nextRunAt || new Date();
+  attrs.lastFinishedAt = attrs.lastFinishedAt || null;
   attrs.type = attrs.type || 'once';
   this.attrs = attrs;
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -311,7 +311,7 @@ Job.prototype.run = function(cb) {
 Job.prototype.isRunning = function() {
   if (!this.attrs.lastRunAt) return false;
   if (!this.attrs.lastFinishedAt) return true;
-  var isLocked = (this.attrs.lockedAt.getTime() !== this._notLocked.getTime());
+  var isLocked = (this.attrs.lockedAt.getTime() !== this.agenda._notLocked.getTime());
   if (isLocked && this.attrs.lastRunAt.getTime() > this.attrs.lastFinishedAt.getTime()) {
     return true;
   }

--- a/test/job.js
+++ b/test/job.js
@@ -507,7 +507,7 @@ describe('agenda', function() {
         setTimeout(function() {
           jobs.stop(function(err, res) {
             jobs._collection.findOne({name: 'longRunningJob'}, function(err, job) {
-              expect(job.lockedAt).to.be(jobs._notLocked);
+              expect(job.lockedAt.getTime()).to.be(jobs._notLocked.getTime());
               done();
             });
           });

--- a/test/job.js
+++ b/test/job.js
@@ -507,7 +507,7 @@ describe('agenda', function() {
         setTimeout(function() {
           jobs.stop(function(err, res) {
             jobs._collection.findOne({name: 'longRunningJob'}, function(err, job) {
-              expect(job.lockedAt).to.be(null);
+              expect(job.lockedAt).to.be(jobs._notLocked);
               done();
             });
           });


### PR DESCRIPTION
Rebased & included the fixes in https://github.com/agenda/agenda/pull/300#issuecomment-308211215.

As per @will123195's original comment this a breaking change (e.g. for Agendash) since an unlocked job now has its `lockedAt` field set to the Unix epoch rather than null, plus the field is always in the document so any `$exists: false` queries won't work. Likewise with the `disabled` field.

Overall, significant performance gains should be made by getting rid of the recursive lock warnings. With 2,000,000 jobs in the database, query time has gone from ~4000ms to ~400ms. Deviating from the original PR is a 2nd query introduced to fix the failing test highlighted in my comment, but it also appears to fix #410 where unfinished jobs weren't being resumed. For the execution plan to use the index effectively the `$or` has to remain top-level, so the query duplication is unavoidable, but thankfully it's low cost (~50ms).

