### PR TITLE
Tests: clean out stray console log

### DIFF
--- a/test/agenda.js
+++ b/test/agenda.js
@@ -84,7 +84,6 @@ describe('Agenda', function() { // eslint-disable-line prefer-arrow-callback
           wee: 1
         });
         await job.save();
-        console.log(job);
         expect(job.attrs._id).not.to.be(undefined);
 
         // Close connection


### PR DESCRIPTION
I can't think of any reason why this was here? Lemme know if it was needed.