### PR TITLE
Make job.touch() promise-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,22 +739,21 @@ Disables the `job`. Upcoming runs won't execute.
 
 Enables the `job` if it got disabled before. Upcoming runs will execute.
 
-### touch(callback)
+### touch()
 
 Resets the lock on the job. Useful to indicate that the job hasn't timed out
-when you have very long running jobs.
+when you have very long running jobs. The call returns a promise that resolves
+when the job's lock has been renewed.
 
 ```js
 agenda.define('super long job', (job, done) => {
-  doSomeLongTask(() => {
-    job.touch(() => {
-      doAnotherLongTask(() => {
-        job.touch(() => {
-          finishOurLongTasks(done);
-        });
-      });
-    });
-  });
+  (async () => {
+    await doSomeLongTask();
+    await job.touch();
+    await doAnotherLongTask();
+    await job.touch();
+    await finishOurLongTasks();
+  })().then(done, done);
 });
 ```
 

--- a/lib/job/touch.js
+++ b/lib/job/touch.js
@@ -1,13 +1,16 @@
 'use strict';
 
+const noCallback = require('../no-callback');
+
 /**
  * Updates "lockedAt" time so the job does not get picked up again
  * @name Job#touch
  * @function
- * @param {Function} cb called when job "touch" fails or passes
  * @returns {undefined}
  */
-module.exports = function(cb) {
+module.exports = async function() {
+  // eslint-disable-next-line prefer-rest-params
+  noCallback(arguments);
   this.attrs.lockedAt = new Date();
-  this.save(cb);
+  return this.save();
 };

--- a/test/job.js
+++ b/test/job.js
@@ -349,18 +349,12 @@ describe('Job', () => {
   });
 
   describe('touch', () => {
-    it('extends the lock lifetime', done => {
+    it('extends the lock lifetime', async() => {
       const lockedAt = new Date();
       const job = new Job({agenda, name: 'some job', lockedAt});
-      job.save = function(cb) {
-        cb();
-      };
-      setTimeout(() => {
-        job.touch(() => {
-          expect(job.attrs.lockedAt).to.be.greaterThan(lockedAt);
-          done();
-        });
-      }, 2);
+      await delay(2);
+      await job.touch();
+      expect(job.attrs.lockedAt).to.be.greaterThan(lockedAt);
     });
   });
 


### PR DESCRIPTION
The [`job.touch()`](https://github.com/agenda/agenda/blob/master/lib/job/touch.js#L10-L13) method didn't get migrated over to promises along with everything else and still expects a callback. However, when it passes that callback down to `job.save()`, an error is thrown because a callback is not allowed.

This managed to slip through because the test for it changed at some point to mock out the implementation of `job.save()` with a callback version that didn't throw when it was called with a callback.

https://github.com/agenda/agenda/blob/bd8a8e003cd09d6e9826accbf6c30be75212a9a9/test/job.js#L352-L364

This PR makes the behavior of `touch()` align with the rest of the library and updates the associated test to remove the mock on `save()`.

Side note: this seems safe to treat as a bugfix rather than a breaking change because passing a callback to `touch()` doesn't work with the current code.