### PR TITLE
Fix flaky test for FIFO ordering with priority

### DIFF
--- a/lib/agenda/db-init.js
+++ b/lib/agenda/db-init.js
@@ -14,7 +14,7 @@ module.exports = function(collection, cb) {
   debug('attempting index creation');
   this._collection.createIndex(this._indices, {
     name: 'findAndLockNextJobIndex'
-  }, (err, result) => {
+  }, err => {
     if (err) {
       debug('index creation failed');
       self.emit('error', err);

--- a/test/job.js
+++ b/test/job.js
@@ -883,9 +883,13 @@ describe('Job', () => {
         if (priorities.length !== 3 || times.length !== 3) {
           return;
         }
-        expect(times.join('')).to.eql(times.sort().join(''));
-        expect(priorities).to.eql([10, 10, -10]);
-        done();
+        try {
+          expect(times.join('')).to.eql(times.sort().join(''));
+          expect(priorities).to.eql([10, 10, -10]);
+          done();
+        } catch (err) {
+          done(err);
+        }
       };
 
       jobs.on('start:fifo-priority', checkResults);
@@ -894,11 +898,14 @@ describe('Job', () => {
         if (err) {
           return done(err);
         }
-        jobs.create('fifo-priority').schedule(new Date(now + 100)).priority('low').save(err => {
+        // Lock both the low and high priority jobs to the exact same date so
+        // that the ordering is predictable
+        const nextDate = new Date(now + 100);
+        jobs.create('fifo-priority').schedule(nextDate).priority('low').save(err => {
           if (err) {
             return done(err);
           }
-          jobs.create('fifo-priority').schedule(new Date(now + 100)).priority('high').save(err => {
+          jobs.create('fifo-priority').schedule(nextDate).priority('high').save(err => {
             if (err) {
               return done(err);
             }


### PR DESCRIPTION
Several PRs have failing builds due to intermittent errors with this specific test. The flakiness in the test is due to the fact that the two jobs that are supposed to run in priority order are scheduled using separately-constructed dates. If the two dates end up differing by even 1ms, the test will fail (since processing order is by time, then priority).

This change make the test use the same date for each of the relevant jobs so that it passes reliably. It also wraps the final expectations in a try/catch so that failures will show the expectation failure, rather than a timeout.