### PR TITLE
Fix wrong path in DOCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,7 +950,7 @@ const agenda = new Agenda(connectionOpts);
 const jobTypes = process.env.JOB_TYPES ? process.env.JOB_TYPES.split(',') : [];
 
 jobTypes.forEach(type => {
-  require('./lib/jobs/' + type)(agenda);
+  require('./jobs/' + type)(agenda);
 });
 
 if (jobTypes.length) {


### PR DESCRIPTION
Hi, 
The `agenda.js` file and `jobs` folder are in `lib` folder.
So, I fixed wrong path(`./lib/jobs` -> `./jobs`) in README.