### PR TITLE
chore: emit type declarations

### DIFF
--- a/lib/agenda/define.ts
+++ b/lib/agenda/define.ts
@@ -13,9 +13,26 @@ export enum JobPriority {
 }
 
 export interface DefineOptions {
+  /**
+   * Maximum number of that job that can be running at once (per instance of agenda)
+   */
   concurrency?: number;
+
+  /**
+   * Maximum number of that job that can be locked at once (per instance of agenda)
+   */
   lockLimit?: number;
+
+  /**
+   * Interval in ms of how long the job stays locked for (see multiple job processors for more info). A job will
+   * automatically unlock if done() is called.
+   */
   lockLifetime?: number;
+
+  /**
+   * (lowest|low|normal|high|highest|number) specifies the priority of the job. Higher priority jobs will run
+   * first.
+   */
   priority?: JobPriority;
 }
 

--- a/lib/agenda/index.ts
+++ b/lib/agenda/index.ts
@@ -121,6 +121,11 @@ class Agenda extends EventEmitter {
   start!: typeof start;
   stop!: typeof stop;
 
+  /**
+   * Constructs a new Agenda object.
+   * @param config Optional configuration to initialize the Agenda.
+   * @param cb Optional callback called with the MongoDB collection.
+   */
   constructor(
     config: AgendaConfig = {},
     cb?: (error: Error, collection: Collection<any> | null) => void

--- a/lib/job/index.ts
+++ b/lib/job/index.ts
@@ -18,31 +18,103 @@ import { Agenda } from "../agenda";
 import { JobPriority } from "../agenda/define";
 import * as mongodb from "mongodb";
 
-export interface JobAttributes {
+export interface JobAttributesData {
+  [key: string]: any;
+}
+export interface JobAttributes<
+  T extends JobAttributesData = JobAttributesData
+> {
+  /**
+   * The record identity.
+   */
   _id?: mongodb.ObjectID;
+
   agenda: Agenda;
+
+  /**
+   * The type of the job (single|normal).
+   */
   type: string;
+
+  /**
+   * The name of the job.
+   */
   name: string;
+
+  /**
+   * Job's state
+   */
   disabled?: boolean;
+
+  /**
+   * Date/time the job will run next.
+   */
   nextRunAt?: Date | null;
+
+  /**
+   * Date/time the job was locked.
+   */
   lockedAt?: Date;
+
+  /**
+   * The priority of the job.
+   */
   priority: number | string;
-  data?: any;
+
+  /**
+   * The job details.
+   */
+  data?: T;
+
   unique?: any;
   uniqueOpts?: {
     insertOnly: boolean;
   };
+
+  /**
+   * How often the job is repeated using a human-readable or cron format.
+   */
   repeatInterval?: string;
+
+  /**
+   * The timezone that conforms to [moment-timezone](http://momentjs.com/timezone/).
+   */
   repeatTimezone?: string | null;
+
   repeatAt?: string;
+
+  /**
+   * Date/time the job was last run.
+   */
   lastRunAt?: Date;
+
+  /**
+   * Date/time the job last finished running.
+   */
   lastFinishedAt?: Date;
+
   startDate?: Date | number | null;
   endDate?: Date | number | null;
   skipDays?: string | null;
+
+  /**
+   * The reason the job failed.
+   */
   failReason?: string;
+
+  /**
+   * The number of times the job has failed.
+   */
   failCount?: number;
+
+  /**
+   * The date/time the job last failed.
+   */
   failedAt?: Date;
+
+  /**
+   * Date/time the job was last modified.
+   */
   lastModifiedBy?: string;
 }
 
@@ -52,9 +124,17 @@ export interface JobAttributes {
  * @property {Object} agenda - The Agenda instance
  * @property {Object} attrs
  */
-class Job {
+class Job<T extends JobAttributesData = JobAttributesData> {
+  /**
+   * The agenda that created the job.
+   */
   agenda: Agenda;
-  attrs: JobAttributes;
+
+  /**
+   * The database record associated with the job.
+   */
+  attrs: JobAttributes<T>;
+
   toJSON!: typeof toJson;
   computeNextRunAt!: typeof computeNextRunAt;
   repeatEvery!: typeof repeatEvery;
@@ -71,7 +151,7 @@ class Job {
   remove!: typeof remove;
   touch!: typeof touch;
 
-  constructor(options: JobAttributes) {
+  constructor(options: JobAttributes<T>) {
     const { agenda, type, nextRunAt, ...args } = options ?? {};
 
     // Save Agenda instance

--- a/lib/utils/create-job.ts
+++ b/lib/utils/create-job.ts
@@ -7,7 +7,7 @@ import { Job, JobAttributes } from "../job";
  * @param {Object} jobData job data
  * @returns {Job} returns created job
  */
-export const createJob = (agenda: Agenda, jobData: JobAttributes) => {
+export const createJob = (agenda: Agenda, jobData: JobAttributes): Job => {
   jobData.agenda = agenda;
   return new Job(jobData);
 };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.1",
   "description": "Light weight job scheduler for Node.js",
   "main": "index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,8 @@
     "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
      "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist",                        /* Redirect output structure to the directory. */


### PR DESCRIPTION
is there any particular reason this isn't being done yet? In my eyes big parts of the definitelyTyped-pkg are outdated, while we could easily bundle the types.