### PR TITLE
Touch shouldn't accept a callback

### DIFF
--- a/lib/job/touch.js
+++ b/lib/job/touch.js
@@ -4,10 +4,9 @@
  * Updates "lockedAt" time so the job does not get picked up again
  * @name Job#touch
  * @function
- * @param {Function} cb called when job "touch" fails or passes
  * @returns {undefined}
  */
-module.exports = function(cb) {
+module.exports = function() {
   this.attrs.lockedAt = new Date();
-  this.save(cb);
+  return this.save();
 };

--- a/test/job.js
+++ b/test/job.js
@@ -351,11 +351,11 @@ describe('Job', () => {
     it('extends the lock lifetime', done => {
       const lockedAt = new Date();
       const job = new Job({agenda, name: 'some job', lockedAt});
-      job.save = function(cb) {
-        cb();
+      job.save = function() {
+        return Promise.resolve();
       };
       setTimeout(() => {
-        job.touch(() => {
+        job.touch().then(() => {
           expect(job.attrs.lockedAt).to.be.greaterThan(lockedAt);
           done();
         });


### PR DESCRIPTION
Touch immediately calls `.save(cb)`, passing in the provided callback. `save` doesn't expect a callback, and throws a "no callback" error. `touch` should instead accept no callback and return a promise.