### PR TITLE
Fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,7 +793,7 @@ agenda.on('success:send email', job => {
 
 ```js
 agenda.on('fail:send email', (err, job) => {
-  console.log('Job failed with error: ${err.message}');
+  console.log(`Job failed with error: ${err.message}`);
 });
 ```
 


### PR DESCRIPTION
Replace single quotes by backtick in string containing a placeholder.