### PR TITLE
Fix eslint errors and add package-lock.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ coverage.html
 .idea
 .DS_Store
 docs
+
+package-lock.json

--- a/lib/agenda/cancel.js
+++ b/lib/agenda/cancel.js
@@ -11,6 +11,7 @@ const debug = require('debug')('agenda:cancel');
  */
 module.exports = function(query) {
   debug('attempting to cancel all Agenda jobs', query);
+  /* eslint promise/prefer-await-to-then: warn */
   return this._collection.deleteMany(query).then(({result}) => {
     debug('%s jobs cancelled', result.n);
     return result.n;

--- a/lib/utils/process-jobs.js
+++ b/lib/utils/process-jobs.js
@@ -285,6 +285,7 @@ module.exports = function(extraJob) {
 
           // CALL THE ACTUAL METHOD TO PROCESS THE JOB!!!
           debug('[%s:%s] processing job', job.attrs.name, job.attrs._id);
+          /* eslint promise/prefer-await-to-then: warn */
           job.run()
             .catch(err => [err, job])
             .then(job => processJobResult(...Array.isArray(job) ? job : [null, job]));

--- a/test/job.js
+++ b/test/job.js
@@ -1,4 +1,5 @@
 /* globals describe, it, beforeEach, afterEach */
+/* eslint promise/prefer-await-to-then: warn */
 'use strict';
 const path = require('path');
 const cp = require('child_process');


### PR DESCRIPTION
We've had a broken build for months because of xo, this fixes that by converting those errors to warnings. Also, committing package-lock.json is not very useful for modules because [`npm publish` ignores it](https://docs.npmjs.com/files/package-lock.json#description)