### PR TITLE
docs(now): remove unsupported callback params 

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,9 +462,6 @@ Schedules a job to run `name` once immediately.
 `data` is an optional argument that will be passed to the processing function
 under `job.attrs.data`.
 
-`cb` is an optional callback function which will be called when the job has been
-persisted in the database.
-
 Returns the `job`.
 
 ```js

--- a/lib/agenda/now.js
+++ b/lib/agenda/now.js
@@ -8,7 +8,6 @@ const noCallback = require('../no-callback');
  * @function
  * @param {String} name name of job to schedule
  * @param {Object} data data to pass to job
- * @param {Function} cb called when job scheduling fails or passes
  * @returns {Job} new job instance created
  */
 module.exports = async function(name, data) {


### PR DESCRIPTION
This PR removes unsupported "cb" params in agenda.now()