### PR TITLE
Fix: Remove date format YYYY-MM-DD to calculate nextRunAt correctly

### DIFF
--- a/lib/job/compute-next-run-at.ts
+++ b/lib/job/compute-next-run-at.ts
@@ -64,7 +64,7 @@ export const computeNextRunAt = function (this: Job): Job {
       // If start date is present, check if the nextDate should be larger or equal to startDate. If not set startDate as nextDate
       if (startDate) {
         startDate = moment
-          .tz(moment(startDate).format("YYYY-MM-DD"), timezone!)
+          .tz(moment(startDate).format(), timezone!)
           .toDate();
         if (startDate > nextDate) {
           cronOptions.currentDate = startDate;
@@ -85,7 +85,7 @@ export const computeNextRunAt = function (this: Job): Job {
       // If endDate is less than the nextDate, set nextDate to null to stop the job from running further
       if (endDate) {
         const endDateDate: Date = moment
-          .tz(moment(endDate).format("YYYY-MM-DD"), timezone!)
+          .tz(moment(endDate).format(), timezone!)
           .toDate();
         if (nextDate > endDateDate) {
           nextDate = null;


### PR DESCRIPTION
When computing nextRunAt for repeating jobs, startDate & endDate are formatted as YYYY-MM-DD:, which truncates the time portion of the dates and causes incorrect calculations of nextRunAt, as mentioned in #1449
https://github.com/agenda/agenda/blob/f328510a88318fb023e3067ef76701b7e5ebd990/lib/job/compute-next-run-at.ts#L67
https://github.com/agenda/agenda/blob/f328510a88318fb023e3067ef76701b7e5ebd990/lib/job/compute-next-run-at.ts#L88