### PR TITLE
Added agenda.on('ready') to README Example Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -932,7 +932,9 @@ jobTypes.forEach(function(type) {
 })
 
 if(jobTypes.length) {
-  agenda.start();
+  agenda.on('ready', function() {
+    agenda.start();
+  });
 }
 
 module.exports = agenda;


### PR DESCRIPTION
wrapped `agenda.start()` in `agenda.on('ready'...` to prevent previously fixed errors like this one https://github.com/agenda/agenda/issues/404#issuecomment-298187262