### PR TITLE
fix: _unlockJobs should return when it resolves

### DIFF
--- a/lib/agenda/stop.ts
+++ b/lib/agenda/stop.ts
@@ -23,7 +23,7 @@ export const stop = async function (this: Agenda): Promise<void> {
 
       if (jobIds.length === 0) {
         debug("no jobs to unlock");
-        resolve();
+        return resolve();
       }
 
       debug("about to unlock jobs with ids: %O", jobIds);


### PR DESCRIPTION
Calling `resolve` does not stop the function execution. This can lead to
the [updateMany](https://github.com/agenda/agenda/blob/master/lib/agenda/stop.ts#L30) call happening even though the promise has resolved
and the promise is no longer awaiting.

For instance in this code:

```
await agenda.stop()
await agenda.close()
```

We may find that we already closed the connection when the stop code is
still trying to reach the Mongo DB