### PR TITLE
Feature: configuration for custom index on jobs collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,23 @@ Takes a `query` which specifies the sort query to be used for finding and lockin
 
 By default it is `{ nextRunAt: 1, priority: -1 }`, which obeys a first in first out approach, with respect to priority.
 
+### index(object)
+
+Optional. Takes an object which specifies the index to create on the jobs collection.
+
+The default index is:
+```json
+{
+  name: 1,
+  nextRunAt: 1,
+  priority: -1,
+  lockedAt: 1,
+  disabled: 1
+}
+```
+
+It is recommended to use the default index. This optional configuration is meant to enable specific optimizations that might be required under specific use-cases.
+
 ## Agenda Events
 
 An instance of an agenda will emit the following events:

--- a/lib/agenda/index.ts
+++ b/lib/agenda/index.ts
@@ -51,6 +51,7 @@ export interface AgendaConfig {
     collection?: string;
     options?: MongoClientOptions;
   };
+  index?: any,
 }
 
 /**
@@ -153,7 +154,7 @@ class Agenda extends EventEmitter {
     this._jobQueue = new JobProcessingQueue();
     this._defaultLockLifetime = config.defaultLockLifetime || 10 * 60 * 1000; // 10 minute default lockLifetime
     this._sort = config.sort || { nextRunAt: 1, priority: -1 };
-    this._indices = {
+    this._indices = config.index || {
       name: 1,
       ...this._sort,
       priority: -1,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenda",
-  "version": "4.2.1",
+  "version": "4.3.1",
   "description": "Light weight job scheduler for Node.js",
   "main": "dist/cjs.js",
   "types": "dist/index.d.ts",

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -220,6 +220,91 @@ describe("Agenda", () => {
           7777
         );
       });
+
+      describe('custom index', () => {
+        it('should create default index when custom index is not specified', async () => {
+          const collectionName = 'agenda_index_test';
+
+          const agenda2 = new Agenda({
+            db: {
+              address: mongoCfg,
+              collection: collectionName,
+            },
+          });
+
+          await agenda2._ready;
+
+          const collection = agenda2._mdb.collection(collectionName);
+
+          try {
+            const indexes = await collection.indexes();
+
+            const expectedIndex = {
+              "key": {
+                "name": 1,
+                "nextRunAt": 1,
+                "priority": -1,
+                "lockedAt": 1,
+                "disabled": 1
+              },
+              "name": "findAndLockNextJobIndex",
+            };
+
+            const index = indexes.find(index => index.name === expectedIndex.name);
+
+            expect(index).to.not.be(null);
+            expect(index.key).to.eql(expectedIndex.key);
+
+          } finally {
+            await agenda2._mdb.dropCollection(collectionName);
+            await agenda2.stop();
+            await agenda2.close();
+          }
+        });
+
+        it('should create custom index when it is specified', async () => {
+          const collectionName = 'agenda_index_test';
+
+          const agenda2 = new Agenda({
+            db: {
+              address: mongoCfg,
+              collection: collectionName,
+            },
+            index: {
+              name: 1,
+              disabled: 1,
+              nextRunAt: 1,
+            }
+          });
+
+          await agenda2._ready;
+
+          const collection = agenda2._mdb.collection(collectionName);
+
+          try {
+            const indexes = await collection.indexes();
+
+            const expectedIndex = {
+              "key": {
+                "name": 1,
+                "disabled": 1,
+                "nextRunAt": 1,
+              },
+              "name": "findAndLockNextJobIndex",
+            };
+
+            const index = indexes.find(index => index.name === expectedIndex.name);
+
+            expect(index).to.not.be(null);
+            expect(index.key).to.eql(expectedIndex.key);
+
+          } finally {
+            await agenda2._mdb.dropCollection(collectionName);
+            await agenda2.stop();
+            await agenda2.close();
+          }
+        });
+      });
     });
     describe("sort", () => {
       it("returns itself", () => {


### PR DESCRIPTION
Added the ability to customize the index created by Agenda.

During our work with Agenda we found that the index agenda creates does not fit our use-case. We have about 500K scheduled jobs and the current index causes our database to choke. As an optimization we found that using a different index yields better performance - less load on the CPU & less scanned keys.

In general, it seems like a good idea to enable Agenda users to customize the index in case it is needed for a specific use-case.

Some of the results of the different index in our use case (MongoDB cloud, M40, 500K scheduled jobs):
CPU:
![image](https://user-images.githubusercontent.com/3032121/160789937-6d903eab-7d9c-4322-9f2e-0b919a54abb4.png)
Profiler (keys examined):
![image](https://user-images.githubusercontent.com/3032121/160790149-59afc630-8e01-4827-9b8e-066be291108f.png)
