### PR TITLE
Remove saveResults examples from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,6 @@ the following:
 - `priority`: `(lowest|low|normal|high|highest|number)` specifies the priority
   of the job. Higher priority jobs will run first. See the priority mapping
   below
-- `shouldSaveResult`: `boolean` flag that specifies whether the result of the job should also be stored in the database. Defaults to false
 
 Priority mapping:
 
@@ -728,17 +727,6 @@ the above priority table.
 job.priority('low');
 await job.save();
 ```
-
-### setShouldSaveResult(setShouldSaveResult)
-
-Specifies whether the result of the job should also be stored in the database. Defaults to false.
-
-```js
-job.setShouldSaveResult(true);
-await job.save();
-```
-
-The data returned by the job will be available on the `result` attribute after it succeeded and got retrieved again from the database, e.g. via `agenda.jobs(...)` or through the [success job event](#agenda-events)).
 
 ### unique(properties, [options])
 


### PR DESCRIPTION
The current docs do not include a saveResults or setSaveResults and they do not work on V6.x

![image](https://user-images.githubusercontent.com/15899938/234920627-a7760d36-780d-47d6-bbe3-4a109f4c8cca.png)
