### PR TITLE
Fixed skipImmediate option in .every

### DIFF
--- a/lib/agenda/every.js
+++ b/lib/agenda/every.js
@@ -25,7 +25,6 @@ module.exports = async function(interval, names, data, options) {
 
     job.attrs.type = 'single';
     job.repeatEvery(interval, options);
-    job.computeNextRunAt();
     await job.save();
 
     return job;

--- a/lib/job/repeat-every.js
+++ b/lib/job/repeat-every.js
@@ -16,6 +16,8 @@ module.exports = function(interval, options) {
     this.attrs.lastRunAt = new Date();
     this.computeNextRunAt();
     this.attrs.lastRunAt = undefined;
+  } else {
+    this.computeNextRunAt();
   }
   return this;
 };

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -248,6 +248,22 @@ describe('Agenda', () => {
           const res = await jobs.jobs({name: 'shouldBeSingleJob'});
           expect(res).to.have.length(1);
         });
+        it('should not run immediately if options.skipImmediate is true', async() => {
+          const jobName = 'send email';
+          await jobs.every('5 minutes', jobName, {}, {skipImmediate: true});
+          const job = (await jobs.jobs({name: jobName}))[0];
+          const nextRunAt = job.attrs.nextRunAt.getTime();
+          const now = new Date().getTime();
+          expect((nextRunAt - now) > 0).to.equal(true);
+        });
+        it('should run immediately if options.skipImmediate is false', async() => {
+          const jobName = 'send email';
+          await jobs.every('5 minutes', jobName, {}, {skipImmediate: false});
+          const job = (await jobs.jobs({name: jobName}))[0];
+          const nextRunAt = job.attrs.nextRunAt.getTime();
+          const now = new Date().getTime();
+          expect((nextRunAt - now) <= 0).to.equal(true);
+        });
       });
       describe('with array of names specified', () => {
         it('returns array of jobs', async() => {


### PR DESCRIPTION
Fixes #610 

The problem was that `.every` indirectly makes two calls to `computeNextRunAt`. Here is what was happening:

1. `.every()` calls `.repeatEvery()`
2. `.repeatEvery()` sets `lastRunAt` to now
3. `.repeatEvery()` calls `.computeNextRunAt()` resulting in `nextRunAt` being now + interval.
4. `.repeatEvery()` resets `lastRunAt` to `undefined`
5. `.every()` then immediately calls `.computeNextRunAt()` with `lastRunAt === undefined` resulting in `nextRunAt` being set to now (without the interval)

I changed `.repeatEvery()` to call `.computeNextRunAt()` exactly once whether `skipImmediate` is true or not and removed the call from `.every()` altogether.