### PR TITLE
fix(schedule): throw error if invalid params to `schedule()`

### DIFF
--- a/lib/agenda/schedule.js
+++ b/lib/agenda/schedule.js
@@ -55,4 +55,6 @@ module.exports = function(when, names, data) {
     debug('Agenda.schedule(%s, %O, [%O])', when, names);
     return createJobs(when, names, data);
   }
+  
+  throw new Error('Invalid job name(s), got "' + names + '"');
 };


### PR DESCRIPTION
Right now if you pass invalid params to `schedule()`, you get `undefined` back. This PR makes `schedule()` throw an error if it can't recognize what it should do.