### PR TITLE
fix: export declarations

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,3 @@
 import { Agenda } from './agenda';
-export { Agenda }
+export { Agenda };
 export default Agenda;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,1 +1,3 @@
-export { Agenda } from './agenda';
+import { Agenda } from './agenda';
+export { Agenda }
+export default Agenda;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.1",
   "description": "Light weight job scheduler for Node.js",
   "main": "index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
@@ -66,7 +66,7 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
-    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    // "skipLibCheck": true,                     /* Skip type checking of declaration files. */
     "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
   }
 }


### PR DESCRIPTION
this would export the types for agenda and therefore give the whole typescript rewrite a legit reason :)

but unfortunately the types are not ready yet for production:
e.g. agenda.define is currently defined like this:
`export const define = function(this: Agenda, name: string, options: any, processor: () => void) {`
a lot of implementations are just like this:
`agenda.define('example', (job, done) => {`

the current type definition does not allow calling agenda.define with just two parameters, 1. options is any and 2. processor is a required additonal attribute. 

There is function overloading available in typescript, see for example in my fork: https://github.com/hokify/agenda/blob/master/src/index.ts#L275
which need to be implemented here too to get things working correctly. Unsure if function overloading is working though with the current file setup, as it requires that everything is part of a class. Right now all methods are split into separate files,.. could work, but haven't tested it. 

Anyways, I'll open this a draft, anyone is welcome to contribute if someone finds time to transfer the types from https://github.com/hokify/agenda to this one and figures out if function overloading works with the current setup? 

Thanks :)