### PR TITLE
Fix periodic node.js process unhandledRejection

### DIFF
--- a/lib/utils/process-jobs.js
+++ b/lib/utils/process-jobs.js
@@ -209,13 +209,13 @@ module.exports = function(extraJob) {
 
     // If the 'nextRunAt' time is older than the current time, run the job
     // Otherwise, setTimeout that gets called at the time of 'nextRunAt'
-    if (job.attrs.nextRunAt < now) {
+    if (job.attrs.nextRunAt <= now) {
       debug('[%s:%s] nextRunAt is in the past, run the job immediately', job.attrs.name, job.attrs._id);
       runOrRetry();
     } else {
       const runIn = job.attrs.nextRunAt - now;
       debug('[%s:%s] nextRunAt is in the future, calling setTimeout(%d)', job.attrs.name, job.attrs._id, runIn);
-      setTimeout(runOrRetry, runIn);
+      setTimeout(jobProcessing, runIn);
     }
 
     /**
@@ -251,9 +251,6 @@ module.exports = function(extraJob) {
           job.run()
             .catch(error => [error, job])
             .then(job => processJobResult(...Array.isArray(job) ? job : [null, job])); // eslint-disable-line promise/prefer-await-to-then
-
-          // Re-run the loop to check for more jobs to process (locally)
-          jobProcessing();
         } else {
           // Run the job immediately by putting it on the top of the queue
           debug('[%s:%s] concurrency preventing immediate run, pushing job to top of queue', job.attrs.name, job.attrs._id);

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -26,7 +26,7 @@ const jobTimeout = process.env.TRAVIS ? 2500 : 500;
 const jobType = 'do work';
 const jobProcessor = () => {};
 
-describe('Agenda', () => {
+describe('Agenda', function() {
   beforeEach(() => {
     // @TODO: this lint issue should be looked into: https://eslint.org/docs/rules/no-async-promise-executor
     // eslint-disable-next-line no-async-promise-executor
@@ -566,6 +566,40 @@ describe('Agenda', () => {
       expect(job1.attrs.data).to.be(3);
       expect(job2.attrs.data).to.be(2);
       expect(job3.attrs.data).to.be(1);
+    });
+  });
+
+  describe("process jobs", function() {
+    it("should not process twice", async function() {
+      this.timeout(10000);
+
+      let unhandledRejections = [];
+      const rejectionsHandler = error => unhandledRejections.push(error);
+      process.on('unhandledRejection', rejectionsHandler);
+
+      let j1processes = 0;
+      jobs.define("j1", (job, done) => {
+        j1processes += 1;
+        done();
+      });
+
+      let j2processes = 0;
+      jobs.define("j2", (job, done) => {
+        j2processes += 1;
+        done();
+      });
+
+      await jobs.start();
+      await jobs.every("5 seconds", "j1");
+      await jobs.every("10 seconds", "j2");
+
+      await delay(6000);
+      process.removeListener('unhandledRejection', rejectionsHandler);
+
+      expect(j1processes).to.equal(2);
+      expect(j2processes).to.equal(1);
+
+      expect(unhandledRejections).to.have.length(0);
     });
   });
 });

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -26,7 +26,7 @@ const jobTimeout = process.env.TRAVIS ? 2500 : 500;
 const jobType = 'do work';
 const jobProcessor = () => {};
 
-describe('Agenda', function() {
+describe('Agenda', function() { // eslint-disable-line prefer-arrow-callback
   beforeEach(() => {
     // @TODO: this lint issue should be looked into: https://eslint.org/docs/rules/no-async-promise-executor
     // eslint-disable-next-line no-async-promise-executor
@@ -569,29 +569,32 @@ describe('Agenda', function() {
     });
   });
 
-  describe("process jobs", function() {
-    it("should not process twice", async function() {
+  describe('process jobs', function() { // eslint-disable-line prefer-arrow-callback
+    it('should not cause unhandledRejection', async function() {
+      // This unit tests if for this bug [https://github.com/agenda/agenda/issues/884]
+      // which is not reproducible with default agenda config on shorter processEvery.
+      // Thus we set the test timeout to 10000, and the delay below to 6000.
       this.timeout(10000);
 
-      let unhandledRejections = [];
+      const unhandledRejections = [];
       const rejectionsHandler = error => unhandledRejections.push(error);
       process.on('unhandledRejection', rejectionsHandler);
 
       let j1processes = 0;
-      jobs.define("j1", (job, done) => {
+      jobs.define('j1', (job, done) => {
         j1processes += 1;
         done();
       });
 
       let j2processes = 0;
-      jobs.define("j2", (job, done) => {
+      jobs.define('j2', (job, done) => {
         j2processes += 1;
         done();
       });
 
       await jobs.start();
-      await jobs.every("5 seconds", "j1");
-      await jobs.every("10 seconds", "j2");
+      await jobs.every('5 seconds', 'j1');
+      await jobs.every('10 seconds', 'j2');
 
       await delay(6000);
       process.removeListener('unhandledRejection', rejectionsHandler);


### PR DESCRIPTION
This PR is a clone of @Scorpil work in #886 , I just added a unit test.
My servers are currently crashing because of this bug. Please, process the PR asap.
Below is the copy-pasta from #886

======

Job processing is called from `processJobResult`, so calling it directly in `runOrRetry` is unnecessary. If executed job is short-lived, it leads to two `jobProcessing` calls occuring at almost the same time, and if there is another job it a queue waiting to be scheduled it will be scheduled twice (see the call to `runOrRetry` with `setTimeout` on line 217). On the second run the queue will be empty, which leads to `UnhandledPromiseRejectionWarning`. Error is thrown on line 228, because `jobQueue.pop()` returns undefined when queue is empty.

Script to help reproduce the issue:
```javascript
const Agenda = require("agenda");
const agenda = new Agenda({ db: { address: "<mongo_url>", collection: "ag_test" }});

agenda.define("j1", (job, done) => {
    console.log(Date.now(), 'j1');
    done();
});

agenda.define("j2", (job, done) => {
    console.log(Date.now(), 'j2');
    done();
});


(async function() {
    await agenda.start();
    await agenda.every("5 seconds", "j1");
    await agenda.every("10 seconds", "j2");
})();
```

Example output:
```
node test.js
(node:17695) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.
1575304118915 'j2'
1575304119055 'j1'
1575304123786 'j1'
(node:17695) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'attrs' of undefined
    at Timeout.runOrRetry [as _onTimeout] (/Users/*/Code/agenda/lib/utils/process-jobs.js:228:47)
    at ontimeout (timers.js:436:11)
    at tryOnTimeout (timers.js:300:5)
    at listOnTimeout (timers.js:263:5)
    at Timer.processTimers (timers.js:223:10)
(node:17695) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:17695) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```