### PR TITLE
Fix define Processor typing

### DIFF
--- a/lib/agenda/define.ts
+++ b/lib/agenda/define.ts
@@ -36,9 +36,9 @@ export interface DefineOptions {
   priority?: JobPriority;
 }
 
-export type Processor =
-  | ((job: Job) => Promise<void>)
-  | ((job: Job, done: () => void) => void);
+export type Processor<T> =
+  | ((job: Job<T>) => Promise<void>)
+  | ((job: Job<T>, done: () => void) => void);
 
 /**
  * Setup definition for job
@@ -49,14 +49,14 @@ export type Processor =
  * @param options options for job to run
  * @param [processor] function to be called to run actual job
  */
-export const define = function (
+export const define = function<T> (
   this: Agenda,
   name: string,
-  options: DefineOptions | Processor,
-  processor?: Processor
+  options: DefineOptions | Processor<T>,
+  processor?: Processor<T>
 ): void {
   if (processor === undefined) {
-    processor = options as Processor;
+    processor = options as Processor<T>;
     options = {};
   }
 


### PR DESCRIPTION
Processor type used in define doesn't use generic typing.

If you try this:
```
import Agenda, { Job } from 'agenda'

const agenda = new Agenda()

const run = async function(job: Job<{test: string}>) {
  return Promise.resolve()
}

agenda.define('test', run)
```

It would raise the following typescript error :
```
Type '(job: Job<{ test: string; }>) => Promise<void>' is not assignable to type '(job: Job<JobAttributesData>) => Promise<void>'.
```

Job class use generic type but default to `JobAttributesData` if none is provided https://github.com/agix/agenda/blob/73184aaa8309e5e89e0cfab766b2cdd6d80e9605/lib/job/index.ts?plain=1#L127

Which is exactly the case in the current Processor definition : https://github.com/agenda/agenda/blob/master/lib/agenda/define.ts#L39-L41


