### PR TITLE
Modifies JobAttributes.lockedAt to allow null values

### DIFF
--- a/lib/job/index.ts
+++ b/lib/job/index.ts
@@ -54,7 +54,7 @@ export interface JobAttributes<
   /**
    * Date/time the job was locked.
    */
-  lockedAt?: Date;
+  lockedAt?: Date | null;
 
   /**
    * The priority of the job.

--- a/lib/job/run.ts
+++ b/lib/job/run.ts
@@ -40,7 +40,7 @@ export const run = async function (this: Job): Promise<Job> {
         this.attrs.lastFinishedAt = new Date();
       }
 
-      this.attrs.lockedAt = undefined;
+      this.attrs.lockedAt = null;
 
       await this.save().catch((error: Error) => {
         debug(


### PR DESCRIPTION
Looks like there was a minor oversight in the recent TypeScript rewrite. Without this change, all of our jobs are constantly locked since `lockedAt` is never reset back to `null` again.