### PR TITLE
dont try and unlock jobs when _lockedJobs is empty

### DIFF
--- a/lib/agenda/stop.js
+++ b/lib/agenda/stop.js
@@ -18,8 +18,21 @@ module.exports = function(cb) {
   const _unlockJobs = function(done) {
     debug('Agenda._unlockJobs()');
     const jobIds = self._lockedJobs.map(job => job.attrs._id);
-    debug('about to unlock jobs with ids: %O', jobIds);
-    self._collection.updateMany({_id: {$in: jobIds}}, {$set: {lockedAt: null}}, done);
+
+    if (jobIds.length >= 1) {
+      debug('about to unlock jobs with ids: %O', jobIds);
+      self._collection.updateMany({_id: {$in: jobIds}}, {$set: {lockedAt: null}}, err => {
+        if (err) {
+          return done(err);
+        }
+
+        self._lockedJobs = [];
+        return done();
+      });
+    } else {
+      debug('no jobs to unlock');
+      return done();
+    }
   };
 
   debug('Agenda.stop called, clearing interval for processJobs()');

--- a/lib/agenda/stop.js
+++ b/lib/agenda/stop.js
@@ -29,10 +29,10 @@ module.exports = function(cb) {
         self._lockedJobs = [];
         return done();
       });
-    } else {
-      debug('no jobs to unlock');
-      return done();
     }
+
+    debug('no jobs to unlock');
+    return done();
   };
 
   debug('Agenda.stop called, clearing interval for processJobs()');

--- a/lib/agenda/stop.js
+++ b/lib/agenda/stop.js
@@ -19,20 +19,20 @@ module.exports = function(cb) {
     debug('Agenda._unlockJobs()');
     const jobIds = self._lockedJobs.map(job => job.attrs._id);
 
-    if (jobIds.length >= 1) {
-      debug('about to unlock jobs with ids: %O', jobIds);
-      self._collection.updateMany({_id: {$in: jobIds}}, {$set: {lockedAt: null}}, err => {
-        if (err) {
-          return done(err);
-        }
-
-        self._lockedJobs = [];
-        return done();
-      });
+    if (jobIds.length === 0) {
+      debug('no jobs to unlock');
+      return done();
     }
 
-    debug('no jobs to unlock');
-    return done();
+    debug('about to unlock jobs with ids: %O', jobIds);
+    self._collection.updateMany({_id: {$in: jobIds}}, {$set: {lockedAt: null}}, err => {
+      if (err) {
+        return done(err);
+      }
+
+      self._lockedJobs = [];
+      return done();
+    });
   };
 
   debug('Agenda.stop called, clearing interval for processJobs()');


### PR DESCRIPTION
This removes a useless database call since the find statement will return nothing if an empty array is passed.