### PR TITLE
Use dist instead of lib and compile TS before publish

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-const Agenda = require('./lib/agenda');
+const Agenda = require('./dist');
 
 module.exports = Agenda;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-const Agenda = require('./dist');
+const { Agenda } = require('./dist/agenda');
 
 module.exports = Agenda;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agenda",
   "version": "4.0.0",
   "description": "Light weight job scheduler for Node.js",
-  "main": "dist/index.js",
+  "main": "index.js",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -2,14 +2,15 @@
   "name": "agenda",
   "version": "4.0.0",
   "description": "Light weight job scheduler for Node.js",
-  "main": "index.js",
+  "main": "dist/index.js",
   "files": [
-    "lib"
+    "dist"
   ],
   "engines": {
     "node": ">=10.0.0"
   },
   "scripts": {
+    "prepublishOnly": "npm run build",
     "build": "tsc",
     "pretest": "npm run build",
     "test": "npm run mocha",


### PR DESCRIPTION
An attempt to fix the build for NPM releases after TypeScript rewrite. (Rewrite PR was https://github.com/agenda/agenda/pull/1123)

Except that I still get `TypeError: Agenda is not a constructor`. 😞  I'm pretty novice with TypeScript so not entirely sure why that's happening.

Feel free to take the PR over!

Fixes https://github.com/agenda/agenda/issues/1191