### PR TITLE
Fixing the format of endData and startDate by adding HH:mm

### DIFF
--- a/lib/job/compute-next-run-at.ts
+++ b/lib/job/compute-next-run-at.ts
@@ -64,7 +64,7 @@ export const computeNextRunAt = function (this: Job): Job {
       // If start date is present, check if the nextDate should be larger or equal to startDate. If not set startDate as nextDate
       if (startDate) {
         startDate = moment
-          .tz(moment(startDate).format("YYYY-MM-DD"), timezone!)
+          .tz(moment(startDate).format("YYYY-MM-DD HH:mm"), timezone!)
           .toDate();
         if (startDate > nextDate) {
           cronOptions.currentDate = startDate;
@@ -85,7 +85,7 @@ export const computeNextRunAt = function (this: Job): Job {
       // If endDate is less than the nextDate, set nextDate to null to stop the job from running further
       if (endDate) {
         const endDateDate: Date = moment
-          .tz(moment(endDate).format("YYYY-MM-DD"), timezone!)
+          .tz(moment(endDate).format("YYYY-MM-DD HH:mm"), timezone!)
           .toDate();
         if (nextDate > endDateDate) {
           nextDate = null;


### PR DESCRIPTION
This solves the issue of `failed to calculate nextRunAt due to invalid repeat interval` this issue because the format truncates the time part, more details in my comment https://github.com/agenda/agenda/pull/1469#issuecomment-1285707498

Reported issue: https://github.com/agenda/agenda/issues/1449
Another PR opened https://github.com/agenda/agenda/pull/1469 to solve the same issue, but I think there is another issue will appear since cron-parser returns DateTime without seconds



