### PR TITLE
Tests: test `lastRunAt` not `nextRunAt` for FIFO tests

### DIFF
--- a/test/job.js
+++ b/test/job.js
@@ -841,7 +841,7 @@ describe('Job', () => {
       const checkResultsPromise = new Promise(resolve =>
         agenda.on('start:fifo-priority', job => {
           priorities.push(job.attrs.priority);
-          times.push(new Date(job.attrs.nextRunAt).getTime());
+          times.push(new Date(job.attrs.lastRunAt).getTime());
           if (priorities.length !== 3 || times.length !== 3) {
             return;
           }


### PR DESCRIPTION
`nextRunAt` seems to be `null` so in here `times` ends up being `[0,0,0]`:

```js
expect(times.join('')).to.eql(times.sort().join(''));
```