### PR TITLE
fix(tests): wrong initial value and lower processEvery for agenda-instance.js

### DIFF
--- a/test/fixtures/agenda-instance.js
+++ b/test/fixtures/agenda-instance.js
@@ -7,7 +7,8 @@ const tests = process.argv.slice(3);
 const agenda = new Agenda({
   db: {
     address: connStr
-  }
+  },
+  processEvery: 100
 }, async() => {
   tests.forEach(test => {
     addTests[test](agenda);

--- a/test/job.js
+++ b/test/job.js
@@ -1142,7 +1142,7 @@ describe('Job', () => {
         const n = cp.fork(serverPath, [mongoCfg, 'daily-array']);
 
         let ran1 = false;
-        let ran2 = true;
+        let ran2 = false;
         let doneCalled = false;
 
         const serviceError = function(e) {


### PR DESCRIPTION
- the initial value is probably just a type mistake that is there since the initial commit. 
- the second one is actually a side effect of another bug that it is working currently, but processEvery has a default value of 5 seconds, therefore only every 5 seconds it is checked if there are new jobs available. The tests itself wait just for 400ms before sending back that the job didn't run..which was not even possible, because agenda could easily be still waiting for 5 seconds to be passed.