### PR TITLE
Solved: Job which are queued with high priority were not given priority 

### DIFF
--- a/lib/agenda/index.js
+++ b/lib/agenda/index.js
@@ -40,7 +40,7 @@ class Agenda extends EventEmitter {
     this._lockedJobs = [];
     this._jobQueue = [];
     this._defaultLockLifetime = config.defaultLockLifetime || 10 * 60 * 1000; // 10 minute default lockLifetime
-    this._sort = config.sort || {nextRunAt: 1, priority: -1};
+    this._sort = config.sort || {priority: -1, nextRunAt: 1};
     this._indices = Object.assign({name: 1}, this._sort, {priority: -1, lockedAt: 1, nextRunAt: 1, disabled: 1});
 
     this._isLockingOnTheFly = false;


### PR DESCRIPTION
    //registering jobs 
    const regJobToProcess = (job) => {
        let job = agenda.create(job.type, job);
        job.schedule('now');
        job.priority(notification.priority || 'low');
        job.save();
    };
    setTimeout(() => {
        regJobToProcess({ type: 'PROCESS_SMS_OTP', priority: 'low', data: 1 });
        regJobToProcess({ type: 'PROCESS_SMS_OTP', priority: 'high', data: 2 });
    }, 5000);
 
When next job is picked, I expected that it will be the job with high priority. But result was not what i expected and It was the one with low priority. So I have gone through some of the code and found out that sorting order was not right and it was taking nextRunTime 1st and than priority. But for priority queue it should be other way around.

Let me know what is the expected behaviour? If current behaviour is not what is expected please review and merge the PR. 