### PR TITLE
Update documentation for `Agenda#now`

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ Schedules a job to run `name` once immediately.
 `data` is an optional argument that will be passed to the processing function
 under `job.attrs.data`.
 
-Returns the `job`.
+Saves the job instance and returns a promise which resolves with the `job`.
 
 ```js
 agenda.now('do the hokey pokey');
@@ -978,11 +978,17 @@ let app = express(),
 
 app.post('/users', (req, res, next) => {
   const user = new User(req.body);
-  user.save(err => {
+  user.save(async err => {
     if (err) {
       return next(err);
     }
-    agenda.now('registration email', {userId: user.primary()});
+    
+    try {
+      await agenda.now('registration email', {userId: user.primary()});
+    } catch (err) {
+      return next(err);
+    }
+    
     res.send(201, user.toJson());
   });
 });

--- a/README.md
+++ b/README.md
@@ -473,10 +473,10 @@ Schedules a job to run `name` once immediately.
 `data` is an optional argument that will be passed to the processing function
 under `job.attrs.data`.
 
-Saves the job instance and returns a promise which resolves with the `job`.
+Returns a promise which resolves with the created job or rejects with an error.
 
 ```js
-agenda.now('do the hokey pokey');
+const job = await agenda.now('do the hokey pokey');
 ```
 
 ### create(jobName, data)
@@ -656,7 +656,7 @@ the following:
 - `insertOnly`: `boolean` will prevent any properties from persisting if the job already exists. Defaults to false.
 
 ```js
-job.unique({'data.type': 'active', 'data.userId': '123', nextRunAt(date)});
+job.unique({'data.type': 'active', 'data.userId': '123'});
 await job.save();
 ```
 

--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ the following:
 - `insertOnly`: `boolean` will prevent any properties from persisting if the job already exists. Defaults to false.
 
 ```js
-job.unique({'data.type': 'active', 'data.userId': '123'});
+job.unique({'data.type': 'active', 'data.userId': '123', nextRunAt(date)});
 await job.save();
 ```
 


### PR DESCRIPTION
[`Agenda#now`](https://github.com/agenda/agenda/blob/master/lib/agenda/now.js) doesn't appear to return the job (for chaining). Unlike other scheduling methods, `now` immediately saves the job.