### PR TITLE
Drop support for legacy `ensureIndex()`

### DIFF
--- a/lib/agenda/db-init.js
+++ b/lib/agenda/db-init.js
@@ -2,31 +2,6 @@
 const debug = require('debug')('agenda:db_init');
 
 /**
- * Internal method called in the case where new indices have an error during creation
- * @param {Error} err error returned from index creation from before
- * @param {*} result result passed in from earlier attempt of creating index
- * @param {Agenda} self instance of Agenda
- * @param {Function} cb called when indices fail or pass
- * @returns {undefined}
- */
-const handleLegacyCreateIndex = (err, result, self, cb) => {
-  if (err && err.message !== 'no such cmd: createIndex') {
-    debug('not attempting legacy index, emitting error');
-    self.emit('error', err);
-  } else {
-    // Looks like a mongo.version < 2.4.x
-    err = null;
-    self._collection.ensureIndex(self._indices, {
-      name: 'findAndLockNextJobIndex'
-    });
-    self.emit('ready');
-  }
-  if (cb) {
-    cb(err, self._collection);
-  }
-};
-
-/**
  * Setup and initialize the collection used to manage Jobs.
  * @param {String} collection name or undefined for default 'agendaJobs'
  * @param {Function} cb called when the db is initialized
@@ -41,10 +16,15 @@ module.exports = function(collection, cb) {
     name: 'findAndLockNextJobIndex'
   }, (err, result) => {
     if (err) {
-      debug('index creation failed, attempting legacy index creation next');
+      debug('index creation failed');
+      self.emit('error', err);
     } else {
       debug('index creation success');
+      self.emit('ready');
     }
-    handleLegacyCreateIndex(err, result, self, cb);
+
+    if (cb) {
+      cb(err, self._collection);
+    }
   });
 };


### PR DESCRIPTION
Correctly calls `createIndex` but then even though there is no error, it proceeds to call `ensureIndex` as well, which is a deprecated method.

Fixes #490.