### PR TITLE
Remove unsupported callback params

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ agenda.define('say hello', job => {
 
 ## Creating Jobs
 
-### every(interval, name, [data], [options], [cb])
+### every(interval, name, [data], [options])
 
 Runs job `name` at the given `interval`. Optionally, data and options can be passed in.
 Every creates a job of type `single`, which means that it will only create one
@@ -402,10 +402,6 @@ under `job.attrs.data`.
 
 `options` is an optional argument that will be passed to [`job.repeatEvery`](#repeateveryinterval-options).
 In order to use this argument, `data` must also be specified.
-
-`cb` is an optional callback function which will be called when the job has been
-persisted in the database.
-
 
 Returns the `job`.
 
@@ -430,16 +426,13 @@ agenda.every('15 minutes', ['printAnalyticsReport', 'sendNotifications', 'update
 
 In this case, `every` returns array of `jobs`.
 
-### schedule(when, name, [data], [cb])
+### schedule(when, name, [data])
 
 Schedules a job to run `name` once at a given time. `when` can be a `Date` or a
 `String` such as `tomorrow at 5pm`.
 
 `data` is an optional argument that will be passed to the processing function
 under `job.attrs.data`.
-
-`cb` is an optional callback function which will be called when the job has been
-persisted in the database.
 
 Returns the `job`.
 
@@ -455,15 +448,12 @@ agenda.schedule('tomorrow at noon', ['printAnalyticsReport', 'sendNotifications'
 
 In this case, `schedule` returns array of `jobs`.
 
-### now(name, [data], [cb])
+### now(name, [data])
 
 Schedules a job to run `name` once immediately.
 
 `data` is an optional argument that will be passed to the processing function
 under `job.attrs.data`.
-
-`cb` is an optional callback function which will be called when the job has been
-persisted in the database.
 
 Returns the `job`.
 

--- a/lib/agenda/now.js
+++ b/lib/agenda/now.js
@@ -8,8 +8,7 @@ const noCallback = require('../no-callback');
  * @function
  * @param {String} name name of job to schedule
  * @param {Object} data data to pass to job
- * @param {Function} cb called when job scheduling fails or passes
- * @returns {Job} new job instance created
+ * @returns {Promise<Job>} new job instance created
  */
 module.exports = async function(name, data) {
   // eslint-disable-next-line prefer-rest-params


### PR DESCRIPTION
This PR removes all unsupported "cb" params in `agenda.every()`, `agenda.now()` and `agenda.schedule()`.
There are #752 and #831 but they are incomplete. This should be an alternative to both of them.