### PR TITLE
Add a tests to ensure stuck jobs are processed

### DIFF
--- a/test/find-and-lock-next-job.js
+++ b/test/find-and-lock-next-job.js
@@ -66,19 +66,55 @@ describe("find-and-lock-next-job", () => {
     await agenda._db.close();
   });
 
-  it("should find jobs with and without lockedAt property", async () => {
+  it("should find jobs without lockedAt property", async () => {
+    const collection = await mongoDb.collection("agendaJobs");
     const job = await agenda.create(jobType, {}).save();
     expect(job.attrs.lockedAt).to.equal(undefined);
     // The above line does not add `lockedAt` to DB. Nevertheless, let's delete it just in case.
-    const { lastErrorObject, value } = await mongoDb
-      .collection("agendaJobs")
-      .findOneAndUpdate({ name: jobType }, { $unset: { lockedAt: "" } }); // deleting the property
+    const { lastErrorObject } = await collection.findOneAndUpdate(
+      { name: jobType },
+      { $unset: { lockedAt: "" } }
+    ); // deleting the property
     expect(lastErrorObject.updatedExisting).to.equal(true);
-    expect(value.lockedAt).to.equal(undefined);
-    expect(value.nextRunAt.getTime()).to.be.lessThan(Date.now() + 1000);
+    const rawJob = await collection.findOne({ name: jobType });
+    expect(rawJob.lockedAt).to.equal(undefined);
+    expect(rawJob.nextRunAt.getTime()).to.be.lessThan(Date.now() + 1000);
 
     agenda.processEvery(100);
+    let processed = 0;
+    const successPromise = new Promise((resolve) => {
+      processed += 1;
+      agenda.on(`success:${jobType}`, resolve);
+    });
 
+    await agenda.start();
+    await successPromise;
+
+    expect(processed).to.equal(1);
+  });
+
+  it("should find and rerun stuck jobs (with long ago lockedAt property)", async () => {
+    const collection = await mongoDb.collection("agendaJobs");
+    const job = await agenda.create(jobType, {}).save();
+    expect(job.attrs.lockedAt).to.equal(undefined);
+    // The above line does not add `lockedAt` to DB. The below simulates a stuck job.
+    const { lastErrorObject } = await collection.findOneAndUpdate(
+      { name: jobType },
+      {
+        $unset: { nextRunAt: "" },
+        $set: {
+          lockedAt: new Date(Date.now() - agenda._defaultLockLifetime - 1000),
+        },
+      }
+    ); //
+    expect(lastErrorObject.updatedExisting).to.equal(true);
+    const rawJob = await collection.findOne({ name: jobType });
+    expect(rawJob.nextRunAt).to.equal(undefined);
+    expect(rawJob.lockedAt.getTime()).to.be.lessThan(
+      Date.now() - agenda._defaultLockLifetime
+    );
+
+    agenda.processEvery(100);
     let processed = 0;
     const successPromise = new Promise((resolve) => {
       processed += 1;

--- a/test/find-and-lock-next-job.js
+++ b/test/find-and-lock-next-job.js
@@ -1,0 +1,92 @@
+/* globals describe, it, beforeEach, afterEach */
+"use strict";
+const expect = require("expect.js");
+const delay = require("delay");
+const { MongoClient } = require("mongodb");
+const { Agenda } = require("../dist");
+
+const mongoHost = process.env.MONGODB_HOST || "localhost";
+const mongoPort = process.env.MONGODB_PORT || "27017";
+const agendaDatabase = "agenda-test";
+const mongoCfg =
+  "mongodb://" + mongoHost + ":" + mongoPort + "/" + agendaDatabase;
+
+// Create agenda instances
+let agenda = null;
+let mongoDb = null;
+let mongoClient = null;
+
+const clearJobs = () => {
+  return mongoDb.collection("agendaJobs").deleteMany({});
+};
+
+const jobType = "do work";
+const jobProcessor = () => {};
+
+describe("find-and-lock-next-job", () => {
+  beforeEach((done) => {
+    agenda = new Agenda(
+      {
+        db: {
+          address: mongoCfg,
+        },
+      },
+      (error) => {
+        if (error) {
+          done(error);
+        }
+
+        MongoClient.connect(
+          mongoCfg,
+          { useUnifiedTopology: true },
+          async (error, client) => {
+            mongoClient = client;
+            mongoDb = client.db(agendaDatabase);
+
+            await delay(50);
+            await clearJobs();
+
+            agenda.define("someJob", jobProcessor);
+            agenda.define("send email", jobProcessor);
+            agenda.define("some job", jobProcessor);
+            agenda.define(jobType, jobProcessor);
+
+            done();
+          }
+        );
+      }
+    );
+  });
+
+  afterEach(async () => {
+    await delay(50);
+    await agenda.stop();
+    await clearJobs();
+    await mongoClient.close();
+    await agenda._db.close();
+  });
+
+  it("should find jobs with and without lockedAt property", async () => {
+    const job = await agenda.create(jobType, {}).save();
+    expect(job.attrs.lockedAt).to.equal(undefined);
+    // The above line does not add `lockedAt` to DB. Nevertheless, let's delete it just in case.
+    const { lastErrorObject, value } = await mongoDb
+      .collection("agendaJobs")
+      .findOneAndUpdate({ name: jobType }, { $unset: { lockedAt: "" } }); // deleting the property
+    expect(lastErrorObject.updatedExisting).to.equal(true);
+    expect(value.lockedAt).to.equal(undefined);
+
+    agenda.processEvery(100);
+
+    let processed = 0;
+    const successPromise = new Promise((resolve) => {
+      processed += 1;
+      agenda.on(`success:${jobType}`, resolve);
+    });
+
+    await agenda.start();
+    await successPromise;
+
+    expect(processed).to.equal(1);
+  });
+});

--- a/test/find-and-lock-next-job.js
+++ b/test/find-and-lock-next-job.js
@@ -75,6 +75,7 @@ describe("find-and-lock-next-job", () => {
       .findOneAndUpdate({ name: jobType }, { $unset: { lockedAt: "" } }); // deleting the property
     expect(lastErrorObject.updatedExisting).to.equal(true);
     expect(value.lockedAt).to.equal(undefined);
+    expect(value.nextRunAt.getTime()).to.be.lessThan(Date.now() + 1000);
 
     agenda.processEvery(100);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+     "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */


### PR DESCRIPTION
This PR adds a unit test which ensures that jobs without `lockedAt` property are properly picked up for processing.
Also, stuck jobs (when `lockedAt` was long ago) are picked up for re-processing.