### PR TITLE
add support for limitless concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ const agenda = new Agenda({processEvery: '30 seconds'});
 ### maxConcurrency(number)
 
 Takes a `number` which specifies the max number of jobs that can be running at
-any given moment. By default it is `20`.
+any given moment. By default it is `20`. If it is negative, the maxConcurrency is limitless.
 
 ```js
 agenda.maxConcurrency(20);
@@ -252,7 +252,7 @@ const agenda = new Agenda({maxConcurrency: 20});
 ### defaultConcurrency(number)
 
 Takes a `number` which specifies the default number of a specific job that can be running at
-any given moment. By default it is `5`.
+any given moment. By default it is `5`. If it is negative, the maxConcurrency is limitless.
 
 ```js
 agenda.defaultConcurrency(5);

--- a/lib/utils/process-jobs.js
+++ b/lib/utils/process-jobs.js
@@ -264,7 +264,7 @@ module.exports = function(extraJob) {
      */
     async function runOrRetry() {
       if (self._processInterval) {
-        if (jobDefinition.concurrency > jobDefinition.running && self._runningJobs.length < self._maxConcurrency) {
+        if (jobDefinition.concurrency < 0 | self._maxConcurrency < 0 | (jobDefinition.concurrency > jobDefinition.running && self._runningJobs.length < self._maxConcurrency)) {
           // Get the deadline of when the job is not supposed to go past for locking
           const lockDeadline = new Date(Date.now() - jobDefinition.lockLifetime);
 


### PR DESCRIPTION
In case you would like to manage you resource usage limits for example by setting limits in kubernetes, the concurrency limits are kind of a synthetic bottleneck. I have a usecase, where these limits are very annoying and setting them to limitless is way more elegant than setting a high value and keep this value in mind, in case something does not work some times.