### PR TITLE
Run Travis tests for multiple MongoDB versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,16 @@ env:
   global:
     # NodeJS v4+ requires gcc 4.8+
     - CXX=g++-4.9 CC=gcc-4.9
-script: make test-once
-env:
   matrix:
     - MONGODB_VER=2.6.6
     - MONGODB_VER=3.4.6
+script: make test-once
 before_script:
-  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-  - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
+  - if [[ $MONGODB_VER == 2.* ]]; then echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list; fi
+  - if [[ $MONGODB_VER == 3.4.* ]]; then echo "deb [ arch=amd64 ] http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list; fi
   - sudo apt-get update
-  - sudo apt-get install -y mongodb-org=$MONGODB_VER mongodb-org-server=$MONGODB_VER mongodb-org-shell=$MONGODB_VER mongodb-org-mongos=$MONGODB_VER mongodb-org-tools=$MONGODB_VER
+  - sudo apt-get install -y mongodb-org=$MONGODB_VER
   - sleep 15 #mongo may not be responded directly. See http://docs.travis-ci.com/user/database-setup/#MongoDB
   - mongo --version
 after_script: make test-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,15 @@ env:
     # NodeJS v4+ requires gcc 4.8+
     - CXX=g++-4.9 CC=gcc-4.9
 script: make test-once
+env:
+  matrix:
+    - MONGODB_VER=2.6.6
+    - MONGODB_VER=3.4.6
 before_script:
   - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
   - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
   - sudo apt-get update
-  - sudo apt-get install -y mongodb-org=2.6.6 mongodb-org-server=2.6.6 mongodb-org-shell=2.6.6 mongodb-org-mongos=2.6.6 mongodb-org-tools=2.6.6
+  - sudo apt-get install -y mongodb-org=$MONGODB_VER mongodb-org-server=$MONGODB_VER mongodb-org-shell=$MONGODB_VER mongodb-org-mongos=$MONGODB_VER mongodb-org-tools=$MONGODB_VER
   - sleep 15 #mongo may not be responded directly. See http://docs.travis-ci.com/user/database-setup/#MongoDB
   - mongo --version
 after_script: make test-coveralls


### PR DESCRIPTION
Repeating same environment variable causes TravisCI to run tests with both MongoDB versions on each NodeJS environment.

I'm not sure if this is too much testing but hey one can never be too careful, especially since MongoDB tends to move kinda fast and deprecate features often.

Docs: https://docs.travis-ci.com/user/environment-variables/