### PR TITLE
fix: typescript export needs es6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1079,8 +1079,8 @@ Please provide us with as much details as possible such as:
 
 #### To turn on logging, please set your DEBUG env variable like so:
 
-- OSX: `DEBUG="agenda:*" node index.js`
-- Linux: `DEBUG="agenda:*" node index.js`
+- OSX: `DEBUG="agenda:*" ts-node src/index.js`
+- Linux: `DEBUG="agenda:*" ts-node src/index.js`
 - Windows CMD: `set DEBUG=agenda:*`
 - Windows PowerShell: `$env:DEBUG = "agenda:*"`
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,0 @@
-const { Agenda } = require('./dist/agenda');
-
-module.exports = Agenda;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,4 +5,6 @@ export { DefineOptions, JobPriority, Processor } from "./agenda/define";
 export { JobOptions } from "./job/repeat-every";
 
 import { Agenda } from "./agenda";
+export { Agenda };
 export default Agenda;
+

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "agenda",
   "version": "4.1.0",
   "description": "Light weight job scheduler for Node.js",
-  "main": "index.js",
-  "types": "./dist/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "es2016",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     "allowJs": true,                       /* Allow javascript files to be compiled. */
@@ -66,7 +66,7 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
-    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    // "skipLibCheck": true,                     /* Skip type checking of declaration files. */
     "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
   }
 }


### PR DESCRIPTION
fixes https://github.com/agenda/agenda/issues/1267

There are two issues:
1.) there is only one default export, no named export. People are assuming a named export will work fine too. Which is not direclty a bug, but a nice to have ;)
2.) The export with es5 does not work correclty, as es5 is not aware of class exports. 
Test:

```ts
import { Agenda } from 'agenda';
console.log('AGENDA', Agenda);
```
```ts
import Agenda from 'agenda';
console.log('AGENDA', Agenda);
```
all should output: 
`AGENDA [class Agenda extends EventEmitter]
`
But with es5 they output:
`AGENDA [Function: Agenda]
`