### PR TITLE
Drop Node.js 4,5 and 6 testing from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@ language: node_js
 services: mongodb
 sudo: required
 node_js:
-  - "4"
-  - "5"
-  - "6"
   - "7"
   - "8"
+  - "9"
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: node_js
 services: mongodb
 sudo: required
 node_js:
-  - "7"
   - "8"
-  - "9"
+  - "10"
 addons:
   apt:
     sources:

--- a/History.md
+++ b/History.md
@@ -1,5 +1,6 @@
 Next
 ====
+  * Drop support for Node.js 4, 5 and 6
   * Drop support for MongoDB 2.4 ([#497](https://github.com/agenda/agenda/pull/497))
   * Rewrite tests: replace mocha and blanket with ava and nyc ([#506](https://github.com/agenda/agenda/pull/506))
   * Optimization: don't try and unlock jobs when `_lockedJobs` is empty ([#509](https://github.com/agenda/agenda/pull/509))

--- a/README.md
+++ b/README.md
@@ -867,7 +867,7 @@ when no connection is available on each [process tick](#processeveryinterval), a
 instance without having to restart the application.
 
 However, if you are using an [existing Mongo client](#mongomongoclientinstance)
-you'll need to configure the `reconnectTries` and `reconnectInterval` [connection settings](http://mongodb.github.io/node-mongodb-native/2.2/reference/connecting/connection-settings/)
+you'll need to configure the `reconnectTries` and `reconnectInterval` [connection settings](http://mongodb.github.io/node-mongodb-native/3.0/reference/connecting/connection-settings/)
 manually, otherwise you'll find that Agenda will throw an error with the message "MongoDB connection is not recoverable,
 application restart required" if the connection cannot be recovered within 30 seconds.
 


### PR DESCRIPTION
- Drop Node.js 4,5, 6 and 7 testing from Travis 

- Keep Node.js 8 testing

- Add Node.js 10 testing

https://github.com/nodejs/Release#release-schedule