### PR TITLE
Add job timeout

### DIFF
--- a/lib/agenda/default-fail-on-timeout.ts
+++ b/lib/agenda/default-fail-on-timeout.ts
@@ -1,0 +1,20 @@
+import { Agenda } from ".";
+import createDebugger from "debug";
+
+const debug = createDebugger("agenda:defaultFailOnTimeout");
+
+/**
+ * Determine if the job should fail when it timeouts.
+ * Default is false
+ * @name Agenda#defaultFailOnTimeout
+ * @function
+ * @param {Boolean} failOnTimeout Whether or not job will fail when timeout
+ */
+export const defaultFailOnTimeout = function (
+  this: Agenda,
+  failOnTimeout: boolean
+): Agenda {
+  debug("Agenda.defaultFailOnTimeout(%s)", failOnTimeout);
+  this._defaultFailOnTimeout = failOnTimeout;
+  return this;
+};

--- a/lib/agenda/default-timeout.ts
+++ b/lib/agenda/default-timeout.ts
@@ -1,0 +1,17 @@
+import { Agenda } from ".";
+import createDebugger from "debug";
+
+const debug = createDebugger("agenda:defaultTimeout");
+
+/**
+ * Set the default timeout (in ms)
+ * Default is 10 * 60 * 1000 ms (10 minutes)
+ * @name Agenda#defaultTimeout
+ * @function
+ * @param {Number} ms time in ms to set default timeout
+ */
+export const defaultTimeout = function (this: Agenda, ms: number): Agenda {
+  debug("Agenda.defaultTimeout(%d)", ms);
+  this._defaultTimeout = ms;
+  return this;
+};

--- a/lib/agenda/define.ts
+++ b/lib/agenda/define.ts
@@ -39,6 +39,16 @@ export interface DefineOptions {
    * Should the return value of the job be persisted
    */
   shouldSaveResult?: boolean;
+
+  /**
+   * Get the number of milliseconds the job can run.
+   */
+  timeout?: number;
+
+  /**
+   * Determine if the job should fail when it timeouts.
+   */
+  failOnTimeout?: boolean;
 }
 
 export type Processor =
