### PR TITLE
DeprecationWarnings: autoReconnect, reconnectTries, reconnectInterval

### DIFF
--- a/lib/agenda/database.js
+++ b/lib/agenda/database.js
@@ -26,7 +26,7 @@ module.exports = function(url, collection, options, cb) {
   }
 
   let reconnectOptions = {autoReconnect: true, reconnectTries: Number.MAX_SAFE_INTEGER, reconnectInterval: this._processEvery};
-  if (options && typeof options.useUnifiedTopology !== 'undefined' && options.useUnifiedTopology === true) {
+  if (options && options.useUnifiedTopology && options.useUnifiedTopology === true) {
     reconnectOptions = {};
   }
 

--- a/lib/agenda/database.js
+++ b/lib/agenda/database.js
@@ -25,8 +25,8 @@ module.exports = function(url, collection, options, cb) {
     url = 'mongodb://' + url;
   }
 
-  var reconnectOptions = {autoReconnect: true, reconnectTries: Number.MAX_SAFE_INTEGER, reconnectInterval: this._processEvery};
-  if(options && "undefined" !== typeof(options["useUnifiedTopology"]) && options["useUnifiedTopology"] === true){
+  let reconnectOptions = {autoReconnect: true, reconnectTries: Number.MAX_SAFE_INTEGER, reconnectInterval: this._processEvery};
+  if (options && typeof options.useUnifiedTopology !== 'undefined' && options.useUnifiedTopology === true) {
     reconnectOptions = {};
   }
 


### PR DESCRIPTION
I'm using the Docker Image mongo:3.6 and switched the "useUnifiedTopology" parameter to true as advised. If I do so I get the following deprecation warnings:

(node:51) DeprecationWarning: The option autoReconnect is incompatible with the unified topology, please read more by visiting http://bit.ly/2D8WfT6
(node:51) DeprecationWarning: The option reconnectTries is incompatible with the unified topology, please read more by visiting http://bit.ly/2D8WfT6
(node:51) DeprecationWarning: The option reconnectInterval is incompatible with the unified topology, please read more by visiting http://bit.ly/2D8WfT6

The fix checks if "useUnifiedTopology" is set and then doesn't use the deprecated options. If "useUnifiedTopology" isn't used, the options stay the same.