### PR TITLE
Fix job queue issues

### DIFF
--- a/lib/agenda/job-processing-queue.js
+++ b/lib/agenda/job-processing-queue.js
@@ -61,7 +61,7 @@ JobProcessingQueue.prototype.insert = function(job) {
 };
 
 /**
- * Returns (does not pop, element remains in queue) first element (always from the right)
+ * Returns first element (always from the right)
  * that can be processed (not blocked by concurrency execution)
  * @param {Object} agendaDefinitions job to add to queue
  * @returns {Job} Next Job to be processed
@@ -75,7 +75,7 @@ JobProcessingQueue.prototype.returnNextConcurrencyFreeJob = function(agendaDefin
     }
   }
 
-  return this._queue[next];
+  return this._queue.splice(next, 1)[0];
 };
 
 module.exports = JobProcessingQueue;

--- a/lib/utils/process-jobs.js
+++ b/lib/utils/process-jobs.js
@@ -204,6 +204,7 @@ module.exports = function(extraJob) {
 
     // Get the next job that is not blocked by concurrency
     const job = jobQueue.returnNextConcurrencyFreeJob(definitions);
+    const jobDefinition = definitions[job.attrs.name];
 
     debug('[%s:%s] about to process job', job.attrs.name, job.attrs._id);
 
@@ -224,8 +225,6 @@ module.exports = function(extraJob) {
      */
     async function runOrRetry() {
       if (self._processInterval) {
-        const job = jobQueue.pop();
-        const jobDefinition = definitions[job.attrs.name];
         if (jobDefinition.concurrency > jobDefinition.running && self._runningJobs.length < self._maxConcurrency) {
           // Get the deadline of when the job is not supposed to go past for locking
           const lockDeadline = new Date(Date.now() - jobDefinition.lockLifetime);
@@ -233,6 +232,7 @@ module.exports = function(extraJob) {
           // This means a job has "expired", as in it has not been "touched" within the lockoutTime
           // Remove from local lock
           // NOTE: Shouldn't we update the 'lockedAt' value in MongoDB so it can be picked up on restart?
+          // No, locked jobs can be locked again if they passed lockDeadLine, check the query in findAndLockNextJob
           if (job.attrs.lockedAt < lockDeadline) {
             debug('[%s:%s] job lock has expired, freeing it up', job.attrs.name, job.attrs._id);
             self._lockedJobs.splice(self._lockedJobs.indexOf(job), 1);
@@ -253,6 +253,7 @@ module.exports = function(extraJob) {
             .then(job => processJobResult(...Array.isArray(job) ? job : [null, job])); // eslint-disable-line promise/prefer-await-to-then
 
           // Re-run the loop to check for more jobs to process (locally)
+          // NOTE: Without jobProcessing after each run of a job, jobs in the jobQueue might be delayed to run
           jobProcessing();
         } else {
           // Run the job immediately by putting it on the top of the queue

--- a/lib/utils/process-jobs.js
+++ b/lib/utils/process-jobs.js
@@ -209,13 +209,13 @@ module.exports = function(extraJob) {
 
     // If the 'nextRunAt' time is older than the current time, run the job
     // Otherwise, setTimeout that gets called at the time of 'nextRunAt'
-    if (job.attrs.nextRunAt <= now) {
+    if (job.attrs.nextRunAt < now) {
       debug('[%s:%s] nextRunAt is in the past, run the job immediately', job.attrs.name, job.attrs._id);
       runOrRetry();
     } else {
       const runIn = job.attrs.nextRunAt - now;
       debug('[%s:%s] nextRunAt is in the future, calling setTimeout(%d)', job.attrs.name, job.attrs._id, runIn);
-      setTimeout(jobProcessing, runIn);
+      setTimeout(runOrRetry, runIn);
     }
 
     /**
@@ -251,6 +251,9 @@ module.exports = function(extraJob) {
           job.run()
             .catch(error => [error, job])
             .then(job => processJobResult(...Array.isArray(job) ? job : [null, job])); // eslint-disable-line promise/prefer-await-to-then
+
+          // Re-run the loop to check for more jobs to process (locally)
+          jobProcessing();
         } else {
           // Run the job immediately by putting it on the top of the queue
           debug('[%s:%s] concurrency preventing immediate run, pushing job to top of queue', job.attrs.name, job.attrs._id);


### PR DESCRIPTION
This PR is related to https://github.com/agenda/agenda/pull/887
We cannot solve one problem and create another.

>>> "Job processing is called from processJobResult, so calling it directly in runOrRetry is unnecessary."

It's necessary because without `jobProcessing` after each run of a job, jobs in the jobQueue might not be able to run on time. `jobProcessing` isn't always called within `processJobResult`, check the first line of the function. 

My fix to the issue "unhandledRejection" is to revert the code to the old version of Agenda. We should not pop job in `runOrRertry` function, because it makes `returnNextConcurrencyFreeJob` pointless, the "conconrrent free" jobs will never be used. The reason that `runOrRetry` is an internal function in `jobProcessing` is because it wants to use the job in the lexical scope.

Will add examples later.