### PR TITLE
Fixed leftover from Kue

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Agenda is great if you need something that is simple and backed by MongoDB.
 | Persistence     | ✓             |  ✓  |   ✓    |
 | UI              | ✓             |     |   ✓    |
 | REST API        |               |     |   ✓    |
-| Optimized for   | Jobs / Messages | Jobs | Messages | Jobs |
+| Optimized for   | Jobs / Messages | Messages | Jobs |
 
 _Kudos for making the comparison chart goes to [Bull](https://www.npmjs.com/package/bull#feature-comparison) maintainers._
 


### PR DESCRIPTION
Fixed leftover column from Kue, resulted in an incorrect table.
Introduced in PR https://github.com/agenda/agenda/pull/851

This makes the feature comparison in sync with the one from Bull.