### PR TITLE
Remove throw statements from process-jobs

### DIFF
--- a/lib/utils/process-jobs.js
+++ b/lib/utils/process-jobs.js
@@ -160,7 +160,9 @@ module.exports = function(extraJob) {
     // Lock the job in MongoDB!
     self._collection.findOneAndUpdate(criteria, update, options, (err, resp) => {
       if (err) {
-        throw err;
+        debug('job lock failed while locking on the fly');
+        self.emit('error', err);
+        return lockOnTheFly();
       }
       // Did the "job" get locked? Create a job object and run
       if (resp.value) {
@@ -200,7 +202,8 @@ module.exports = function(extraJob) {
     self._findAndLockNextJob(name, definitions[name], (err, job) => {
       if (err) {
         debug('[%s] job lock failed while filling queue', name);
-        throw err;
+        self.emit('error', err);
+        return;
       }
 
       // Still have the job?
@@ -306,7 +309,8 @@ module.exports = function(extraJob) {
    */
   function processJobResult(err, job) {
     if (err && !job) {
-      throw (err);
+      self.emit('error', err);
+      return;
     }
     const name = job.attrs.name;
 


### PR DESCRIPTION
The file lib/utils/process-jobs.js throws errors that can't be caught, since process-jobs is initiated by setInterval. This branch replaces causes agenda to emit error events instead of throwing an exception.