### PR TITLE
Fixed ESLint erros and warnings

### DIFF
--- a/lib/agenda/has-mongo-protocol.js
+++ b/lib/agenda/has-mongo-protocol.js
@@ -1,8 +1,8 @@
 'use strict';
 /**
  * Given a mongo connection url will check if it contains the mongo
- * @param url
- * @returns {boolean}
+ * @param {string} url URL to be tested
+ * @returns {boolean} whether or not the url is a valid mongo URL
  */
 module.exports = function(url) {
   return url.match(/mongodb(?:\+srv)?:\/\/.*/) !== null;

--- a/lib/agenda/save-job.js
+++ b/lib/agenda/save-job.js
@@ -5,7 +5,7 @@ const {processJobs} = require('../utils');
 /**
  * Given a result for findOneAndUpdate() or insert() above, determine whether to process
  * the job immediately or to let the processJobs() interval pick it up later
- * @param {Error} err error passed in via MongoDB call as to whether modify call failed or passed
+ * @param {Job} job job instance
  * @param {*} result the data returned from the findOneAndUpdate() call or insertOne() call
  * @access private
  * @returns {undefined}

--- a/lib/agenda/start.js
+++ b/lib/agenda/start.js
@@ -7,7 +7,7 @@ const {processJobs} = require('../utils');
  * This method will only resolve if a db has been set up beforehand.
  * @name Agenda#start
  * @function
- * @returns {Promise}
+ * @returns {Promise} resolves if db set beforehand, returns undefined otherwise
  */
 module.exports = async function() {
   if (this._processInterval) {

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -3,9 +3,9 @@
 const expect = require('expect.js');
 const {MongoClient} = require('mongodb');
 const delay = require('delay');
-const Agenda = require('..');
 const Job = require('../lib/job');
 const hasMongoProtocol = require('../lib/agenda/has-mongo-protocol');
+const Agenda = require('..');
 
 const mongoHost = process.env.MONGODB_HOST || 'localhost';
 const mongoPort = process.env.MONGODB_PORT || '27017';

--- a/test/job.js
+++ b/test/job.js
@@ -8,8 +8,8 @@ const {MongoClient} = require('mongodb');
 const Q = require('q');
 const delay = require('delay');
 const sinon = require('sinon');
-const Agenda = require('..');
 const Job = require('../lib/job');
+const Agenda = require('..');
 
 const mongoHost = process.env.MONGODB_HOST || 'localhost';
 const mongoPort = process.env.MONGODB_PORT || '27017';


### PR DESCRIPTION
Fix for issue #846
When linting project with `npm run lint` JSDoc warnings and import order errors are thrown.
Here I add descriptions to some JSDoc params, remove description of non-existing params and changer import order to what JSLint requested.