### PR TITLE
Upgrading node-cron dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/agenda/agenda/issues"
   },
   "dependencies": {
-    "cron": "~1.3.0",
+    "cron": "~1.5.0",
     "date.js": "~0.3.2",
     "debug": "~3.1.0",
     "human-interval": "~0.1.3",


### PR DESCRIPTION
Hi All, 

A major bug  that blocks the event loop was discovered  in all versions of Cron; a library that is currently utilized by  [Agenda](https://github.com/agenda/agenda/blob/master/lib/job/compute-next-run-at.js#L38)  for computing the next run of a cron string.

This was due to an unexpected behavior  that exists in `moment/momen-timezone ` [library](https://github.com/moment/moment-timezone/issues/676) which is used by cron when calculating the next run date.


This only occurs on  DST switches (2 times a year)  but could be fatal for some use-cases.


More details here: [link](https://github.com/kelektiv/node-cron/issues/381)


Thanks alot.