### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "url": "https://github.com/agenda/agenda/issues"
   },
   "dependencies": {
-    "cron": "~1.1.0",
+    "cron": "~1.2.1",
     "date.js": "~0.3.1",
-    "debug": "^2.6.8",
+    "debug": "~3.0.0",
     "human-interval": "~0.1.3",
-    "moment-timezone": "^0.5.0",
-    "mongodb": "^2.2.10"
+    "moment-timezone": "~0.5.0",
+    "mongodb": "~2.2.10"
   },
   "devDependencies": {
     "blanket": "^1.2.3",


### PR DESCRIPTION
- Update `cron` and `debug` packages to latest
- Set semver version range to more strict `~version` ("Approximately equivalent to version") instead of `^version` ("Compatible with version")

Note that `debug` has 3 breaking changes: https://github.com/visionmedia/debug/blob/master/CHANGELOG.md#300--2017-08-08