### PR TITLE
rm broken and obsolete instruction to createIndex

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,38 +184,9 @@ If you're using the `db` options, or call `database`, then you may still need to
 ### mongo(mongoClientInstance)
 
 Use an existing mongodb-native MongoClient instance. This can help consolidate connections to a
-database. You can instead use `.database` to have agenda handle connecting for
-you.
+database. You can instead use `.database` to have agenda handle connecting for you.
 
-Please note that this must be a *collection*. Also, you will want to run the following
-afterwards to ensure the database has the proper indexes:
-
-```js
-(async () => {
-  await agenda._ready;
-
-  try {
-    agenda._collection.createIndex({
-      disabled: 1,
-      lockedAt: 1,
-      name: 1,
-      nextRunAt: 1,
-      priority: -1
-    }, {
-      name: 'findAndLockNextJobIndex'
-    });
-  } catch (err) {
-    console.log('Failed to create Agenda index!');
-    console.error(err);
-
-    throw err;
-  }
-
-  console.log('Agenda index created.');
-})();
-```
-
-You can also specify it during instantiation.
+You can also specify it during instantiation:
 
 ```js
 const agenda = new Agenda({mongo: mongoClientInstance});


### PR DESCRIPTION
The index is created [already](https://github.com/agenda/agenda/blob/9e88934cab6d301b26e8bc9a1bf72410f793e07a/lib/agenda/db-init.js#L17) by default, and actually trying to run agenda._collection.createIndex(...) as instructed in the README will fail with `MongoError: Index must have unique name.`:

```js
import 'dotenv/config';
import Agenda from 'agenda';
import MongoClient from 'mongodb';

(async function main() {
  const mongoClient = await MongoClient.connect(process.env.MONGO_URL, { useNewUrlParser: true });
  try {
    await mongoClient.db().dropCollection('agendaJobs');
    console.log('agendaJobs collection dropped');
  } catch (e) {
    console.log('agendaJobs collection did not exist, Agenda will create it');
  }

  const agenda = new Agenda({
    mongo: mongoClient.db(),
  });
  // Don't even need to await agenda._ready;
  console.log('Indexes before:', await agenda._collection.indexInformation());

  // Fails with MongoError: Index must have unique name.
  await agenda._collection.createIndex({
    disabled: 1,
    lockedAt: 1,
    name: 1,
    nextRunAt: 1,
    priority: -1
  }, {
    name: 'findAndLockNextJobIndex'
  });
  mongoClient.close();
}());
```