### PR TITLE
Fixed final occurrence not being calculated

### DIFF
--- a/lib/job/compute-next-run-at.ts
+++ b/lib/job/compute-next-run-at.ts
@@ -83,13 +83,8 @@ export const computeNextRunAt = function (this: Job): Job {
       }
 
       // If endDate is less than the nextDate, set nextDate to null to stop the job from running further
-      if (endDate) {
-        const endDateDate: Date = moment
-          .tz(moment(endDate).format("YYYY-MM-DD"), timezone!)
-          .toDate();
-        if (nextDate > endDateDate) {
-          nextDate = null;
-        }
+      if (endDate && nextDate > endDate) {
+        nextDate = null;
       }
 
       this.attrs.nextRunAt = nextDate;


### PR DESCRIPTION
Fixes a bug where the final occurrence of a job scheduled with a cron string would fail to be calculated. 

This would happen because there existed a check to ensure that the next calculated occurrence was always before (inclusive) the end date of the job. However the end date value this check compared to was the end date, but at time 00:00:00. Instead of at the time stored for the job.

For example imagine there is a job with the cron string `0 20 * * *`. This specifies the job should run daily at 20:00:00 (8 PM). If you want this job to run up until (inclusive) 2022-07-31 you might set an `endDate` for the job to be `2022-07-31 20:00:00.000Z`. During job invocation before the final run of the job, aka at `2022-07-30 20:0000.000Z`, Agenda goes to calculate the next occurrence. It would find the next occurrence date to be `2022-07-31 20:00:00.000Z`. It would then compare this to the stored end date, but with a time of 00:00:00. Resulting in the comparison `2022-07-31 20:00:00.000Z < 2022-07-31 00:00:00.000Z`. This comparison would fail and in your Agenda job you would find:

```json
"failCount" : 1,
"failReason" : "failed to calculate nextRunAt due to invalid repeat interval",
```

The end date parameter is inclusive according to the docs on `endDate`:

> options.endDate: Date the job should not repeat after the endDate. The job can run on the end-date itself, but not after that.

Therefore Agenda's logic should find this final occurrence to be valid. However due to the logical bug of stripping the time of end date before the comparison Agenda found the final occurrence to be invalid.