### PR TITLE
Revert "fix: unlock job test needs cb"

### DIFF
--- a/test/job.js
+++ b/test/job.js
@@ -642,8 +642,8 @@ describe('Job', () => {
     });
 
     it('clears locks on stop', async() => {
-      agenda.define('longRunningJob', (job, cb) => { // eslint-disable-line no-unused-vars
-        // Job never finishes (the 2nd parameter is important, otherwise the job finishes immediately)
+      agenda.define('longRunningJob', job => { // eslint-disable-line no-unused-vars
+        // Job never finishes
       });
       agenda.every('10 seconds', 'longRunningJob');
       agenda.processEvery('1 second');


### PR DESCRIPTION
Reverts agenda/agenda#1138

This worked somehow on PR but now I'm seeing consistent failures on other rebased PRs for this test:

> does not on-the-fly lock more than agenda._lockLimit jobs

FYI @ simllll 