### PR TITLE
Add Node.js v16 in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
         mongodb-version: [3.4, 3.6, 4.0, 4.2, 4.4]
     steps:
       - name: Git checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         mongodb-version: [3.4, 3.6, 4.0, 4.2, 4.4]
     steps:
       - name: Git checkout


### PR DESCRIPTION
Adds Node.js v16 into test rig.

Happy to keep v10 if anyone thinks it's still important. It's no longer maintained. Edit: we're keeping it.

https://nodejs.org/en/about/releases/

Meanwhile, let's start test for new LTS active.