### PR TITLE
Add new attribute 'result' to job to record the job's execution result

### DIFF
--- a/lib/job/run.js
+++ b/lib/job/run.js
@@ -18,11 +18,15 @@ module.exports = function() {
     self.computeNextRunAt();
     await self.save();
 
-    const jobCallback = async err => {
+    const jobCallback = async (err, result) => {
       if (err) {
         self.fail(err);
       } else {
         self.attrs.lastFinishedAt = new Date();
+      }
+
+      if (result) {
+        self.attrs.result = result;
       }
 
       self.attrs.lockedAt = null;


### PR DESCRIPTION
A new attribute to handle job's results that maybe could be helpful to debug or to collect relevant information.