### PR TITLE
only send lib to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.9.1",
   "description": "Light weight job scheduler for Node.js",
   "main": "index.js",
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "test": "eslint lib/* index.js && mocha --reporter spec --timeout 3500",
     "blanket": {


### PR DESCRIPTION
This slims down the package downloaded via npm since we exclude the test directory and files such as `.eslintrc` and `.travis.yml`.

Before:
```
yarn pkgfiles v0.27.5
$ "/Users/xo/code/agenda/node_modules/.bin/pkgfiles"

PATH                              SIZE     %   
.npmignore                        38 B     0%  
index.js                          58 B     0%  
.editorconfig                     360 B    0%  
docker-compose.yml                378 B    0%  
test/fixtures/agenda-instance.js  669 B    0%  
.eslintrc                         896 B    0%  
package.json                      1.07 kB  1%  
LICENSE.md                        1.11 kB  1%  
test/fixtures/addTests.js         1.83 kB  1%  
test/retry.js                     2.26 kB  1%  
History.md                        8.99 kB  5%  
lib/job.js                        11.3 kB  6%  
test/agenda.js                    16.1 kB  8%  
README.md                         27.9 kB  15% 
test/job.js                       31.7 kB  17% 
lib/agenda.js                     36.3 kB  19% 
yarn.lock                         48.8 kB  26% 
                                               
DIR                               SIZE     %   
test/fixtures/                    2.5 kB   1%  
lib/                              47.7 kB  25% 
test/                             52.5 kB  28% 
.                                 190 kB   100%

PKGFILES SUMMARY
Size on Disk with Dependencies  ~42.5 MB
Size with Dependencies          ~30.3 MB
Publishable Size                ~190 kB 
Number of Directories           4       
Number of Files                 17      
Done in 2.57s.
```

After:
```
yarn pkgfiles v0.27.5
$ "/Users/xo/code/agenda/node_modules/.bin/pkgfiles"

PATH           SIZE     %   
index.js       58 B     0%  
package.json   1.09 kB  1%  
LICENSE.md     1.11 kB  1%  
History.md     8.99 kB  10% 
lib/job.js     11.3 kB  13% 
README.md      27.9 kB  32% 
lib/agenda.js  36.3 kB  42% 
                            
DIR            SIZE     %   
lib/           47.7 kB  55% 
.              86.8 kB  100%

PKGFILES SUMMARY
Size on Disk with Dependencies  ~42.5 MB
Size with Dependencies          ~30.3 MB
Publishable Size                ~86.8 kB
Number of Directories           2       
Number of Files                 7       
Done in 2.71s.
```