### PR TITLE
Jsdoc: run on publish on right files

### DIFF
--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -4,7 +4,7 @@
         "dictionaries": ["jsdoc"]
     },
     "source": {
-        "include": ["lib", "package.json", "README.md"],
+        "include": ["dist", "package.json", "README.md"],
         "includePattern": ".js$",
         "excludePattern": "(node_modules/|docs)"
     },
@@ -18,6 +18,7 @@
         "destination": "./docs/",
         "encoding": "utf8",
         "recurse": true,
-        "template": "./node_modules/jsdoc-template"
+        "template": "./node_modules/jsdoc-template",
+        "tutorials": "https://github.com/agenda/agenda/tree/master/examples"
     }
 }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
     "mocha-debug": "DEBUG=agenda:**,-agenda:internal:** mocha --reporter spec --timeout 8000 -b",
     "mocha-debug-internal": "DEBUG=agenda:internal:** mocha --reporter spec --timeout 8000 -b",
     "mocha-debug-all": "DEBUG=agenda:** mocha --reporter spec --timeout 8000 -b",
+    "postversion": "npm run docs",
     "predocs": "npm run build",
-    "docs": "jsdoc --configure .jsdoc.json --verbose ./dist"
+    "docs": "jsdoc --configure .jsdoc.json --verbose"
   },
   "config": {
     "blanket": {


### PR DESCRIPTION
- Run jsdoc generation after running `npm publish`
- Run on `dist` since jsdoc doesn't understand TypeScript :-(

Feel free to take the PR over! Might not have headspace to continue on this.

Related to https://github.com/agenda/agenda/issues/1198