### PR TITLE
Add  option on mongo connection

### DIFF
--- a/lib/agenda/database.js
+++ b/lib/agenda/database.js
@@ -26,7 +26,7 @@ module.exports = function(url, collection, options, cb) {
   }
 
   collection = collection || 'agendaJobs';
-  options = Object.assign({autoReconnect: true, reconnectTries: Number.MAX_SAFE_INTEGER, reconnectInterval: this._processEvery}, options);
+  options = Object.assign({autoReconnect: true, reconnectTries: Number.MAX_SAFE_INTEGER, reconnectInterval: this._processEvery, useNewUrlParser: true}, options);
   MongoClient.connect(url, options, (error, client) => {
     if (error) {
       debug('error connecting to MongoDB using collection: [%s]', collection);


### PR DESCRIPTION
Add `newUrlParser` option on MongoDB connection to prevent warning on the console.
#738 