### PR TITLE
job queue bug fix

### DIFF
--- a/lib/utils/process-jobs.js
+++ b/lib/utils/process-jobs.js
@@ -234,7 +234,7 @@ module.exports = function(extraJob) {
 
     // Get the next job that is not blocked by concurrency
     let next;
-    for (next = jobQueue.length - 1; next > 0; next -= 1) {
+    for (next = jobQueue.length - 1; next >= 0; next -= 1) {
       const def = definitions[jobQueue[next].attrs.name];
       if (def.concurrency > def.running) {
         break;
@@ -256,6 +256,7 @@ module.exports = function(extraJob) {
       const runIn = job.attrs.nextRunAt - now;
       debug('[%s:%s] nextRunAt is in the future, calling setTimeout(%d)', job.attrs.name, job.attrs._id, runIn);
       setTimeout(runOrRetry, runIn);
+      jobProcessing();
     }
 
     /**


### PR DESCRIPTION
"Get the next job that is not blocked by concurrency", it should check the last job in the job queue. If the last job gets blocked by concurrency, the job will be put on top of the job queue which doesn't make sense.