### PR TITLE
Fix Linter errors blocking CI

### DIFF
--- a/lib/agenda/cancel.js
+++ b/lib/agenda/cancel.js
@@ -9,13 +9,14 @@ const debug = require('debug')('agenda:cancel');
  * @caller client code, Agenda.purge(), Job.remove()
  * @returns {Promise<Number>} A promise that contains the number of removed documents when fulfilled.
  */
-module.exports = function(query) {
+module.exports = async function(query) {
   debug('attempting to cancel all Agenda jobs', query);
-  return this._collection.deleteMany(query).then(({result}) => {
+  try {
+    const {result} = await this._collection.deleteMany(query);
     debug('%s jobs cancelled', result.n);
     return result.n;
-  }).catch(err => {
+  } catch (err) {
     debug('error trying to delete jobs from MongoDB');
     throw err;
-  });
+  }
 };

--- a/lib/utils/process-jobs.js
+++ b/lib/utils/process-jobs.js
@@ -285,11 +285,10 @@ module.exports = function(extraJob) {
 
           // CALL THE ACTUAL METHOD TO PROCESS THE JOB!!!
           debug('[%s:%s] processing job', job.attrs.name, job.attrs._id);
-          try {
-            processJobResult(null, await job.run());
-          } catch (err) {
-            processJobResult(err);
-          }
+
+          job.run()
+            .catch(err => [err, job])
+            .then(job => processJobResult(...Array.isArray(job) ? job : [null, job])); // eslint-disable-line promise/prefer-await-to-then
 
           // Re-run the loop to check for more jobs to process (locally)
           jobProcessing();

--- a/lib/utils/process-jobs.js
+++ b/lib/utils/process-jobs.js
@@ -286,10 +286,9 @@ module.exports = function(extraJob) {
           // CALL THE ACTUAL METHOD TO PROCESS THE JOB!!!
           debug('[%s:%s] processing job', job.attrs.name, job.attrs._id);
           try {
-            const runJob = await job.run();
-            processJobResult(...Array.isArray(runJob) ? runJob : [null, runJob]);
+            processJobResult(null, await job.run());
           } catch (err) {
-            throw err;
+            processJobResult(err);
           }
 
           // Re-run the loop to check for more jobs to process (locally)

--- a/lib/utils/process-jobs.js
+++ b/lib/utils/process-jobs.js
@@ -262,7 +262,7 @@ module.exports = function(extraJob) {
      * Internal method that tries to run a job and if it fails, retries again!
      * @returns {undefined}
      */
-    function runOrRetry() {
+    async function runOrRetry() {
       if (self._processInterval) {
         if (jobDefinition.concurrency > jobDefinition.running && self._runningJobs.length < self._maxConcurrency) {
           // Get the deadline of when the job is not supposed to go past for locking
@@ -285,9 +285,12 @@ module.exports = function(extraJob) {
 
           // CALL THE ACTUAL METHOD TO PROCESS THE JOB!!!
           debug('[%s:%s] processing job', job.attrs.name, job.attrs._id);
-          job.run()
-            .catch(err => [err, job])
-            .then(job => processJobResult(...Array.isArray(job) ? job : [null, job]));
+          try {
+            const runJob = await job.run();
+            processJobResult(...Array.isArray(runJob) ? runJob : [null, runJob]);
+          } catch (err) {
+            throw err;
+          }
 
           // Re-run the loop to check for more jobs to process (locally)
           jobProcessing();

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "debug": "~3.1.0",
     "human-interval": "~0.1.3",
     "moment-timezone": "~0.5.0",
-    "mongodb": "~3.1"
+    "mongodb": "~3.2.2"
   },
   "devDependencies": {
     "blanket": "1.2.3",

--- a/test/job.js
+++ b/test/job.js
@@ -324,7 +324,7 @@ describe('Job', () => {
       job.attrs.name = 'failBoat2';
       agenda.define('failBoat2', (job, cb) => {
         Q.delay(100)
-          .then(() => { // eslint-disable-line
+          .then(() => { // eslint-disable-line promise/prefer-await-to-then
             throw new Error('Zomg fail');
           })
           .fail(cb)

--- a/test/job.js
+++ b/test/job.js
@@ -801,9 +801,11 @@ describe('Job', () => {
 
       agenda.start();
 
-      await agenda.schedule(new Date(now + 100), 'blocking', {i: 1});
-      await agenda.schedule(new Date(now + 100), 'blocking', {i: 2});
-      await agenda.schedule(new Date(now + 100), 'non-blocking', {i: 3});
+      return Promise.all([
+        agenda.schedule(new Date(now + 100), 'blocking', {i: 1}),
+        agenda.schedule(new Date(now + 100), 'blocking', {i: 2}),
+        agenda.schedule(new Date(now + 100), 'non-blocking', {i: 3})
+      ]);
     });
 
     it('should run jobs as first in first out (FIFO)', async() => {

--- a/test/job.js
+++ b/test/job.js
@@ -257,18 +257,14 @@ describe('Job', () => {
       await job.save();
       await job.remove();
 
-      try {
-        const result = await mongoDb
-          .collection('agendaJobs')
-          .find({
-            _id: job.attrs._id
-          })
-          .toArray();
+      const result = await mongoDb
+        .collection('agendaJobs')
+        .find({
+          _id: job.attrs._id
+        })
+        .toArray();
 
-        expect(result).to.have.length(0);
-      } catch (e) {
-        throw e;
-      }
+      expect(result).to.have.length(0);
     });
   });
 

--- a/test/job.js
+++ b/test/job.js
@@ -36,14 +36,12 @@ describe('Job', () => {
       db: {
         address: mongoCfg
       }
-    }, err => {
+    }, async err => {
       if (err) {
         done(err);
       }
-      MongoClient.connect(mongoCfg, async(err, client) => {
-        if (err) {
-          done(err);
-        }
+      try {
+        const client = await MongoClient.connect(mongoCfg, {useNewUrlParser: true});
         mongoClient = client;
         mongoDb = client.db(agendaDatabase);
 
@@ -55,7 +53,9 @@ describe('Job', () => {
         agenda.define('some job', jobProcessor);
         agenda.define(jobType, jobProcessor);
         done();
-      });
+      } catch (err) {
+        done(err);
+      }
     });
   });
 
@@ -249,22 +249,26 @@ describe('Job', () => {
   });
 
   describe('remove', () => {
-    it('removes the job', done => {
+    it('removes the job', async() => {
       const job = new Job({
         agenda,
         name: 'removed job'
       });
-      job.save().then(() => {});
-      job.remove().then(() => {});
-      mongoDb.collection('agendaJobs').find({
-        _id: job.attrs._id
-      }).toArray((err, j) => {
-        if (err) {
-          done(err);
-        }
-        expect(j).to.have.length(0);
-        done();
-      });
+      await job.save();
+      await job.remove();
+
+      try {
+        const result = await mongoDb
+          .collection('agendaJobs')
+          .find({
+            _id: job.attrs._id
+          })
+          .toArray();
+
+        expect(result).to.have.length(0);
+      } catch (e) {
+        throw e;
+      }
     });
   });
 
@@ -319,9 +323,12 @@ describe('Job', () => {
     it('handles errors with q promises', () => {
       job.attrs.name = 'failBoat2';
       agenda.define('failBoat2', (job, cb) => {
-        Q.delay(100).then(() => {
-          throw new Error('Zomg fail');
-        }).fail(cb).done();
+        Q.delay(100)
+          .then(() => { // eslint-disable-line
+            throw new Error('Zomg fail');
+          })
+          .fail(cb)
+          .done();
       });
       job.run().catch(err => {
         expect(err).to.be.ok();
@@ -616,12 +623,13 @@ describe('Job', () => {
       const processorPromise = new Promise(async resolve =>
         agenda.define('lock job', {
           lockLifetime: 50
-        }, () => {
+        }, async() => {
           startCounter++;
 
           if (startCounter !== 1) {
             expect(startCounter).to.be(2);
-            agenda.stop().then(resolve);
+            await agenda.stop();
+            resolve();
           }
         })
       );
@@ -631,7 +639,7 @@ describe('Job', () => {
       agenda.defaultConcurrency(100);
       agenda.processEvery(10);
       agenda.every('0.02 seconds', 'lock job');
-      agenda.stop().then(() => {});
+      await agenda.stop();
       await agenda.start();
       await processorPromise;
     });
@@ -642,12 +650,13 @@ describe('Job', () => {
       const processorPromise = new Promise(async resolve =>
         agenda.define('lock job', {
           lockLifetime: 50
-        }, (job, cb) => { // eslint-disable-line no-unused-vars
+        }, async(job, cb) => { // eslint-disable-line no-unused-vars
           runCount++;
 
           if (runCount !== 1) {
             expect(runCount).to.be(2);
-            agenda.stop().then(resolve);
+            await agenda.stop();
+            resolve();
           }
         })
       );
@@ -762,7 +771,7 @@ describe('Job', () => {
   });
 
   describe('job concurrency', () => {
-    it('should not block a job for concurrency of another job', done => {
+    it('should not block a job for concurrency of another job', async() => {
       agenda.processEvery(50);
 
       const processed = [];
@@ -787,15 +796,14 @@ describe('Job', () => {
       agenda.on('complete', () => {
         if (!finished && processed.length === 3) {
           finished = true;
-          done();
         }
       });
 
       agenda.start();
 
-      agenda.schedule(new Date(now + 100), 'blocking', {i: 1}).then(() => {});
-      agenda.schedule(new Date(now + 100), 'blocking', {i: 2}).then(() => {});
-      agenda.schedule(new Date(now + 100), 'non-blocking', {i: 3}).then(() => {});
+      await agenda.schedule(new Date(now + 100), 'blocking', {i: 1});
+      await agenda.schedule(new Date(now + 100), 'blocking', {i: 2});
+      await agenda.schedule(new Date(now + 100), 'non-blocking', {i: 3});
     });
 
     it('should run jobs as first in first out (FIFO)', async() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,9 +258,10 @@ browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
 
-bson@~1.0.4:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/bson/-/bson-1.0.9.tgz#12319f8323b1254739b7c6bef8d3e89ae05a2f57"
+bson@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.1.tgz#4330f5e99104c4e751e7351859e2d408279f2f13"
+  integrity sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg==
 
 buf-compare@^1.0.0:
   version "1.0.1"
@@ -1974,20 +1975,24 @@ moment-timezone@^0.5.x, moment-timezone@~0.5.0:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
-mongodb-core@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-3.1.0.tgz#af91f36fd560ed785f4e61e694432df4d3698aad"
+mongodb-core@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-3.2.3.tgz#eb9bcb876f169f5843fd135f7f7686dbac0e9e34"
+  integrity sha512-UyI0rmvPPkjOJV8XGWa9VCTq7R4hBVipimhnAXeSXnuAPjuTqbyfA5Ec9RcYJ1Hhu+ISnc8bJ1KfGZd4ZkYARQ==
   dependencies:
-    bson "~1.0.4"
+    bson "^1.1.1"
     require_optional "^1.0.1"
+    safe-buffer "^5.1.2"
   optionalDependencies:
     saslprep "^1.0.0"
 
-mongodb@~3.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.1.0.tgz#20cd836381a4d8a6b1c5a194bb9c8dde852163bb"
+mongodb@~3.2.2:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.2.3.tgz#4610ee33d300caa74329c2dd03e137210723cd91"
+  integrity sha512-jw8UyPsq4QleZ9z+t/pIVy3L++51vKdaJ2Q/XXeYxk/3cnKioAH8H6f5tkkDivrQL4PUgUOHe9uZzkpRFH1XtQ==
   dependencies:
-    mongodb-core "3.1.0"
+    mongodb-core "^3.2.3"
+    safe-buffer "^5.1.2"
 
 ms@2.0.0:
   version "2.0.0"
@@ -2525,9 +2530,10 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safe-regex@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This is mostly refactoring the test suite to use async/await instead of promises. 

The only exception to this was the section where Q promises were being intentionally tested. I figured most people using those style promises aren't also using async/await in conjunction, so I added an eslint ignore there. 

I can re-write those using async/await if there is interest. 

Also, the catch block in the runOrRetry method didn't actually do anything, so I took the liberty of throwing that exception instead of returning an array nowhere. 