### PR TITLE
Docs: Add REST API to comparison chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Agenda is great if you need something that is simple and backed by MongoDB.
 | Atomic ops      | ✓             |       |  ✓  |        |
 | Persistence     | ✓             |   ✓   |  ✓  |   ✓    |
 | UI              | ✓             |   ✓   |     |   ✓    |
+| REST API        |               |       |     |   ✓    |
 | Optimized for   | Jobs / Messages | Jobs | Messages | Jobs |
 
 _Kudos for making the comparison chart goes to [Bull](https://www.npmjs.com/package/bull#feature-comparison) maintainers._


### PR DESCRIPTION
Now that REST API supports Agenda v2 (https://github.com/agenda/agenda-rest/issues/20), suppose we can add it to comparison chart?