### PR TITLE
fix master: add missing debug dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "cron": "~1.1.0",
     "date.js": "~0.3.1",
+    "debug": "^3.0.0",
     "human-interval": "~0.1.3",
     "moment-timezone": "^0.5.0",
     "mongodb": "^2.2.10"


### PR DESCRIPTION
@OmgImAlexis The current master of agenda@latest on npm is completely failing because the debug dependency is missing in package.json even though it is used throughout the code.

Please merge this urgently and republish :)

```
Error: Cannot find module 'debug'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
...

```