### PR TITLE
Specify call order for start

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,8 +554,8 @@ run them. You can also stop the queue.
 
 ### start
 
-Starts the job queue processing, checking `processEvery` time to see if there
-are new jobs.
+Starts the job queue processing, checking [`processEvery`](#processeveryinterval) time to see if there
+are new jobs. Must be called *after* `processEvery`, and *before* any job scheduling (e.g. `every`).
 
 ### stop
 


### PR DESCRIPTION
Calling `processEvery` after `start` means the interval will be ignored.

Calling `every` before `start` yields a Mongo Error:

> TypeError: Cannot read property 'findOneAndUpdate' of undefined
    at Agenda.module.exports [as saveJob] 