### PR TITLE
fix: Typescript optional parameters

### DIFF
--- a/lib/agenda/close.ts
+++ b/lib/agenda/close.ts
@@ -8,8 +8,9 @@ const debug = createDebugger("agenda:close");
  * If the mongoDb instance was supplied during instantiation or via agenda.mongo, this function will do nothing and return agenda anyway.
  * @name Agenda#close
  * @function
- * @param option: { force: boolean } Force close, emitting no events
+ * @param [option]: { force: boolean } Force close, emitting no events
  *
+ * 
  * @caller client code
  *
  * @link https://mongodb.github.io/node-mongodb-native/2.0/api/Db.html#close

--- a/lib/agenda/database.ts
+++ b/lib/agenda/database.ts
@@ -10,9 +10,9 @@ const debug = createDebugger("agenda:database");
  * @name Agenda#database
  * @function
  * @param url MongoDB server URI
- * @param collection name of collection to use. Defaults to `agendaJobs`
- * @param options options for connecting
- * @param cb callback of MongoDB connection
+ * @param [collection] name of collection to use. Defaults to `agendaJobs`
+ * @param [options] options for connecting
+ * @param [cb] callback of MongoDB connection
  * NOTE:
  * If `url` includes auth details then `options` must specify: { 'uri_decode_auth': true }. This does Auth on
  * the specified database, not the Admin database. If you are using Auth on the Admin DB and not on the Agenda DB,

--- a/lib/agenda/db-init.ts
+++ b/lib/agenda/db-init.ts
@@ -9,7 +9,7 @@ const debug = createDebugger("agenda:db_init");
  * @name Agenda#dbInit
  * @function
  * @param collection name or undefined for default 'agendaJobs'
- * @param cb called when the db is initialized
+ * @param [cb] called when the db is initialized
  */
 export const dbInit = function (
   this: Agenda,

--- a/lib/agenda/define.ts
+++ b/lib/agenda/define.ts
@@ -47,7 +47,7 @@ export type Processor =
  * @function
  * @param name name of job
  * @param options options for job to run
- * @param processor function to be called to run actual job
+ * @param [processor] function to be called to run actual job
  */
 export const define = function (
   this: Agenda,

--- a/lib/agenda/every.ts
+++ b/lib/agenda/every.ts
@@ -26,8 +26,8 @@ export const every = async function (
    * Internal method to setup job that gets run every interval
    * @param interval run every X interval
    * @param name String job to schedule
-   * @param data data to run for job
-   * @param options options to run job for
+   * @param [data] data to run for job
+   * @param [options] options to run job for
    * @returns instance of job
    */
   const createJob = async (
@@ -47,8 +47,8 @@ export const every = async function (
    * Internal helper method that uses createJob to create jobs for an array of names
    * @param interval run every X interval
    * @param names Strings of jobs to schedule
-   * @param data data to run for job
-   * @param options options to run job for
+   * @param [data] data to run for job
+   * @param [options] options to run job for
    * @return array of jobs created
    */
   const createJobs = async (

--- a/lib/agenda/jobs.ts
+++ b/lib/agenda/jobs.ts
@@ -7,10 +7,10 @@ import { createJob } from "../utils";
  * Finds all jobs matching 'query'
  * @name Agenda#jobs
  * @function
- * @param query object for MongoDB
- * @param sort object for MongoDB
- * @param limit number of documents to return from MongoDB
- * @param number of documents to skip in MongoDB
+ * @param [query] object for MongoDB
+ * @param [sort] object for MongoDB
+ * @param [limit] number of documents to return from MongoDB
+ * @param [number] of documents to skip in MongoDB
  * @returns resolves when fails or passes
  */
 export const jobs = async function (

--- a/lib/agenda/mongo.ts
+++ b/lib/agenda/mongo.ts
@@ -6,8 +6,8 @@ import { Agenda } from ".";
  * @name Agenda#mongo
  * @function
  * @param mdb instance of MongoClient to use
- * @param collection name collection we want to use ('agendaJobs')
- * @param cb called when MongoDB connection fails or passes
+ * @param [collection] name collection we want to use ('agendaJobs')
+ * @param [cb] called when MongoDB connection fails or passes
  */
 export const mongo = function (
   this: Agenda,


### PR DESCRIPTION
Problem:

![image](https://user-images.githubusercontent.com/6287367/110943324-62461000-833b-11eb-92a2-7685321c0ac9.png)

Workaround:

```javascript
await agenda.every('10 minutes', 'some job', undefined, undefined);
```

What this MR will do:
- will fix optional parameters in type declarations

```javascript

// instead of this:
await agenda.every('10 minutes', 'some job', undefined, undefined);

// we will be able to do this:
await agenda.every('10 minutes', 'some job');
```
