### PR TITLE
Update README.md to have correct priority mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ Priority mapping:
 {
   highest: 20,
   high: 10,
-  default: 0,
+  normal: 0,
   low: -10,
   lowest: -20
 }


### PR DESCRIPTION
The map has `normal: 0`, but documentation was `default: 0` - updated docs.