### PR TITLE
Check endDate and startDate are defined when calculating nextRunAt

### DIFF
--- a/lib/job/compute-next-run-at.ts
+++ b/lib/job/compute-next-run-at.ts
@@ -62,7 +62,7 @@ export const computeNextRunAt = function (this: Job) {
       }
 
       // If start date is present, check if the nextDate should be larger or equal to startDate. If not set startDate as nextDate
-      if (startDate !== null) {
+      if (startDate) {
         startDate = moment
           .tz(moment(startDate).format("YYYY-MM-DD"), timezone)
           .toDate();
@@ -83,7 +83,7 @@ export const computeNextRunAt = function (this: Job) {
       }
 
       // If endDate is less than the nextDate, set nextDate to null to stop the job from running further
-      if (endDate !== null) {
+      if (endDate) {
         const endDateDate: Date = moment
           .tz(moment(endDate).format("YYYY-MM-DD"), timezone)
           .toDate();

--- a/test/job.js
+++ b/test/job.js
@@ -355,6 +355,15 @@ describe("Job", () => {
         job.computeNextRunAt();
         expect(job.attrs.nextRunAt).to.be(undefined);
       });
+
+      it("sets the correct interval when endDate is undefined", () => {
+        // (Issue #1224): failed to calculate nextRunAt when endDate is undefined
+        job.repeatEvery("0 0 * * *"); // Daily at midnight
+        job.attrs.endDate = undefined;
+        job.computeNextRunAt();
+        expect(job.attrs.failCount).to.be(undefined);
+        expect(job.attrs.nextRunAt).not.to.be(undefined);
+      });
     });
 
     it("gives the correct nextDate when the lastRun is 1ms before the expected time", () => {


### PR DESCRIPTION
Fixing the issue with https://github.com/agenda/agenda/issues/1224
For backward compatibility check that endDate and startDate are defined when calculating `nextRunAt` value.
When upgrading from an older version of agenda those fields could be missing from the job and fail the computation of `nextRunAt` with 'failed to calculate nextRunAt due to an invalid repeat interval' exception.

![image](https://user-images.githubusercontent.com/17844958/106655999-c3433100-65a2-11eb-9830-709cc325b3b9.png)
