### PR TITLE
Readme: update agenda.jobs for v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,9 +517,8 @@ Lets you query all of the jobs in the agenda job's database. This is a full [mon
 `find` query. See mongodb-native's documentation for details.
 
 ```js
-agenda.jobs({name: 'printAnalyticsReport'}, (err, jobs) => {
-  // Work with jobs (see below)
-});
+const jobs = await agenda.jobs({name: 'printAnalyticsReport'});
+// Work with jobs (see below)
 ```
 
 ### cancel(mongodb-native query, cb)


### PR DESCRIPTION
fix Readme for agenda.jobs to use await for v 2.0.0