### PR TITLE
Add optional callback to done() for job processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,10 @@ Before you can use a job, you must define its processing behavior.
 Defines a job with the name of `jobName`. When a job of `jobName` gets run, it
 will be passed to `fn(job, done)`. To maintain asynchronous behavior, you must
 call `done()` when you are processing the job. If your function is synchronous,
-you may omit `done` from the signature.
+you may omit `done` from the signature. You can also provide a callback function
+to the `done()` function, which will be called with the result of updating the
+job in the database. If both an error and a callback are provided, the error
+must come first (i.e. `done(err, cb)`).
 
 `options` is an optional argument which can overwrite the defaults. It can take
 the following:

--- a/lib/agenda/db-init.js
+++ b/lib/agenda/db-init.js
@@ -14,7 +14,7 @@ module.exports = function(collection, cb) {
   debug('attempting index creation');
   this._collection.createIndex(this._indices, {
     name: 'findAndLockNextJobIndex'
-  }, (err, result) => {
+  }, err => {
     if (err) {
       debug('index creation failed');
       self.emit('error', err);

--- a/lib/job/run.js
+++ b/lib/job/run.js
@@ -16,7 +16,14 @@ module.exports = function(cb) {
     debug('[%s:%s] setting lastRunAt to: %s', self.attrs.name, self.attrs._id, self.attrs.lastRunAt.toISOString());
     self.computeNextRunAt();
     self.save(() => {
-      const jobCallback = function(err) {
+      const jobCallback = function(err, jobCb) {
+        // If there is only one argument and it is a function, treat it as the
+        // jobCb, rather than an error
+        if (arguments.length === 1 && typeof err === 'function') {
+          jobCb = err;
+          err = undefined;
+        }
+
         if (err) {
           self.fail(err);
         }
@@ -29,6 +36,7 @@ module.exports = function(cb) {
 
         self.save((saveErr, job) => {
           cb && cb(err || saveErr, job);  // eslint-disable-line no-unused-expressions
+          jobCb && jobCb(saveErr, job);   // eslint-disable-line no-unused-expressions
           if (err) {
             agenda.emit('fail', err, self);
             agenda.emit('fail:' + self.attrs.name, err, self);

--- a/test/job.js
+++ b/test/job.js
@@ -302,6 +302,7 @@ describe('Job', () => {
         done();
       });
     });
+
     it('updates nextRunAt', done => {
       const now = new Date();
       job.repeatEvery('10 minutes');
@@ -312,6 +313,7 @@ describe('Job', () => {
         });
       }, 5);
     });
+
     it('handles errors', done => {
       job.attrs.name = 'failBoat';
       jobs.define('failBoat', () => {
@@ -322,6 +324,7 @@ describe('Job', () => {
         done();
       });
     });
+
     it('handles errors with q promises', done => {
       job.attrs.name = 'failBoat2';
       jobs.define('failBoat2', (job, cb) => {
@@ -370,6 +373,42 @@ describe('Job', () => {
             done();
           });
         });
+      });
+    });
+
+    it('allows a callback to be provided for the underlying save operation', done => {
+      jobs.define('testRunCb', (job, defineDone) => {
+        setTimeout(() => {
+          defineDone(err => {
+            if (err) {
+              return done(err);
+            }
+
+            done();
+          });
+        }, 100);
+      });
+
+      job = new Job({agenda: jobs, name: 'testRunCb'});
+      job.run();
+    });
+
+    it('allows an error and a callback to be provided', done => {
+      jobs.define('testRunCb', (job, defineDone) => {
+        setTimeout(() => {
+          defineDone(new Error('fail'), err => {
+            if (err) {
+              return done(err);
+            }
+
+            done();
+          });
+        }, 100);
+      });
+
+      job = new Job({agenda: jobs, name: 'testRunCb'});
+      job.run(err => {
+        expect(err).to.be.ok();
       });
     });
   });


### PR DESCRIPTION
Under the current behavior, there is no reliable way of determining the result of calling `done()` when processing a job. There are 'success', 'fail' and 'complete' events, but these have to be correlated back to the specific job for which `done()` was called and they are unreliable for determining failures to save the job when calling `done(err)`.

This PR adds an optional callback to the `done()` function when processing a job. If provided, the callback is called with the result of saving the job's updated state to the database. This can be used to add instrumentation/logging or additional error handling to job processing without the extra correlation required when listening to events.