### PR TITLE
fix: make optional mongo-collection optional and allow dates for dates

### DIFF
--- a/lib/agenda/db-init.ts
+++ b/lib/agenda/db-init.ts
@@ -13,11 +13,11 @@ const debug = createDebugger("agenda:db_init");
  */
 export const dbInit = function (
   this: Agenda,
-  collection: string | undefined,
+  collection = "agendaJobs",
   cb?: (error: Error, collection: Collection<any> | null) => void
 ): void {
   debug("init database collection using name [%s]", collection);
-  this._collection = this._mdb.collection(collection || "agendaJobs"); // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing
+  this._collection = this._mdb.collection(collection);
   debug("attempting index creation");
   this._collection.createIndex(
     this._indices,

--- a/lib/agenda/every.ts
+++ b/lib/agenda/every.ts
@@ -19,8 +19,8 @@ export const every = async function (
   this: Agenda,
   interval: string,
   names: string | string[],
-  data: unknown,
-  options: JobOptions
+  data?: unknown,
+  options?: JobOptions
 ): Promise<any> {
   /**
    * Internal method to setup job that gets run every interval
@@ -33,8 +33,8 @@ export const every = async function (
   const createJob = async (
     interval: string,
     name: string,
-    data: unknown,
-    options: JobOptions
+    data?: unknown,
+    options?: JobOptions
   ): Promise<Job> => {
     const job = this.create(name, data);
 
@@ -54,8 +54,8 @@ export const every = async function (
   const createJobs = async (
     interval: string,
     names: string[],
-    data: unknown,
-    options: JobOptions
+    data?: unknown,
+    options?: JobOptions
   ): Promise<Job[] | undefined> => {
     try {
       const jobs: Array<Promise<Job>> = [];

--- a/lib/agenda/mongo.ts
+++ b/lib/agenda/mongo.ts
@@ -12,7 +12,7 @@ import { Agenda } from ".";
 export const mongo = function (
   this: Agenda,
   mdb: Db,
-  collection: string | undefined,
+  collection?: string,
   cb?: (error: Error, collection: Collection<any> | null) => void
 ): Agenda {
   this._mdb = mdb;

--- a/lib/agenda/schedule.ts
+++ b/lib/agenda/schedule.ts
@@ -15,7 +15,7 @@ const debug = createDebugger("agenda:schedule");
  */
 export const schedule = function (
   this: Agenda,
-  when: string,
+  when: string | Date,
   names: string[],
   data: any
 ): undefined | Promise<Job | Job[]> {
@@ -27,7 +27,7 @@ export const schedule = function (
    * @returns instance of new job
    */
   const createJob = async (
-    when: string,
+    when: string | Date,
     name: string,
     data: any
   ): Promise<Job> => {
@@ -46,7 +46,7 @@ export const schedule = function (
    * @returns jobs that were created
    */
   const createJobs = async (
-    when: string,
+    when: string | Date,
     names: string[],
     data: any
   ): Promise<Job[]> => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,8 @@
-export { Agenda, AgendaConfig } from "./agenda";
+export * from "./agenda";
+export * from "./job";
 
 export { DefineOptions, JobPriority, Processor } from "./agenda/define";
 export { JobOptions } from "./job/repeat-every";
+
+import { Agenda } from "./agenda";
+export default Agenda;


### PR DESCRIPTION
has been optional and kinda still is, only the types didn't reflect it. added some root level exports for compat. with the former types pkg