### PR TITLE
Remove duplicated call to jobProcessing

### DIFF
--- a/lib/utils/process-jobs.js
+++ b/lib/utils/process-jobs.js
@@ -209,13 +209,13 @@ module.exports = function(extraJob) {
 
     // If the 'nextRunAt' time is older than the current time, run the job
     // Otherwise, setTimeout that gets called at the time of 'nextRunAt'
-    if (job.attrs.nextRunAt < now) {
+    if (job.attrs.nextRunAt <= now) {
       debug('[%s:%s] nextRunAt is in the past, run the job immediately', job.attrs.name, job.attrs._id);
       runOrRetry();
     } else {
       const runIn = job.attrs.nextRunAt - now;
       debug('[%s:%s] nextRunAt is in the future, calling setTimeout(%d)', job.attrs.name, job.attrs._id, runIn);
-      setTimeout(runOrRetry, runIn);
+      setTimeout(jobProcessing, runIn);
     }
 
     /**

--- a/lib/utils/process-jobs.js
+++ b/lib/utils/process-jobs.js
@@ -251,9 +251,6 @@ module.exports = function(extraJob) {
           job.run()
             .catch(error => [error, job])
             .then(job => processJobResult(...Array.isArray(job) ? job : [null, job])); // eslint-disable-line promise/prefer-await-to-then
-
-          // Re-run the loop to check for more jobs to process (locally)
-          jobProcessing();
         } else {
           // Run the job immediately by putting it on the top of the queue
           debug('[%s:%s] concurrency preventing immediate run, pushing job to top of queue', job.attrs.name, job.attrs._id);


### PR DESCRIPTION
Job processing is called from `processJobResult`, so calling it directly in `runOrRetry` is unnecessary. If executed job is short-lived, it leads to two `jobProcessing` calls occuring at almost the same time, and if there is another job it a queue waiting to be scheduled it will be scheduled twice (see the call to `runOrRetry` with `setTimeout` on line 217). On the second run the queue will be empty, which leads to `UnhandledPromiseRejectionWarning`. Error is thrown on line 228, because `jobQueue.pop()` returns undefined when queue is empty.

Script to help reproduce the issue:
```javascript
const Agenda = require("agenda");
const agenda = new Agenda({ db: { address: "<mongo_url>", collection: "ag_test" }});

agenda.define("j1", (job, done) => {
    console.log(Date.now(), 'j1');
    done();
});

agenda.define("j2", (job, done) => {
    console.log(Date.now(), 'j2');
    done();
});


(async function() {
    await agenda.start();
    await agenda.every("5 seconds", "j1");
    await agenda.every("10 seconds", "j2");
})();
```

Example output:
```
node test.js
(node:17695) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.
1575304118915 'j2'
1575304119055 'j1'
1575304123786 'j1'
(node:17695) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'attrs' of undefined
    at Timeout.runOrRetry [as _onTimeout] (/Users/*/Code/agenda/lib/utils/process-jobs.js:228:47)
    at ontimeout (timers.js:436:11)
    at tryOnTimeout (timers.js:300:5)
    at listOnTimeout (timers.js:263:5)
    at Timer.processTimers (timers.js:223:10)
(node:17695) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:17695) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```