### PR TITLE
mongodb upgrade to 3.x, noIndexCheck flag

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 2017,
+    "sourceType": "module"
+  },
+
+  "env": {
+    "es6": true,
+    "node": true
+  },
+
+  "globals": {
+    "process": true,
+    "document": false,
+    "navigator": false,
+    "window": false
+  }
+}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ Install via NPM
 
 You will also need a working [Mongo](https://www.mongodb.com/) database (v3) to point it to.
 
+# Breaking changes for agenda 1.1
+Set the "db" config paramter to your agenda database.
+```js
+var agenda = new Agenda({db: {db: mongoAgendaDatabase, address: mongoConnectionString}});
+```
+`db: mongoAgendaDatabase` is a new parameter to specify the database. The database you are specifying in the connection string is the authentication database only. In generell it's the same value.
+E.g.: mongodb://127.0.0.1/agenda-db would need a paramater 'db': 'agenda-db'.
 
 # Example Usage
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,16 @@ You will also need a working [Mongo](https://www.mongodb.com/) database (v3) to 
 
 var mongoConnectionString = 'mongodb://127.0.0.1/agenda';
 
-var agenda = new Agenda({db: {address: mongoConnectionString}});
+var agenda = new Agenda({db: {db: 'agenda-test', address: mongoConnectionString}});
 
 // or override the default collection name:
-// var agenda = new Agenda({db: {address: mongoConnectionString, collection: 'jobCollectionName'}});
+// var agenda = new Agenda({db: {db: 'agenda-test', address: mongoConnectionString, collection: 'jobCollectionName'}});
 
 // or pass additional connection options:
-// var agenda = new Agenda({db: {address: mongoConnectionString, collection: 'jobCollectionName', options: {ssl: true}}});
+// var agenda = new Agenda({db: {db: 'agenda-test', address: mongoConnectionString, collection: 'jobCollectionName', options: {ssl: true}}});
+
+// or disable auto index creation: noIndexCheck
+// var agenda = new Agenda({db: {db: 'agenda-test', address: mongoConnectionString, collection: 'jobCollectionName', noIndexCheck: true}});
 
 // or pass in an existing mongodb-native MongoClient instance
 // var agenda = new Agenda({mongo: myMongoClient});

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Install via NPM
 You will also need a working [Mongo](https://www.mongodb.com/) database (v3) to point it to.
 
 # Breaking changes for agenda 1.1
-Set the "db" config paramter to your agenda database.
+Set the "database" config paramter to your agenda database.
 ```js
-var agenda = new Agenda({db: {db: mongoAgendaDatabase, address: mongoConnectionString}});
+var agenda = new Agenda({db: {database: mongoAgendaDatabase, address: mongoConnectionString}});
 ```
-`db: mongoAgendaDatabase` is a new parameter to specify the database. The database you are specifying in the connection string is the authentication database only. In generell it's the same value.
-E.g.: mongodb://127.0.0.1/agenda-db would need a paramater 'db': 'agenda-db'.
+`database: mongoAgendaDatabase` is a new parameter to specify the database. The database you are specifying in the connection string is the authentication database only. In generell it's the same value.
+E.g.: mongodb://127.0.0.1/agenda-db would need a paramater 'database': 'agenda-db'.
 
 # Example Usage
 
@@ -48,16 +48,16 @@ E.g.: mongodb://127.0.0.1/agenda-db would need a paramater 'db': 'agenda-db'.
 
 var mongoConnectionString = 'mongodb://127.0.0.1/agenda';
 
-var agenda = new Agenda({db: {db: 'agenda-test', address: mongoConnectionString}});
+var agenda = new Agenda({db: {database: 'agenda-test', address: mongoConnectionString}});
 
 // or override the default collection name:
-// var agenda = new Agenda({db: {db: 'agenda-test', address: mongoConnectionString, collection: 'jobCollectionName'}});
+// var agenda = new Agenda({db: {database: 'agenda-test', address: mongoConnectionString, collection: 'jobCollectionName'}});
 
 // or pass additional connection options:
-// var agenda = new Agenda({db: {db: 'agenda-test', address: mongoConnectionString, collection: 'jobCollectionName', options: {ssl: true}}});
+// var agenda = new Agenda({db: {database: 'agenda-test', address: mongoConnectionString, collection: 'jobCollectionName', options: {ssl: true}}});
 
 // or disable auto index creation: noIndexCheck
-// var agenda = new Agenda({db: {db: 'agenda-test', address: mongoConnectionString, collection: 'jobCollectionName', noIndexCheck: true}});
+// var agenda = new Agenda({db: {database: 'agenda-test', address: mongoConnectionString, collection: 'jobCollectionName', noIndexCheck: true}});
 
 // or pass in an existing mongodb-native MongoClient instance
 // var agenda = new Agenda({mongo: myMongoClient});
@@ -160,7 +160,7 @@ agenda.database('localhost:27017/agenda-test', 'agendaJobs');
 You can also specify it during instantiation.
 
 ```js
-var agenda = new Agenda({db: { address: 'localhost:27017/agenda-test', collection: 'agendaJobs' }});
+var agenda = new Agenda({db: { database: 'agenad-test', address: 'localhost:27017/agenda-test', collection: 'agendaJobs' }});
 ```
 
 Agenda will emit a `ready` event (see [Agenda Events](#agenda-events)) when properly connected to the database and it is safe to start using Agenda.

--- a/lib/agenda/database.js
+++ b/lib/agenda/database.js
@@ -21,8 +21,8 @@ module.exports = function(url, config, cb) {
     url = 'mongodb://' + url;
   }
 
-  const collection = config && config.collection || 'agendaJobs';
-  const db = config && config.db || 'agenda';
+  const collection = (config && config.collection) || 'agendaJobs';
+  const db = (config && config.db) || 'agenda';
 
   const options = Object.assign({
     autoReconnect: true,

--- a/lib/agenda/database.js
+++ b/lib/agenda/database.js
@@ -5,8 +5,7 @@ const debug = require('debug')('agenda:database');
 /**
  * Connect to the spec'd MongoDB server and database.
  * @param {String} url MongoDB server URI
- * @param {String} collection name of collection to use
- * @param {Object} options options for connecting
+ * @param {Object} config
  * @param {Function} cb callback of MongoDB connection
  * @returns {exports}
  * NOTE:
@@ -16,19 +15,20 @@ const debug = require('debug')('agenda:database');
  * or use Agenda.mongo(). If your app already has a MongoDB connection then use that. ie. specify config.mongo in
  * the constructor or use Agenda.mongo().
  */
-module.exports = function(url, collection, config, cb) {
+module.exports = function(url, config, cb) {
   const self = this;
   if (!url.match(/^mongodb:\/\/.*/)) {
     url = 'mongodb://' + url;
   }
 
-  collection = collection || 'agendaJobs';
+  const collection = config && config.collection || 'agendaJobs';
+  const db = config && config.db || 'agenda';
+
   const options = Object.assign({
     autoReconnect: true,
     reconnectTries: Number.MAX_SAFE_INTEGER,
-    reconnectInterval: this._processEvery,
-    db: 'agenda'
-  }, config.options);
+    reconnectInterval: this._processEvery
+  }, config && config.options);
   MongoClient.connect(url, options, (error, client) => {
     if (error) {
       debug('error connecting to MongoDB using db [%s] and collection: [%s]', options.db, collection);
@@ -40,7 +40,7 @@ module.exports = function(url, collection, config, cb) {
       return;
     }
     debug('successful connection to MongoDB using db [%s] and collection: [%s]', options.db, collection);
-    self._mdb = client.db(options.db || 'agenda');
+    self._mdb = client.db(db);
     if(!config.noIndexCheck) self.db_init(collection, cb);
   });
   return this;

--- a/lib/agenda/database.js
+++ b/lib/agenda/database.js
@@ -41,7 +41,7 @@ module.exports = function(url, collection, options, cb) {
     }
     debug('successful connection to MongoDB using db [%s] and collection: [%s]', options.db, collection);
     self._mdb = client.db(options.db || 'agenda');
-    if(!options.skipAutoIndex) self.db_init(collection, cb);
+    if(!options.noIndexCheck) self.db_init(collection, cb);
   });
   return this;
 };

--- a/lib/agenda/database.js
+++ b/lib/agenda/database.js
@@ -31,7 +31,7 @@ module.exports = function(url, config, cb) {
   }, config && config.options);
   MongoClient.connect(url, options, (error, client) => {
     if (error) {
-      debug('error connecting to MongoDB using db [%s] and collection: [%s]', options.db, collection);
+      debug('error connecting to MongoDB using db [%s] and collection: [%s]', db, collection);
       if (cb) {
         cb(error, null);
       } else {
@@ -39,7 +39,7 @@ module.exports = function(url, config, cb) {
       }
       return;
     }
-    debug('successful connection to MongoDB using db [%s] and collection: [%s]', options.db, collection);
+    debug('successful connection to MongoDB using db [%s] and collection: [%s]', db, collection);
     self._mdb = client.db(db);
     if(!config.noIndexCheck) self.db_init(collection, cb);
   });

--- a/lib/agenda/database.js
+++ b/lib/agenda/database.js
@@ -40,6 +40,7 @@ module.exports = function(url, config, cb) {
       return;
     }
     debug('successful connection to MongoDB using db [%s] and collection: [%s]', db, collection);
+    self._db = client;
     self._mdb = client.db(db);
     self.db_init(config, cb);
   });

--- a/lib/agenda/database.js
+++ b/lib/agenda/database.js
@@ -5,7 +5,7 @@ const debug = require('debug')('agenda:database');
 /**
  * Connect to the spec'd MongoDB server and database.
  * @param {String} url MongoDB server URI
- * @param {Object} config
+ * @param {Object} dbConfig
  * @param {Function} cb callback of MongoDB connection
  * @returns {exports}
  * NOTE:
@@ -15,23 +15,23 @@ const debug = require('debug')('agenda:database');
  * or use Agenda.mongo(). If your app already has a MongoDB connection then use that. ie. specify config.mongo in
  * the constructor or use Agenda.mongo().
  */
-module.exports = function(url, config, cb) {
+module.exports = function(url, dbConfig, cb) {
   const self = this;
   if (!url.match(/^mongodb:\/\/.*/)) {
     url = 'mongodb://' + url;
   }
 
-  const collection = (config && config.collection) || 'agendaJobs';
-  const db = (config && config.db) || 'agenda';
+  const collection = (dbConfig && dbConfig.collection) || 'agendaJobs';
+  const database = (dbConfig && dbConfig.database) || 'agenda';
 
   const options = Object.assign({
     autoReconnect: true,
     reconnectTries: Number.MAX_SAFE_INTEGER,
     reconnectInterval: this._processEvery
-  }, config && config.options);
+  }, dbConfig && dbConfig.options);
   MongoClient.connect(url, options, (error, client) => {
     if (error) {
-      debug('error connecting to MongoDB using db [%s] and collection: [%s]', db, collection);
+      debug('error connecting to MongoDB using database [%s] and collection: [%s]', database, collection);
       if (cb) {
         cb(error, null);
       } else {
@@ -39,10 +39,10 @@ module.exports = function(url, config, cb) {
       }
       return;
     }
-    debug('successful connection to MongoDB using db [%s] and collection: [%s]', db, collection);
+    debug('successful connection to MongoDB using database [%s] and collection: [%s]', database, collection);
     self._db = client;
-    self._mdb = client.db(db);
-    self.db_init(config, cb);
+    self._mdb = client.db(database);
+    self.db_init(dbConfig, cb);
   });
   return this;
 };

--- a/lib/agenda/database.js
+++ b/lib/agenda/database.js
@@ -41,7 +41,7 @@ module.exports = function(url, config, cb) {
     }
     debug('successful connection to MongoDB using db [%s] and collection: [%s]', db, collection);
     self._mdb = client.db(db);
-    if(!config.noIndexCheck) self.db_init(collection, cb);
+    self.db_init(config, cb);
   });
   return this;
 };

