### PR TITLE
Calculate the next run date on your own

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 
 - Minimal overhead. Agenda aims to keep its code base small.
 - Mongo backed persistence layer.
-- Scheduling with configurable priority, concurrency, and repeating
-- Scheduling via cron or human readable syntax.
+- Scheduling with configurable priority, concurrency, and repeating.
+- Scheduling via cron, human readable syntax or your own parser (ex. using later.js).
 - Event backed job queue that you can hook into.
 - [Agendash](https://github.com/agenda/agendash): optional standalone web-interface
 
@@ -136,6 +136,24 @@ agenda.processEvery('1.5 minutes');
 agenda.processEvery('3 days and 4 hours');
 agenda.processEvery('3 days, 4 hours and 36 seconds');
 ```
+
+Feel free to use your own parser like later.js 
+```js
+var agenda = new Agenda({
+  getNextRunAt(job) {
+    // parse time (ex. using Later.js)
+    // calc and return the next run date
+  }
+});
+
+agenda.every(
+  'Every 2 weeks on Mon, Fri at 07:07 pm', 
+  'my task', 
+  { ... }, 
+  { timezone: 'America/Los_Angeles' }
+);
+```
+Also it will work for `agenda.schedule`, `job.repeatEvery`, `job.repeatAt` and `job.schedule`
 
 ### database(url, [collectionName])
 

--- a/lib/agenda/index.js
+++ b/lib/agenda/index.js
@@ -30,6 +30,7 @@ class Agenda extends Emitter {
     this._defaultLockLifetime = config.defaultLockLifetime || 10 * 60 * 1000; // 10 minute default lockLifetime
     this._sort = config.sort || {nextRunAt: 1, priority: -1};
     this._indices = Object.assign({name: 1}, this._sort, {priority: -1, lockedAt: 1, nextRunAt: 1, disabled: 1});
+    this._getNextRunAt = config.getNextRunAt;
 
     this._isLockingOnTheFly = false;
     this._jobsToLock = [];

--- a/lib/job/compute-next-run-at.js
+++ b/lib/job/compute-next-run-at.js
@@ -32,13 +32,18 @@ module.exports = function() {
     let lastRun = this.attrs.lastRunAt || new Date();
     lastRun = dateForTimezone(lastRun);
     try {
-      const cronTime = new CronTime(interval);
-      let nextDate = cronTime._getNextDateFrom(lastRun);
-      if (nextDate.valueOf() === lastRun.valueOf()) {
-        // Handle cronTime giving back the same date for the next run time
-        nextDate = cronTime._getNextDateFrom(dateForTimezone(new Date(lastRun.valueOf() + 1000)));
+      if (typeof this.agenda._getNextRunAt === 'function') {
+        this.attrs.nextRunAt = this.agenda._getNextRunAt(this);
+      } else {
+        const cronTime = new CronTime(interval);
+        let nextDate = cronTime._getNextDateFrom(lastRun);
+        if (nextDate.valueOf() === lastRun.valueOf()) {
+          // Handle cronTime giving back the same date for the next run time
+          nextDate = cronTime._getNextDateFrom(dateForTimezone(new Date(lastRun.valueOf() + 1000)));
+        }
+        this.attrs.nextRunAt = nextDate;
       }
-      this.attrs.nextRunAt = nextDate;
+
       debug('[%s:%s] nextRunAt set to [%s]', this.attrs.name, this.attrs._id, this.attrs.nextRunAt.toISOString());
     } catch (e) {
       // Nope, humanInterval then!
@@ -66,6 +71,15 @@ module.exports = function() {
    */
   function computeFromRepeatAt() {
     const lastRun = this.attrs.lastRunAt || new Date();
+
+    if (typeof this.agenda._getNextRunAt === 'function') {
+      this.attrs.nextRunAt = this.agenda._getNextRunAt(this);
+
+      debug('[%s:%s] nextRunAt set to [%s]', this.attrs.name, this.attrs._id, this.attrs.nextRunAt.toISOString());
+
+      return;
+    }
+
     const nextDate = date(repeatAt).valueOf();
 
     // If you do not specify offset date for below test it will fail for ms

--- a/lib/job/schedule.js
+++ b/lib/job/schedule.js
@@ -7,6 +7,14 @@ const date = require('date.js');
  * @returns {exports} instance of Job
  */
 module.exports = function(time) {
-  this.attrs.nextRunAt = (time instanceof Date) ? time : date(time);
+  const timeHasDateType = time instanceof Date;
+
+  if (!timeHasDateType && typeof this.agenda._getNextRunAt === 'function') {
+    this.attrs.nextRunAt = this.agenda._getNextRunAt(this, time);
+
+    return this;
+  }
+
+  this.attrs.nextRunAt = timeHasDateType ? time : date(time);
   return this;
 };


### PR DESCRIPTION
Agenda is an awesome scheduling lib and we've decided to migrate our project to it. We use complex schedule rules with Later.js. Since agenda uses its own parsers to interprets intervals we cannot just migrate to it (it's impossible). I think it would be awesome to let users use their own parsers.

Feel free to use your own parser like later.js 
```js
var agenda = new Agenda({
  getNextRunAt(job) {
    // calc and return the next run date
  }
});

agenda.every(
  'Every 2 weeks on Mon, Fri at 07:07 pm', 
  'my task', 
  { ... }, 
  { timezone: 'America/Los_Angeles' }
);
```
Also it will work for `agenda.schedule`, `job.repeatEvery`, `job.repeatAt` and `job.schedule`