### PR TITLE
docs: fix wrong console log statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,7 +793,7 @@ agenda.on('success:send email', job => {
 
 ```js
 agenda.on('fail:send email', (err, job) => {
-  console.log('Job failed with error: ${err.message}');
+  console.log(`Job failed with error: ${err.message}`);
 });
 ```
 


### PR DESCRIPTION
- Console log should not contain single quotes but template literals