--- a/lib/agenda/database.js
+++ b/lib/agenda/database.js
@@ -23,10 +23,15 @@ module.exports = function(url, collection, options, cb) {
   }
 
   collection = collection || 'agendaJobs';
-  options = Object.assign({autoReconnect: true, reconnectTries: Number.MAX_SAFE_INTEGER, reconnectInterval: this._processEvery}, options);
-  MongoClient.connect(url, options, (error, db) => {
+  options = Object.assign({
+    autoReconnect: true,
+    reconnectTries: Number.MAX_SAFE_INTEGER,
+    reconnectInterval: this._processEvery,
+    db: 'agenda'
+  }, options);
+  MongoClient.connect(url, options, (error, client) => {
     if (error) {
-      debug('error connecting to MongoDB using collection: [%s]', collection);
+      debug('error connecting to MongoDB using db [%s] and collection: [%s]', options.db, collection);
       if (cb) {
         cb(error, null);
       } else {
@@ -34,9 +39,9 @@ module.exports = function(url, collection, options, cb) {
       }
       return;
     }
-    debug('successful connection to MongoDB using collection: [%s]', collection);
-    self._mdb = db;
-    self.db_init(collection, cb);
+    debug('successful connection to MongoDB using db [%s] and collection: [%s]', options.db, collection);
+    self._mdb = client.db(options.db || 'agenda');
+    if(!options.skipAutoIndex) self.db_init(collection, cb);
   });
   return this;
 };

--- a/lib/agenda/database.js
+++ b/lib/agenda/database.js
@@ -16,19 +16,19 @@ const debug = require('debug')('agenda:database');
  * or use Agenda.mongo(). If your app already has a MongoDB connection then use that. ie. specify config.mongo in
  * the constructor or use Agenda.mongo().
  */
-module.exports = function(url, collection, options, cb) {
+module.exports = function(url, collection, config, cb) {
   const self = this;
   if (!url.match(/^mongodb:\/\/.*/)) {
     url = 'mongodb://' + url;
   }
 
   collection = collection || 'agendaJobs';
-  options = Object.assign({
+  const options = Object.assign({
     autoReconnect: true,
     reconnectTries: Number.MAX_SAFE_INTEGER,
     reconnectInterval: this._processEvery,
     db: 'agenda'
-  }, options);
+  }, config.options);
   MongoClient.connect(url, options, (error, client) => {
     if (error) {
       debug('error connecting to MongoDB using db [%s] and collection: [%s]', options.db, collection);
@@ -41,7 +41,7 @@ module.exports = function(url, collection, options, cb) {
     }
     debug('successful connection to MongoDB using db [%s] and collection: [%s]', options.db, collection);
     self._mdb = client.db(options.db || 'agenda');
-    if(!options.noIndexCheck) self.db_init(collection, cb);
+    if(!config.noIndexCheck) self.db_init(collection, cb);
   });
   return this;
 };

--- a/lib/agenda/db-init.js
+++ b/lib/agenda/db-init.js
@@ -7,16 +7,17 @@ const debug = require('debug')('agenda:db_init');
  * @param {Function} cb called when the db is initialized
  * @returns {undefined}
  */
-module.exports = function(config, cb) {
+module.exports = function(dbConfig, cb) {
   const self = this;
 
-  const collection = (config && config.collection) || 'agendaJobs';
+  const collection = (dbConfig && dbConfig.collection) || 'agendaJobs';
 
   debug('init database collection using name [%s]', collection);
   this._collection = this._mdb.collection(collection || 'agendaJobs');
 
-  if (config && config.noIndexCheck) {
+  if (dbConfig && dbConfig.noIndexCheck) {
     self.emit('ready');
+
     if (cb) {
       return cb(null, self._collection);
     }

--- a/lib/agenda/db-init.js
+++ b/lib/agenda/db-init.js
@@ -15,7 +15,7 @@ module.exports = function(config, cb) {
   debug('init database collection using name [%s]', collection);
   this._collection = this._mdb.collection(collection || 'agendaJobs');
 
-  if (config.noIndexCheck) {
+  if (config && config.noIndexCheck) {
     self.emit('ready');
     if (cb) {
       return cb(null, self._collection);

--- a/lib/agenda/db-init.js
+++ b/lib/agenda/db-init.js
@@ -10,7 +10,7 @@ const debug = require('debug')('agenda:db_init');
 module.exports = function(config, cb) {
   const self = this;
 
-  const collection = config && config.collection || 'agendaJobs';
+  const collection = (config && config.collection) || 'agendaJobs';
 
   debug('init database collection using name [%s]', collection);
   this._collection = this._mdb.collection(collection || 'agendaJobs');
@@ -30,7 +30,7 @@ module.exports = function(config, cb) {
       debug('index creation failed');
       self.emit('error', err);
     } else {
-      debug('index creation success');
+      debug('index creation success', result);
       self.emit('ready');
     }
 

--- a/lib/agenda/db-init.js
+++ b/lib/agenda/db-init.js
@@ -7,10 +7,19 @@ const debug = require('debug')('agenda:db_init');
  * @param {Function} cb called when the db is initialized
  * @returns {undefined}
  */
-module.exports = function(collection, cb) {
+module.exports = function(config, cb) {
   const self = this;
+
+  const collection = config && config.collection || 'agendaJobs';
+
   debug('init database collection using name [%s]', collection);
   this._collection = this._mdb.collection(collection || 'agendaJobs');
+
+  if (config.noIndexCheck) {
+    self.emit('ready');
+    return cb(null, self._collection);
+  }
+
   debug('attempting index creation');
   this._collection.createIndex(this._indices, {
     name: 'findAndLockNextJobIndex'

--- a/lib/agenda/db-init.js
+++ b/lib/agenda/db-init.js
@@ -17,7 +17,9 @@ module.exports = function(config, cb) {
 
   if (config.noIndexCheck) {
     self.emit('ready');
-    return cb(null, self._collection);
+    if (cb) {
+      return cb(null, self._collection);
+    }
   }
 
   debug('attempting index creation');

--- a/lib/agenda/find-and-lock-next-job.js
+++ b/lib/agenda/find-and-lock-next-job.js
@@ -18,22 +18,7 @@ module.exports = function(jobName, definition, cb) {
   const now = new Date();
   const lockDeadline = new Date(Date.now().valueOf() - definition.lockLifetime);
   debug('_findAndLockNextJob(%s, [Function], cb)', jobName);
-
-  // Don't try and access MongoDB if we've lost connection to it.
-  // Trying to resolve crash on Dev PC when it resumes from sleep. NOTE: Does this still happen?
-  const s = this._mdb.s || this._mdb.db.s;
-  if (s.topology.connections().length === 0) {
-    if (s.topology.autoReconnect && !s.topology.isDestroyed()) {
-      // Continue processing but notify that Agenda has lost the connection
-      debug('Missing MongoDB connection, not attempting to find and lock a job');
-      self.emit('error', new Error('Lost MongoDB connection'));
-      cb();
-    } else {
-      // No longer recoverable
-      debug('topology.autoReconnect: %s, topology.isDestroyed(): %s', s.topology.autoReconnect, s.topology.isDestroyed());
-      cb(new Error('MongoDB connection is not recoverable, application restart required'));
-    }
-  } else {
+  
     /**
     * Query used to find job to run
     * @type {{$or: [*]}}
@@ -80,5 +65,4 @@ module.exports = function(jobName, definition, cb) {
       }
       cb(err, job);
     });
-  }
 };

--- a/lib/agenda/find-and-lock-next-job.js
+++ b/lib/agenda/find-and-lock-next-job.js
@@ -18,51 +18,51 @@ module.exports = function(jobName, definition, cb) {
   const now = new Date();
   const lockDeadline = new Date(Date.now().valueOf() - definition.lockLifetime);
   debug('_findAndLockNextJob(%s, [Function], cb)', jobName);
-  
-    /**
-    * Query used to find job to run
-    * @type {{$or: [*]}}
-    */
-    const JOB_PROCESS_WHERE_QUERY = {
-      $or: [{
-        name: jobName,
-        lockedAt: null,
-        nextRunAt: {$lte: this._nextScanAt},
-        disabled: {$ne: true}
-      }, {
-        name: jobName,
-        lockedAt: {$exists: false},
-        nextRunAt: {$lte: this._nextScanAt},
-        disabled: {$ne: true}
-      }, {
-        name: jobName,
-        lockedAt: {$lte: lockDeadline},
-        disabled: {$ne: true}
-      }]
-    };
 
-    /**
-    * Query used to set a job as locked
-    * @type {{$set: {lockedAt: Date}}}
-    */
-    const JOB_PROCESS_SET_QUERY = {$set: {lockedAt: now}};
+  /**
+  * Query used to find job to run
+  * @type {{$or: [*]}}
+  */
+  const JOB_PROCESS_WHERE_QUERY = {
+    $or: [{
+      name: jobName,
+      lockedAt: null,
+      nextRunAt: {$lte: this._nextScanAt},
+      disabled: {$ne: true}
+    }, {
+      name: jobName,
+      lockedAt: {$exists: false},
+      nextRunAt: {$lte: this._nextScanAt},
+      disabled: {$ne: true}
+    }, {
+      name: jobName,
+      lockedAt: {$lte: lockDeadline},
+      disabled: {$ne: true}
+    }]
+  };
 
-    /**
-    * Query used to affect what gets returned
-    * @type {{returnOriginal: boolean, sort: object}}
-    */
-    const JOB_RETURN_QUERY = {returnOriginal: false, sort: this._sort};
+  /**
+  * Query used to set a job as locked
+  * @type {{$set: {lockedAt: Date}}}
+  */
+  const JOB_PROCESS_SET_QUERY = {$set: {lockedAt: now}};
 
-    // Find ONE and ONLY ONE job and set the 'lockedAt' time so that job begins to be processed
-    this._collection.findOneAndUpdate(JOB_PROCESS_WHERE_QUERY, JOB_PROCESS_SET_QUERY, JOB_RETURN_QUERY, (err, result) => {
-      let job;
-      if (!err && result.value) {
-        debug('found a job available to lock, creating a new job on Agenda with id [%s]', result.value._id);
-        job = createJob(self, result.value);
-      }
-      if (err) {
-        debug('error occurred when running query to find and lock job');
-      }
-      cb(err, job);
-    });
+  /**
+  * Query used to affect what gets returned
+  * @type {{returnOriginal: boolean, sort: object}}
+  */
+  const JOB_RETURN_QUERY = {returnOriginal: false, sort: this._sort};
+
+  // Find ONE and ONLY ONE job and set the 'lockedAt' time so that job begins to be processed
+  this._collection.findOneAndUpdate(JOB_PROCESS_WHERE_QUERY, JOB_PROCESS_SET_QUERY, JOB_RETURN_QUERY, (err, result) => {
+    let job;
+    if (!err && result.value) {
+      debug('found a job available to lock, creating a new job on Agenda with id [%s]', result.value._id);
+      job = createJob(self, result.value);
+    }
+    if (err) {
+      debug('error occurred when running query to find and lock job');
+    }
+    cb(err, job);
+  });
 };

--- a/lib/agenda/index.js
+++ b/lib/agenda/index.js
@@ -34,7 +34,7 @@ class Agenda extends Emitter {
     this._isLockingOnTheFly = false;
     this._jobsToLock = [];
     if (config.mongo) {
-      this.mongo(config.mongo, config.db ? config.db.collection : undefined, cb);
+      this.mongo(config.mongo, config.db ? config.db.collection : undefined, config.db.options, cb);
     } else if (config.db) {
       this.database(config.db.address, config.db.collection, config.db.options, cb);
     }

--- a/lib/agenda/index.js
+++ b/lib/agenda/index.js
@@ -34,9 +34,9 @@ class Agenda extends Emitter {
     this._isLockingOnTheFly = false;
     this._jobsToLock = [];
     if (config.mongo) {
-      this.mongo(config.mongo, config.db ? config.db.collection : undefined, config.db.options, cb);
+      this.mongo(config.mongo, config.db && config.db.collection, config.db, cb);
     } else if (config.db) {
-      this.database(config.db.address, config.db.collection, config.db.options, cb);
+      this.database(config.db.address, config.db.collection, config.db, cb);
     }
   }
 }

--- a/lib/agenda/index.js
+++ b/lib/agenda/index.js
@@ -36,7 +36,7 @@ class Agenda extends Emitter {
     if (config.mongo) {
       this.mongo(config.mongo, config.db, cb);
     } else if (config.db) {
-      this.database(config.db.address, config.db.collection, config.db, cb);
+      this.database(config.db.address, config.db, cb);
     }
   }
 }

--- a/lib/agenda/index.js
+++ b/lib/agenda/index.js
@@ -34,7 +34,7 @@ class Agenda extends Emitter {
     this._isLockingOnTheFly = false;
     this._jobsToLock = [];
     if (config.mongo) {
-      this.mongo(config.mongo, config.db && config.db.collection, config.db, cb);
+      this.mongo(config.mongo, config.db, cb);
     } else if (config.db) {
       this.database(config.db.address, config.db.collection, config.db, cb);
     }

--- a/lib/agenda/mongo.js
+++ b/lib/agenda/mongo.js
@@ -7,8 +7,8 @@
  * @param {Function} cb called when MongoDB connection fails or passes
  * @returns {exports} instance of Agenda
  */
-module.exports = function(mdb, collection, cb) {
+module.exports = function(mdb, collection, options, cb) {
   this._mdb = mdb;
-  this.db_init(collection, cb);
+  if(!options.skipAutoIndex) this.db_init(collection, cb);
   return this;
 };

--- a/lib/agenda/mongo.js
+++ b/lib/agenda/mongo.js
@@ -7,8 +7,8 @@
  * @param {Function} cb called when MongoDB connection fails or passes
  * @returns {exports} instance of Agenda
  */
-module.exports = function(mdb, config, cb) {
+module.exports = function(mdb, dbConfig, cb) {
   this._mdb = mdb;
-  this.db_init(config, cb);
+  this.db_init(dbConfig, cb);
   return this;
 };

--- a/lib/agenda/mongo.js
+++ b/lib/agenda/mongo.js
@@ -9,7 +9,6 @@
  */
 module.exports = function(mdb, config, cb) {
   this._mdb = mdb;
-  const collection = config && config.collection || 'agendaJobs';
-  if(!config.noIndexCheck) this.db_init(collection, cb);
+  this.db_init(config, cb);
   return this;
 };

--- a/lib/agenda/mongo.js
+++ b/lib/agenda/mongo.js
@@ -9,6 +9,6 @@
  */
 module.exports = function(mdb, collection, options, cb) {
   this._mdb = mdb;
-  if(!options.skipAutoIndex) this.db_init(collection, cb);
+  if(!options.noIndexCheck) this.db_init(collection, cb);
   return this;
 };

--- a/lib/agenda/mongo.js
+++ b/lib/agenda/mongo.js
@@ -7,8 +7,8 @@
  * @param {Function} cb called when MongoDB connection fails or passes
  * @returns {exports} instance of Agenda
  */
-module.exports = function(mdb, collection, options, cb) {
+module.exports = function(mdb, collection, config, cb) {
   this._mdb = mdb;
-  if(!options.noIndexCheck) this.db_init(collection, cb);
+  if(!config.noIndexCheck) this.db_init(collection, cb);
   return this;
 };

--- a/lib/agenda/mongo.js
+++ b/lib/agenda/mongo.js
@@ -7,8 +7,9 @@
  * @param {Function} cb called when MongoDB connection fails or passes
  * @returns {exports} instance of Agenda
  */
-module.exports = function(mdb, collection, config, cb) {
+module.exports = function(mdb, config, cb) {
   this._mdb = mdb;
+  const collection = config && config.collection || 'agendaJobs';
   if(!config.noIndexCheck) this.db_init(collection, cb);
   return this;
 };

--- a/lib/utils/process-jobs.js
+++ b/lib/utils/process-jobs.js
@@ -203,7 +203,7 @@ module.exports = function(extraJob) {
       if (err) {
         debug('[%s] job lock failed while filling queue', name);
         self.emit('error', err);
-          return;
+        return;
       }
 
       // Still have the job?

--- a/lib/utils/process-jobs.js
+++ b/lib/utils/process-jobs.js
@@ -160,7 +160,9 @@ module.exports = function(extraJob) {
     // Lock the job in MongoDB!
     self._collection.findOneAndUpdate(criteria, update, options, (err, resp) => {
       if (err) {
-        throw err;
+        debug('job lock failed while locking on the fly');
+        self.emit('error', err);
+        return lockOnTheFly();
       }
       // Did the "job" get locked? Create a job object and run
       if (resp.value) {
@@ -200,7 +202,8 @@ module.exports = function(extraJob) {
     self._findAndLockNextJob(name, definitions[name], (err, job) => {
       if (err) {
         debug('[%s] job lock failed while filling queue', name);
-        throw err;
+        self.emit('error', err);
+          return;
       }
 
       // Still have the job?
@@ -306,7 +309,8 @@ module.exports = function(extraJob) {
    */
   function processJobResult(err, job) {
     if (err && !job) {
-      throw (err);
+      self.emit('error', err);
+      return;
     }
     const name = job.attrs.name;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenda",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Light weight job scheduler for Node.js",
   "main": "index.js",
   "files": [
@@ -38,7 +38,7 @@
     "debug": "~3.1.0",
     "human-interval": "~0.1.3",
     "moment-timezone": "~0.5.0",
-    "mongodb": "~2.2.33"
+    "mongodb": "~3.0.3"
   },
   "devDependencies": {
     "blanket": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenda",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Light weight job scheduler for Node.js",
   "main": "index.js",
   "files": [

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -7,7 +7,8 @@ const Job = require('../lib/job');
 
 const mongoHost = process.env.MONGODB_HOST || 'localhost';
 const mongoPort = process.env.MONGODB_PORT || '27017';
-const mongoCfg = 'mongodb://' + mongoHost + ':' + mongoPort + '/agenda-test';
+const mongoCfgDb = 'agenda-test';
+const mongoCfg = 'mongodb://' + mongoHost + ':' + mongoPort + '/' + mongoCfgDb;
 
 // Create agenda instances
 let jobs = null;
@@ -27,7 +28,7 @@ describe('Agenda', () => {
   beforeEach(done => {
     jobs = new Agenda({
       db: {
-        db: 'agenda-test',
+        database: mongoCfgDb,
         address: mongoCfg
       }
     }, () => {
@@ -36,16 +37,14 @@ describe('Agenda', () => {
           done(err);
         }
         mongoClient = client;
-        mongoDb = client.db('agenda-test');
-        setTimeout(() => {
-          clearJobs(() => {
-            jobs.define('someJob', jobProcessor);
-            jobs.define('send email', jobProcessor);
-            jobs.define('some job', jobProcessor);
-            jobs.define(jobType, jobProcessor);
-            done();
-          });
-        }, 50);
+        mongoDb = client.db(mongoCfgDb);
+        clearJobs(() => {
+          jobs.define('someJob', jobProcessor);
+          jobs.define('send email', jobProcessor);
+          jobs.define('some job', jobProcessor);
+          jobs.define(jobType, jobProcessor);
+          done();
+        });;
       });
     });
   });
@@ -70,7 +69,7 @@ describe('Agenda', () => {
   describe('configuration methods', () => {
     it('sets the _db directly when passed as an option', () => {
       const agenda = new Agenda({mongo: mongoDb});
-      expect(agenda._mdb.databaseName).to.equal('agenda-test');
+      expect(agenda._mdb.databaseName).to.equal(mongoCfgDb);
     });
   });
 
@@ -79,7 +78,7 @@ describe('Agenda', () => {
       it('sets the _db directly', () => {
         const agenda = new Agenda();
         agenda.mongo(mongoDb);
-        expect(agenda._mdb.databaseName).to.equal('agenda-test');
+        expect(agenda._mdb.databaseName).to.equal(mongoCfgDb);
       });
 
       it('returns itself', () => {

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -29,11 +29,11 @@ describe('Agenda', () => {
         address: mongoCfg
       }
     }, () => {
-      MongoClient.connect(mongoCfg, (err, db) => {
+      MongoClient.connect(mongoCfg, (err, client) => {
         if (err) {
           done(err);
         }
-        mongo = db;
+        mongo = client.db('agenda-test');
         setTimeout(() => {
           clearJobs(() => {
             jobs.define('someJob', jobProcessor);

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -385,7 +385,7 @@ describe('Agenda', () => {
               if (err) {
                 done(err);
               }
-              mongo.collection('agendaJobs').find({
+              mongoDb.collection('agendaJobs').find({
                 name: 'unique job'
               }).toArray((err, job) => { // eslint-disable-line max-nested-callbacks
                 if (err) {

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -54,7 +54,10 @@ describe('Agenda', () => {
     setTimeout(() => {
       jobs.stop(() => {
         clearJobs(() => {
-          mongoClient.close(done);
+          mongoClient.close(() => {
+            if (jobs._db) jobs._db.close(done);
+            else done();
+          });
         });
       });
     }, 50);

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -15,7 +15,7 @@ let mongoDb = null;
 let mongoClient = null;
 
 const clearJobs = done => {
-  mongoDb.collection('agendaJobs').remove({}, done);
+  mongoDb.collection('agendaJobs').removeMany({}, done);
 };
 
 // Slow timeouts for Travis
@@ -27,6 +27,7 @@ describe('Agenda', () => {
   beforeEach(done => {
     jobs = new Agenda({
       db: {
+        db: 'agenda-test',
         address: mongoCfg
       }
     }, () => {

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -53,9 +53,7 @@ describe('Agenda', () => {
     setTimeout(() => {
       jobs.stop(() => {
         clearJobs(() => {
-          mongoClient.close(() => {
-            jobs._mdb.close(done);
-          });
+          mongoClient.close(done);
         });
       });
     }, 50);

--- a/test/job.js
+++ b/test/job.js
@@ -19,7 +19,7 @@ let mongoDb = null;
 let mongoClient = null;
 
 const clearJobs = done => {
-  mongoDb.collection('agendaJobs').remove({}, done);
+  mongoDb.collection('agendaJobs').removeMany({}, done);
 };
 
 // Slow timeouts for Travis

--- a/test/job.js
+++ b/test/job.js
@@ -60,9 +60,7 @@ describe('Job', () => {
     setTimeout(() => {
       jobs.stop(() => {
         clearJobs(() => {
-          mongoClient.close(() => {
-            jobs._mdb.close(done);
-          });
+          mongoClient.close(done);
         });
       });
     }, 50);
@@ -259,7 +257,7 @@ describe('Job', () => {
           if (err) {
             return done(err);
           }
-          mongo.collection('agendaJobs').find({
+          mongoDb.collection('agendaJobs').find({
             _id: job.attrs._id
           }).toArray((err, j) => {
             if (err) {

--- a/test/job.js
+++ b/test/job.js
@@ -36,11 +36,11 @@ describe('Job', () => {
       if (err) {
         done(err);
       }
-      MongoClient.connect(mongoCfg, (err, db) => {
+      MongoClient.connect(mongoCfg, (err, client) => {
         if (err) {
           done(err);
         }
-        mongo = db;
+        mongo = client.db('agenda-test');
         setTimeout(() => {
           clearJobs(() => {
             jobs.define('someJob', jobProcessor);

--- a/test/job.js
+++ b/test/job.js
@@ -60,7 +60,10 @@ describe('Job', () => {
     setTimeout(() => {
       jobs.stop(() => {
         clearJobs(() => {
-          mongoClient.close(done);
+          mongoClient.close(() => {
+            if (jobs._db) jobs._db.close(done);
+            else done();
+          });
         });
       });
     }, 50);

--- a/test/job.js
+++ b/test/job.js
@@ -15,10 +15,11 @@ const mongoCfg = 'mongodb://' + mongoHost + ':' + mongoPort + '/agenda-test';
 
 // Create agenda instances
 let jobs = null;
-let mongo = null;
+let mongoDb = null;
+let mongoClient = null;
 
 const clearJobs = done => {
-  mongo.collection('agendaJobs').remove({}, done);
+  mongoDb.collection('agendaJobs').remove({}, done);
 };
 
 // Slow timeouts for Travis
@@ -40,7 +41,8 @@ describe('Job', () => {
         if (err) {
           done(err);
         }
-        mongo = client.db('agenda-test');
+        mongoClient = client;
+        mongoDb = client.db('agenda-test');
         setTimeout(() => {
           clearJobs(() => {
             jobs.define('someJob', jobProcessor);
@@ -58,7 +60,7 @@ describe('Job', () => {
     setTimeout(() => {
       jobs.stop(() => {
         clearJobs(() => {
-          mongo.close(() => {
+          mongoClient.close(() => {
             jobs._mdb.close(done);
           });
         });

--- a/test/job.js
+++ b/test/job.js
@@ -11,7 +11,8 @@ const Job = require('../lib/job');
 
 const mongoHost = process.env.MONGODB_HOST || 'localhost';
 const mongoPort = process.env.MONGODB_PORT || '27017';
-const mongoCfg = 'mongodb://' + mongoHost + ':' + mongoPort + '/agenda-test';
+const mongoCfgDb = 'agenda-test';
+const mongoCfg = 'mongodb://' + mongoHost + ':' + mongoPort + '/' + mongoCfgDb;
 
 // Create agenda instances
 let jobs = null;
@@ -19,7 +20,7 @@ let mongoDb = null;
 let mongoClient = null;
 
 const clearJobs = done => {
-  mongoDb.collection('agendaJobs').removeMany({}, done);
+  mongoDb.collection('agendaJobs').deleteMany({}, done);
 };
 
 // Slow timeouts for Travis
@@ -31,6 +32,7 @@ describe('Job', () => {
   beforeEach(done => {
     jobs = new Agenda({
       db: {
+        database: mongoCfgDb,
         address: mongoCfg
       }
     }, err => {
@@ -42,16 +44,14 @@ describe('Job', () => {
           done(err);
         }
         mongoClient = client;
-        mongoDb = client.db('agenda-test');
-        setTimeout(() => {
-          clearJobs(() => {
-            jobs.define('someJob', jobProcessor);
-            jobs.define('send email', jobProcessor);
-            jobs.define('some job', jobProcessor);
-            jobs.define(jobType, jobProcessor);
-            done();
-          });
-        }, 50);
+        mongoDb = client.db(mongoCfgDb);
+        clearJobs(() => {
+          jobs.define('someJob', jobProcessor);
+          jobs.define('send email', jobProcessor);
+          jobs.define('some job', jobProcessor);
+          jobs.define(jobType, jobProcessor);
+          done();
+        });
       });
     });
   });

--- a/test/retry.js
+++ b/test/retry.js
@@ -28,8 +28,8 @@ describe('Retry', () => {
       if (err) {
         done(err);
       }
-      MongoClient.connect(mongoCfg, (error, db) => {
-        mongo = db;
+      MongoClient.connect(mongoCfg, (error, client) => {
+        mongo = client.db('agenda-test');
         setTimeout(() => {
           clearJobs(() => {
             jobs.define('someJob', jobProcessor);

--- a/test/retry.js
+++ b/test/retry.js
@@ -49,9 +49,7 @@ describe('Retry', () => {
     setTimeout(() => {
       jobs.stop(() => {
         clearJobs(() => {
-          mongoClient.close(() => {
-            jobs._mdb.close(done);
-          });
+          mongoClient.close(done);
         });
       });
     }, 50);

--- a/test/retry.js
+++ b/test/retry.js
@@ -13,7 +13,7 @@ let mongoDb = null;
 let mongoClient = null;
 
 const clearJobs = done => {
-  mongoDb.collection('agendaJobs').remove({}, done);
+  mongoDb.collection('agendaJobs').removeMany({}, done);
 };
 
 const jobType = 'do work';

--- a/test/retry.js
+++ b/test/retry.js
@@ -49,7 +49,10 @@ describe('Retry', () => {
     setTimeout(() => {
       jobs.stop(() => {
         clearJobs(() => {
-          mongoClient.close(done);
+          mongoClient.close(() => {
+            if (jobs._db) jobs._db.close(done);
+            else done();
+          });
         });
       });
     }, 50);
@@ -73,6 +76,7 @@ describe('Retry', () => {
     });
 
     jobs.on('success:a job', () => {
+      jobs.stop();
       done();
     });
 

--- a/test/retry.js
+++ b/test/retry.js
@@ -9,10 +9,11 @@ const mongoCfg = 'mongodb://' + mongoHost + ':' + mongoPort + '/agenda-test';
 
 // Create agenda instances
 let jobs = null;
-let mongo = null;
+let mongoDb = null;
+let mongoClient = null;
 
 const clearJobs = done => {
-  mongo.collection('agendaJobs').remove({}, done);
+  mongoDb.collection('agendaJobs').remove({}, done);
 };
 
 const jobType = 'do work';
@@ -29,7 +30,8 @@ describe('Retry', () => {
         done(err);
       }
       MongoClient.connect(mongoCfg, (error, client) => {
-        mongo = client.db('agenda-test');
+        mongoClient = client;
+        mongoDb = client.db('agenda-test');
         setTimeout(() => {
           clearJobs(() => {
             jobs.define('someJob', jobProcessor);
@@ -47,7 +49,7 @@ describe('Retry', () => {
     setTimeout(() => {
       jobs.stop(() => {
         clearJobs(() => {
-          mongo.close(() => {
+          mongoClient.close(() => {
             jobs._mdb.close(done);
           });
         });


### PR DESCRIPTION
Closes https://github.com/agenda/agenda/issues/497

This PR upgrades the underlying mongodb driver to 3.0.3. Warning: you have to specify the database now by adding: 

```js
db: {
       database: 'agenda-test'
}
```
to agenda config, otherwise "agenda" is used as default database.

Furthermore you can add noIndexCheck: true (under db config) in production, so agenda does not perform an ensureIndex query.
```js
db: {
       noIndexCheck: true
}
```

Besides that I removed a code part that somehow stopped agenda from working from time to time (due to the reason it didn't reconnect correclty) and fixed the tests to run with the new driver. I also added the patch #561 by andylansen.