### PR TITLE
Support async functions in job processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ const agenda = new Agenda({db: {address: mongoConnectionString}});
 // or pass in an existing mongodb-native MongoClient instance
 // const agenda = new Agenda({mongo: myMongoClient});
 
-agenda.define('delete old users', (job, done) => {
-  User.remove({lastLogIn: {$lt: twoDaysAgo}}, done);
+agenda.define('delete old users', async job => {
+  await User.remove({lastLogIn: {$lt: twoDaysAgo}});
 });
 
 (async function() { // IIFE to give access to async/await
@@ -91,14 +91,14 @@ agenda.define('delete old users', (job, done) => {
 ```
 
 ```js
-agenda.define('send email report', {priority: 'high', concurrency: 10}, (job, done) => {
+agenda.define('send email report', {priority: 'high', concurrency: 10}, async job => {
   const {to} = job.attrs.data;
-  emailClient.send({
+  await emailClient.send({
     to,
     from: 'example@example.com',
     subject: 'Email Report',
     body: '...'
-  }, done);
+  });
 });
 
 (async function() {
@@ -326,8 +326,9 @@ Takes a `number` which specifies the default lock lifetime in milliseconds. By
 default it is 10 minutes. This can be overridden by specifying the
 `lockLifetime` option to a defined job.
 
-A job will unlock if it is finished (ie. `done` is called) before the `lockLifetime`.
-The lock is useful if the job crashes or times out.
+A job will unlock if it is finished (ie. the returned Promise resolves/rejects
+or `done` is specified in the params and `done()` is called) before the
+`lockLifetime`. The lock is useful if the job crashes or times out.
 
 ```js
 agenda.defaultLockLifetime(10000);
@@ -365,9 +366,11 @@ Before you can use a job, you must define its processing behavior.
 ### define(jobName, [options], fn)
 
 Defines a job with the name of `jobName`. When a job of `jobName` gets run, it
-will be passed to `fn(job, done)`. To maintain asynchronous behavior, you must
-call `done()` when you are processing the job. If your function is synchronous,
-you may omit `done` from the signature.
+will be passed to `fn(job, done)`. To maintain asynchronous behavior, you may
+either provide a Promise-returning function in `fn` *or* provide `done` as a
+second parameter to `fn`. If `done` is specified in the function signature, you
+must call `done()` when you are processing the job. If your function is
+synchronous or returns a Promise, you may omit `done` from the signature.
 
 `options` is an optional argument which can overwrite the defaults. It can take
 the following:
@@ -375,7 +378,7 @@ the following:
 - `concurrency`: `number` maximum number of that job that can be running at once (per instance of agenda)
 - `lockLimit`: `number` maximum number of that job that can be locked at once (per instance of agenda)
 - `lockLifetime`: `number` interval in ms of how long the job stays locked for (see [multiple job processors](#multiple-job-processors) for more info).
-A job will automatically unlock if `done()` is called.
+A job will automatically unlock once a returned promise resolves/rejects (or if `done` is specified in the signature and `done()` is called).
 - `priority`: `(lowest|low|normal|high|highest|number)` specifies the priority
   of the job. Higher priority jobs will run first. See the priority mapping
   below
@@ -392,6 +395,15 @@ Priority mapping:
 ```
 
 Async Job:
+```js
+agenda.define('some long running job', async job => {
+  const data = await doSomelengthyTask();
+  await formatThatData(data);
+  await sendThatData(data);
+});
+```
+
+Async Job (using `done`):
 ```js
 agenda.define('some long running job', (job, done) => {
   doSomelengthyTask(data => {
@@ -435,12 +447,10 @@ persisted in the database.
 Returns the `job`.
 
 ```js
-agenda.define('printAnalyticsReport', (job, done) => {
-  User.doSomethingReallyIntensive((err, users) => {
-    processUserData();
-    console.log('I print a report!');
-    done();
-  });
+agenda.define('printAnalyticsReport', async job => {
+  const users = await User.doSomethingReallyIntensive();
+  processUserData(users);
+  console.log('I print a report!');
 });
 
 agenda.every('15 minutes', 'printAnalyticsReport');
@@ -598,7 +608,8 @@ specify a longer lockLifetime.
 By default it is 10 minutes. Typically you shouldn't have a job that runs for 10 minutes,
 so this is really insurance should the job queue crash before the job is unlocked.
 
-When a job is finished (ie. `done` is called), it will automatically unlock.
+When a job is finished (i.e. the returned promise resolves/rejects or `done` is
+specified in the signature and `done()` is called), it will automatically unlock.
 
 ## Manually working with a job
 
@@ -746,14 +757,12 @@ when you have very long running jobs. The call returns a promise that resolves
 when the job's lock has been renewed.
 
 ```js
-agenda.define('super long job', (job, done) => {
-  (async () => {
-    await doSomeLongTask();
-    await job.touch();
-    await doAnotherLongTask();
-    await job.touch();
-    await finishOurLongTasks();
-  })().then(done, done);
+agenda.define('super long job', async job => {
+  await doSomeLongTask();
+  await job.touch();
+  await doAnotherLongTask();
+  await job.touch();
+  await finishOurLongTasks();
 });
 ```
 
@@ -956,16 +965,12 @@ let email = require('some-email-lib'),
   User = require('../models/user-model.js');
 
 module.exports = function(agenda) {
-  agenda.define('registration email', (job, done) => {
-    User.get(job.attrs.data.userId, (err, user) => {
-      if (err) {
-        return done(err);
-      }
-      email(user.email(), 'Thanks for registering', 'Thanks for registering ' + user.name(), done);
-    });
+  agenda.define('registration email', async job => {
+    const user = await User.get(job.attrs.data.userId);
+    await email(user.email(), 'Thanks for registering', 'Thanks for registering ' + user.name());
   });
 
-  agenda.define('reset password', (job, done) => {
+  agenda.define('reset password', async job => {
     // Etc
   });
 

--- a/lib/job/run.js
+++ b/lib/job/run.js
@@ -18,7 +18,14 @@ module.exports = function() {
     self.computeNextRunAt();
     await self.save();
 
+    let finished = false;
     const jobCallback = async err => {
+      // We don't want to complete the job multiple times
+      if (finished) {
+        return;
+      }
+      finished = true;
+
       if (err) {
         self.fail(err);
       } else {
@@ -60,10 +67,10 @@ module.exports = function() {
       }
       if (definition.fn.length === 2) {
         debug('[%s:%s] process function being called', self.attrs.name, self.attrs._id);
-        definition.fn(self, jobCallback);
+        await definition.fn(self, jobCallback);
       } else {
         debug('[%s:%s] process function being called', self.attrs.name, self.attrs._id);
-        definition.fn(self);
+        await definition.fn(self);
         await jobCallback();
       }
     } catch (err) {

--- a/test/job.js
+++ b/test/job.js
@@ -328,6 +328,128 @@ describe('Job', () => {
       });
     });
 
+    it('allows async functions', async() => {
+      job.attrs.name = 'async';
+
+      const successSpy = sinon.stub();
+      let finished = false;
+
+      agenda.once('success:async', successSpy);
+
+      agenda.define('async', async() => {
+        await delay(5);
+        finished = true;
+      });
+
+      expect(finished).to.equal(false);
+      await job.run();
+      expect(successSpy.callCount).to.equal(1);
+      expect(finished).to.equal(true);
+    });
+
+    it('handles errors from async functions', async() => {
+      job.attrs.name = 'asyncFail';
+
+      const failSpy = sinon.stub();
+      const err = new Error('failure');
+
+      agenda.once('fail:asyncFail', failSpy);
+
+      agenda.define('asyncFail', async() => {
+        await delay(5);
+        throw err;
+      });
+
+      await job.run();
+      expect(failSpy.callCount).to.equal(1);
+      expect(failSpy.calledWith(err)).to.equal(true);
+    });
+
+    it('waits for the callback to be called even if the function is async', async() => {
+      job.attrs.name = 'asyncCb';
+
+      const successSpy = sinon.stub();
+      let finishedCb = false;
+
+      agenda.once('success:asyncCb', successSpy);
+
+      agenda.define('asyncCb', async(job, cb) => {
+        (async() => {
+          await delay(5);
+          finishedCb = true;
+          cb();
+        })();
+      });
+
+      await job.run();
+      expect(finishedCb).to.equal(true);
+      expect(successSpy.callCount).to.equal(1);
+    });
+
+    it('uses the callback error if the function is async and didn\'t reject', async() => {
+      job.attrs.name = 'asyncCbError';
+
+      const failSpy = sinon.stub();
+      const err = new Error('failure');
+
+      agenda.once('fail:asyncCbError', failSpy);
+
+      agenda.define('asyncCbError', async(job, cb) => {
+        (async() => {
+          await delay(5);
+          cb(err);
+        })();
+      });
+
+      await job.run();
+      expect(failSpy.callCount).to.equal(1);
+      expect(failSpy.calledWith(err)).to.equal(true);
+    });
+
+    it('favors the async function error over the callback error if it comes first', async() => {
+      job.attrs.name = 'asyncCbTwoError';
+
+      const failSpy = sinon.stub();
+      const fnErr = new Error('functionFailure');
+      const cbErr = new Error('callbackFailure');
+
+      agenda.on('fail:asyncCbTwoError', failSpy);
+
+      agenda.define('asyncCbTwoError', async(job, cb) => {
+        (async() => {
+          await delay(5);
+          cb(cbErr);
+        })();
+        throw fnErr;
+      });
+
+      await job.run();
+      expect(failSpy.callCount).to.equal(1);
+      expect(failSpy.calledWith(fnErr)).to.equal(true);
+      expect(failSpy.calledWith(cbErr)).to.equal(false);
+    });
+
+    it('favors the callback error over the async function error if it comes first', async() => {
+      job.attrs.name = 'asyncCbTwoErrorCb';
+
+      const failSpy = sinon.stub();
+      const fnErr = new Error('functionFailure');
+      const cbErr = new Error('callbackFailure');
+
+      agenda.on('fail:asyncCbTwoErrorCb', failSpy);
+
+      agenda.define('asyncCbTwoErrorCb', async(job, cb) => {
+        cb(cbErr);
+        await delay(5);
+        throw fnErr;
+      });
+
+      await job.run();
+      expect(failSpy.callCount).to.equal(1);
+      expect(failSpy.calledWith(cbErr)).to.equal(true);
+      expect(failSpy.calledWith(fnErr)).to.equal(false);
+    });
+
     it(`doesn't allow a stale job to be saved`, async() => {
       job.attrs.name = 'failBoat3';
       await job.save();


### PR DESCRIPTION
Adds support for using `async` functions in asynchronous job processing in addition to the current `done` parameter that can be provided. The semantics are as follows:

 * When using a `done` param with no async function, the behavior is the same as before
 * When using an async function with no `done` parameter, the job is considered finished when the async function returns or the returned promise resolves (if using promises directly). If it throws or rejects the promise, the job is considered failed.
 * When both an async function and a `done` parameter are provided, either one can cause the job to fail (by calling `done(err)` or throwing from the async function), but only the `done()` function being called with no error can cause the job to succeed. This is mostly as a courtesy and avoids people having to wrap things in `new Promise()` just to prevent it from completing before they want it to.

cc: @OmgImAlexis 