### PR TITLE
Remove comments refrencing deprecated findAndModify

### DIFF
--- a/lib/agenda/index.js
+++ b/lib/agenda/index.js
@@ -1,7 +1,3 @@
-/**
- * @TODO: Refactor remaining deprecated MongoDB Native Driver methods: findAndModify()
- */
-
 const {EventEmitter} = require('events');
 const humanInterval = require('human-interval');
 

--- a/lib/agenda/save-job.js
+++ b/lib/agenda/save-job.js
@@ -16,7 +16,7 @@ const processDbResult = (job, result) => {
   debug('processDbResult() called with success, checking whether to process job immediately or not');
 
   // We have a result from the above calls
-  // findAndModify() returns different results than insertOne() so check for that
+  // findOneAndUpdate() returns different results than insertOne() so check for that
   let res = result.ops ? result.ops : result.value;
   if (res) {
     // If it is an array, grab the first job


### PR DESCRIPTION
Deprecated `findAndModify()` has already been updated to `findOneAndUpdate()` in https://github.com/agenda/agenda/pull/448