### PR TITLE
Improved readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ being stored in memory.
 
 Also worth noting is that if the job queue is shutdown, any jobs stored in memory
 that haven't run will still be locked, meaning that you may have to wait for the
-lock to expire.
+lock to expire. By defualt it is `'5 seconds'`.
 
 ```js
 agenda.processEvery('1 minute');


### PR DESCRIPTION
The `README.md` was missing the default value for `processEvery`, had to look it up on the source code, link: https://github.com/agenda/agenda/blob/master/lib/agenda/index.js#L33

Hope this PR would help someone else in the future, keep on with the great work 👍 