### PR TITLE
every: make the single type to be disabled

### DIFF
--- a/lib/agenda/every.js
+++ b/lib/agenda/every.js
@@ -23,7 +23,7 @@ module.exports = async function(interval, names, data, options) {
   const createJob = async (interval, name, data, options) => {
     const job = this.create(name, data);
 
-    job.attrs.type = 'single';
+    job.attrs.type = options.type || 'single';
     job.repeatEvery(interval, options);
     job.computeNextRunAt();
     await job.save();


### PR DESCRIPTION
The every job is using the same document in the collection `jobs`, it might be configurable in user-land at some use cases.

Adding the `type` options for someone which wants every job to create a new instance(`job`) in every time :)
