### PR TITLE
job queue bug fix

### DIFF
--- a/lib/utils/process-jobs.js
+++ b/lib/utils/process-jobs.js
@@ -234,11 +234,16 @@ module.exports = function(extraJob) {
 
     // Get the next job that is not blocked by concurrency
     let next;
-    for (next = jobQueue.length - 1; next > 0; next -= 1) {
+    for (next = jobQueue.length - 1; next >= 0; next -= 1) {
       const def = definitions[jobQueue[next].attrs.name];
       if (def.concurrency > def.running) {
         break;
       }
+    }
+
+    // all the jobs are blocked by concurrency
+    if (next < 0) {
+      return;
     }
 
     // We now have the job we are going to process and its definition
@@ -256,6 +261,7 @@ module.exports = function(extraJob) {
       const runIn = job.attrs.nextRunAt - now;
       debug('[%s:%s] nextRunAt is in the future, calling setTimeout(%d)', job.attrs.name, job.attrs._id, runIn);
       setTimeout(runOrRetry, runIn);
+      jobProcessing();
     }
 
     /**


### PR DESCRIPTION
"Get the next job that is not blocked by concurrency", it should check all jobs in the job queue. If the last job gets blocked by concurrency, the job will be put on top of the job queue which doesn't make sense.