### PR TITLE
Check that the new nextRunAt is different that the previous nextRunAt…

### DIFF
--- a/lib/job/compute-next-run-at.js
+++ b/lib/job/compute-next-run-at.js
@@ -15,6 +15,7 @@ module.exports = function() {
   const interval = this.attrs.repeatInterval;
   const timezone = this.attrs.repeatTimezone;
   const {repeatAt} = this.attrs;
+  const previousNextRunAt = this.attrs.nextRunAt || new Date();
   this.attrs.nextRunAt = undefined;
 
   const dateForTimezone = date => {
@@ -37,7 +38,7 @@ module.exports = function() {
     try {
       const cronTime = new CronTime(interval);
       let nextDate = cronTime._getNextDateFrom(lastRun);
-      if (nextDate.valueOf() === lastRun.valueOf()) {
+      if (nextDate.valueOf() === lastRun.valueOf() || nextDate.valueOf() <= previousNextRunAt.valueOf()) {
         // Handle cronTime giving back the same date for the next run time
         nextDate = cronTime._getNextDateFrom(dateForTimezone(new Date(lastRun.valueOf() + 1000)));
       }

--- a/test/job.js
+++ b/test/job.js
@@ -223,6 +223,22 @@ describe('Job', () => {
       expect(moment(job.attrs.nextRunAt).toDate().getDate()).to.be(moment(job.attrs.lastRunAt).add(1, 'days').toDate().getDate());
     });
 
+    it('gives the correct nextDate when the lastRun is 1ms before the expected time', () => {
+      // (Issue #858): lastRunAt being 1ms before the nextRunAt makes cronTime return the same nextRunAt
+      const last = new Date();
+      last.setSeconds(59);
+      last.setMilliseconds(999);
+      const next = new Date(last.valueOf() + 1);
+      const expectedDate = new Date(next.valueOf() + 60000);
+      job.attrs.lastRunAt = last;
+      job.attrs.nextRunAt = next;
+      job.repeatEvery('* * * * *', {
+        timezone: 'GMT'
+      });
+      job.computeNextRunAt();
+      expect(job.attrs.nextRunAt.valueOf()).to.be(expectedDate.valueOf());
+    });
+
     describe('when repeat at time is invalid', () => {
       beforeEach(() => {
         job.attrs.repeatAt = 'foo';


### PR DESCRIPTION
Fixing the issue with (#858)
When the lastJobAt is before the nextRunAt, the cronTab gives a nextRunAt at the same value as the previous one, making it run twice for the same period.

Ex.: In this case, it ran twice for the 13:25 timeframe.

`Starting job (lastRunAt):  2019-10-04T13:24:00.001Z (nextRunAt):  2019-10-04T13:25:00.000Z`
`Starting job (lastRunAt):  2019-10-04T13:24:59.999Z (nextRunAt):  2019-10-04T13:25:00.000Z`
`Starting job (lastRunAt):  2019-10-04T13:25:00.070Z (nextRunAt):  2019-10-04T13:26:00.000Z`
`Starting job (lastRunAt):  2019-10-04T13:26:00.003Z (nextRunAt):  2019-10-04T13:27:00.000Z`

Added an extra condition where the cronTime was validated to also make sure it's not the same as the previous nextRunAt.