### PR TITLE
[BUGFIX] Add check to ensure that `setTimeout` is not called with a value greater than MAX_SIGNED_INTEGER

### DIFF
--- a/lib/utils/process-jobs.ts
+++ b/lib/utils/process-jobs.ts
@@ -4,6 +4,7 @@ import { Job } from "../job";
 import { Agenda } from "../agenda";
 
 const debug = createDebugger("agenda:internal:processJobs");
+const MAX_SIGNED_INTEGER = Math.pow(2, 31) - 1;
 
 /**
  * Process methods for jobs
@@ -240,8 +241,6 @@ export const processJobs = async function (
       self._isJobQueueFilling.delete(name);
     }
   }
-
-  const MAX_SIGNED_INTEGER = Math.pow(2, 31) - 1;
 
   /**
    * Internal method that processes any jobs in the local queue (array)


### PR DESCRIPTION
## Summary
In my local dev environment I've occasionally run into a scenario where my console gets flooded with `TimeoutOverflowWarning`s. I eventually traced the problem back to agenda's `processJobs` logic which would set the timeout for re-processing a future job without checking the bounds of the timeout value.

![screen recording](https://user-images.githubusercontent.com/3218825/138183208-0264c809-4cda-4225-b72a-e68f43cc82e5.gif)

## Investigation
Unfortunately for us, the `setTimeout` method interprets values greather than `2e31-1` as a negative value, which is in turn interpreted as `1ms`, causing a tight loop which will continue until the differen between "now" and `nextRunAt` is less than MAX_SIGNED_INTEGER.

## Changes
* Added a upper limit on the `runIn` interval calculation by adding a `Math.min` computation against MAX_SIGNED_INTEGER (`2e31-1`)
* Opted to still set a timeout for MAX_SIGNED_INTEGER to ensure no weirdness in long-running servers

Keywords: TimeoutOverflowWarning