### PR TITLE
Remove support for deprecated versions of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@ language: node_js
 services: mongodb
 sudo: required
 node_js:
-  - "4"
-  - "5"
   - "6"
   - "7"
   - "8"
+  - "10"
 addons:
   apt:
     sources:


### PR DESCRIPTION
Node v4 and v5 does not receive updates now