### PR TITLE
Update compilers for Nodejs v4+ in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,19 @@ node_js:
   - "6"
   - "7"
   - "8"
+addons:
+  apt:
+    sources:
+      # gcc 4.8+ requires ubuntu-toolchain-r-test
+      - ubuntu-toolchain-r-test
+    packages:
+      # NodeJS v4+ requires gcc 4.8+
+      - g++-4.9
+      - gcc-4.9
+env:
+  global:
+    # NodeJS v4+ requires gcc 4.8+
+    - CXX=g++-4.9 CC=gcc-4.9
 script: make test-once
 before_script:
   - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
@@ -16,6 +29,3 @@ before_script:
   - sleep 15 #mongo may not be responded directly. See http://docs.travis-ci.com/user/database-setup/#MongoDB
   - mongo --version
 after_script: make test-coveralls
-before_install:
-  # Travis uses an ancient GCC
-  - export CC="gcc-4.9" CXX="g++-4.9"


### PR DESCRIPTION
Updating to Travis way of adding gcc/g++ compilers.

See _Node.js v4 (or io.js v3) compiler requirements_:
https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements

Should get rid of warning:
> Starting with io.js 3 and Node.js 4, building native extensions requires C++11-compatible compiler, which seems unavailable on this VM. Please read https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements.

---

Also kind of no-brainer so I'll just wait for tests to pass and merge.