### PR TITLE
fix: Add try/catch block to agenda#now method

### DIFF
--- a/lib/agenda/now.js
+++ b/lib/agenda/now.js
@@ -8,16 +8,21 @@ const noCallback = require('../no-callback');
  * @function
  * @param {String} name name of job to schedule
  * @param {Object} data data to pass to job
- * @returns {Job} new job instance created
+ * @returns {Promise} resolves with the new job instance created
  */
 module.exports = async function(name, data) {
-  // eslint-disable-next-line prefer-rest-params
-  noCallback(arguments, 2);
   debug('Agenda.now(%s, [Object])', name);
-  const job = this.create(name, data);
+  try {
+    // eslint-disable-next-line prefer-rest-params
+    noCallback(arguments, 2);
+    const job = this.create(name, data);
 
-  job.schedule(new Date());
-  await job.save();
+    job.schedule(new Date());
+    await job.save();
 
-  return job;
+    return job;
+  } catch (err) {
+    debug('error trying to create a job for this exact moment');
+    throw err;
+  }
 };


### PR DESCRIPTION
- Enclose agenda#now with try catch as it is an async method
- throw error in case of an error in creating/saving the job.
- Supplements documentation changes mentioned in #874 