@@ -75,7 +85,10 @@ export const define = function (
       (options as DefineOptions).lockLifetime || this._defaultLockLifetime,
     running: 0,
     locked: 0,
-    shouldSaveResult: (options as DefineOptions).shouldSaveResult || false
+    shouldSaveResult: (options as DefineOptions).shouldSaveResult || false,
+    timeout: (options as DefineOptions).timeout || this._defaultTimeout,
+    shouldFailOnTimeout:
+      (options as DefineOptions).failOnTimeout || this._defaultFailOnTimeout,
   };
   debug(
     "job [%s] defined with following options: \n%O",

--- a/lib/agenda/index.ts
+++ b/lib/agenda/index.ts
@@ -35,6 +35,8 @@ import { schedule } from "./schedule";
 import { sort } from "./sort";
 import { start } from "./start";
 import { stop } from "./stop";
+import { defaultTimeout } from "./default-timeout";
+import { defaultFailOnTimeout } from "./default-fail-on-timeout";
 
 export interface AgendaConfig {
   name?: string;
@@ -44,6 +46,8 @@ export interface AgendaConfig {
   lockLimit?: number;
   defaultLockLimit?: number;
   defaultLockLifetime?: number;
+  defaultTimeout?: number;
+  defaultFailOnTimeout?: boolean;
   sort?: any;
   mongo?: MongoDb;
   db?: {
@@ -73,6 +77,8 @@ export interface AgendaConfig {
  * @property {Boolean} _isLockingOnTheFly - true if 'lockingOnTheFly' is currently running. Prevent concurrent execution of this method.
  * @property {Map} _isJobQueueFilling - A map of jobQueues and if the 'jobQueueFilling' method is currently running for a given map. 'lockingOnTheFly' and 'jobQueueFilling' should not run concurrently for the same jobQueue. It can cause that lock limits aren't honored.
  * @property {Array} _jobsToLock
+ * @property {Number} _defaultTimeout
+ * @property {Boolean} _defaultFailOnTimeout
  */
 class Agenda extends EventEmitter {
   _defaultConcurrency: any;
@@ -99,6 +105,8 @@ class Agenda extends EventEmitter {
   _collection!: Collection;
   _nextScanAt: any;
   _processInterval: any;
+  _defaultTimeout: number;
+  _defaultFailOnTimeout: boolean;
 
   cancel!: typeof cancel;
   close!: typeof close;
@@ -125,6 +133,8 @@ class Agenda extends EventEmitter {
   sort!: typeof sort;
   start!: typeof start;
   stop!: typeof stop;
+  defaultTimeout!: typeof defaultTimeout;
+  defaultFailOnTimeout!: typeof defaultFailOnTimeout;
 
   /**
    * Constructs a new Agenda object.
@@ -152,6 +162,8 @@ class Agenda extends EventEmitter {
     this._lockedJobs = [];
     this._jobQueue = new JobProcessingQueue();
     this._defaultLockLifetime = config.defaultLockLifetime || 10 * 60 * 1000; // 10 minute default lockLifetime
+    this._defaultTimeout = config.defaultTimeout || 10 * 60 * 1000; // 10 minute default timeout
+    this._defaultFailOnTimeout = config.defaultFailOnTimeout || false;
     this._sort = config.sort || { nextRunAt: 1, priority: -1 };
     this._indices = {
       name: 1,
@@ -217,5 +229,7 @@ Agenda.prototype.schedule = schedule;
 Agenda.prototype.sort = sort;
 Agenda.prototype.start = start;
 Agenda.prototype.stop = stop;
+Agenda.prototype.defaultTimeout = defaultTimeout;
+Agenda.prototype.defaultFailOnTimeout = defaultFailOnTimeout;
 
 export { Agenda };

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -230,6 +230,24 @@ describe("Agenda", () => {
         expect(agenda._sort).to.eql({ nextRunAt: -1 });
       });
     });
+    describe("defaultTimeout", () => {
+      it("returns itself", () => {
+        expect(agenda.defaultTimeout(1000)).to.be(agenda);
+      });
+      it("sets the default timeout", () => {
+        agenda.defaultTimeout(9999);
+        expect(agenda._defaultTimeout).to.be(9999);
+      });
+    });
+    describe("defaultFailOnTimeout", () => {
+      it("returns itself", () => {
+        expect(agenda.defaultFailOnTimeout(false)).to.be(agenda);
+      });
+      it("sets the defaultFailOnTimeout option", () => {
+        agenda.defaultFailOnTimeout(true);
+        expect(agenda._defaultFailOnTimeout).to.be(true);
+      });
+    });
   });
 
   describe("job methods", () => {

--- a/test/job.js
+++ b/test/job.js
@@ -621,6 +621,24 @@ describe("Job", () => {
       const deletedJob = await agenda.jobs({ name: "failBoat3" });
       expect(deletedJob).to.have.length(0);
     });
+
+    it("handles timeout errors", async () => {
+      await agenda.processEvery(5);
+      job.attrs.name = "failBoat4";
+      await job.save();
+      agenda.define(
+        "failBoat4",
+        { timeout: 15, failOnTimeout: true },
+        async (job, cb) => {
+          await delay(100);
+          cb();
+        }
+      );
+
+      await job.run();
+
+      expect(job.attrs.failReason).to.be("failBoat4 timeout");
+    });
   });
 
   describe("touch", () => {
@@ -1284,7 +1302,7 @@ describe("Job", () => {
         expect(job.attrs.shouldSaveResult).to.be(true);
       });
       it("should set option via constructor", () => {
-        const job = new Job({shouldSaveResult: true});
+        const job = new Job({ shouldSaveResult: true });
         expect(job.attrs.shouldSaveResult).to.be(true);
       });
       it("returns the job", () => {
@@ -1302,7 +1320,7 @@ describe("Job", () => {
           await agenda.now("savedResultJob");
           await delay(jobTimeout);
           const result = await agenda.jobs({ name: "savedResultJob" });
-          expect(result[0].attrs.result).to.be(undefined)
+          expect(result[0].attrs.result).to.be(undefined);
         });
         it("should not save result if option is false", async () => {
           agenda.define("savedResultJob", {shouldSaveResult: false}, (job, cb) => {
@@ -1312,7 +1330,7 @@ describe("Job", () => {
           await agenda.now("savedResultJob");
           await delay(jobTimeout);
           const result = await agenda.jobs({ name: "savedResultJob" });
-          expect(result[0].attrs.result).to.be(undefined)
+          expect(result[0].attrs.result).to.be(undefined);
         });
         it("should save result if option is true", async () => {
           agenda.define("savedResultJob", {shouldSaveResult: true}, (job, cb) => {
@@ -1335,7 +1353,7 @@ describe("Job", () => {
           await agenda.now("savedResultJob");
           await delay(jobTimeout);
           const result = await agenda.jobs({ name: "savedResultJob" });
-          expect(result[0].attrs.result).to.be(undefined)
+          expect(result[0].attrs.result).to.be(undefined);
         });
         it("should not save result if option is false", async () => {
           agenda.define("savedResultJob", {shouldSaveResult: false}, async (job) => {
@@ -1345,7 +1363,7 @@ describe("Job", () => {
           await agenda.now("savedResultJob");
           await delay(jobTimeout);
           const result = await agenda.jobs({ name: "savedResultJob" });
-          expect(result[0].attrs.result).to.be(undefined)
+          expect(result[0].attrs.result).to.be(undefined);
         });
         it("should save result if option is true", async () => {
           agenda.define("savedResultJob", {shouldSaveResult: true}, async (job) => {
@@ -1367,7 +1385,7 @@ describe("Job", () => {
           await agenda.now("savedResultJob");
           await delay(jobTimeout);
           const result = await agenda.jobs({ name: "savedResultJob" });
-          expect(result[0].attrs.result).to.be(undefined)
+          expect(result[0].attrs.result).to.be(undefined);
         });
         it("should not save result if option is false", async () => {
           agenda.define("savedResultJob", {shouldSaveResult: false}, (job) => {
@@ -1377,10 +1395,10 @@ describe("Job", () => {
           await agenda.now("savedResultJob");
           await delay(jobTimeout);
           const result = await agenda.jobs({ name: "savedResultJob" });
-          expect(result[0].attrs.result).to.be(undefined)
+          expect(result[0].attrs.result).to.be(undefined);
         });
         it("should save result if option is true", async () => {
-          agenda.define("savedResultJob", {shouldSaveResult: true}, (job) => {
+          agenda.define("savedResultJob", { shouldSaveResult: true }, (job) => {
             return "job-result";
           });
           await agenda.start();
@@ -1391,7 +1409,7 @@ describe("Job", () => {
         });
       });
     });
-  })
+  });
 
   describe("Integration Tests", () => {
     describe(".every()", () => {


### PR DESCRIPTION
Related to #893

The issue can happen if a job is running and never ending. When running jobs number is greater than job concurrency number, a job will pop from queue and insert at the queue first position, which will be an endless loop.