### PR TITLE
Reset failReason, failCount, and failedAt when a job completes successfully.

### DIFF
--- a/lib/job/run.js
+++ b/lib/job/run.js
@@ -23,6 +23,9 @@ module.exports = function() {
         self.fail(err);
       } else {
         self.attrs.lastFinishedAt = new Date();
+        self.attrs.failReason = null;
+        self.attrs.failCount = 0;
+        self.attrs.failedAt = null;
       }
 
       self.attrs.lockedAt = null;


### PR DESCRIPTION
Reset failReason, failCount, and failedAt when a job completes successfully.  This is useful for repeating jobs so that those values aren't carried over when the next failure occurs.