### PR TITLE
Drop Node.js 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 services: mongodb
 sudo: required
 node_js:
-  - 8
   - 10
   - 12
 addons:

--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@ Next
 ====
 
 * https://github.com/agenda/agenda/pulls
+* Stop testing for Node.js 8. This might still work but we're no longer actively testing for it.
 
 2.3.0 / 2019-12-16
 ==================

--- a/History.md
+++ b/History.md
@@ -2,7 +2,7 @@ Next
 ====
 
 * https://github.com/agenda/agenda/pulls
-* Stop testing for Node.js 8. This might still work but we're no longer actively testing for it.
+* Stop testing for Node.js 8. This might still work but we're no longer actively testing for it. ([#925](https://github.com/agenda/agenda/pull/925))
 
 2.3.0 / 2019-12-16
 ==================

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "test": "npm run lint && npm run mocha",


### PR DESCRIPTION
Drops Node.js 8 support. I mainly just wanted to update dependencies to the latest and at least `xo` (dev-dependency) isn't compatible with Node.js 8 anymore. 

The maintenance period for 8 has finished anyway so I think this is an ok move: https://nodejs.org/en/about/releases/