### PR TITLE
feat: add top-level `agenda.disable` and `agenda.enable` methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import * as debug from 'debug';
 
-import type { Db, Filter, MongoClientOptions, Sort } from 'mongodb';
+import type { Db, Filter, MongoClientOptions, Sort, UpdateResult } from 'mongodb';
 import { SortDirection } from 'mongodb';
 import { ForkOptions } from 'child_process';
 import type { IJobDefinition } from './types/JobDefinition';
@@ -199,6 +199,62 @@ export class Agenda extends EventEmitter {
 			throw error;
 		}
 	}
+
+  /**
+ * Disables any jobs matching the passed MongoDB query by setting the `disabled` flag to `true`
+ * @name Agenda#disable
+ * @function
+ * @param query MongoDB query to use when enabling
+ * @returns {Promise<number>} Resolved with the number of disabled job instances.
+ */
+async disable (
+  this: Agenda,
+  query: Filter<IJobParameters> = {}
+): Promise<number> {
+  debug("attempting to disable all jobs matching query", query);
+  try {
+    const { modifiedCount, matchedCount } = await this.db.collection.updateMany(query, {
+      $set: { disabled: true },
+    });
+    debug(`${modifiedCount} jobs disabled`);
+    if(matchedCount !== modifiedCount) {
+      debug(`WARN: ${matchedCount} jobs matched query but ${modifiedCount} were modified`);
+    }
+    return modifiedCount;
+  } catch (error) {
+    debug("error trying to mark jobs as `disabled`");
+    throw error;
+  }
+};
+
+/**
+ * Enables any jobs matching the passed MongoDB query by setting the `disabled` flag to `false`
+ * @name Agenda#enable
+ * @function
+ * @param query MongoDB query to use when enabling
+ * @caller client code, Agenda.purge(), Job.remove()
+ * @returns {Promise<Number>} A promise that contains the number of removed documents when fulfilled.
+ */
+async enable (
+  this: Agenda,
+  query:  Filter<IJobParameters> = {}
+): Promise<number> {
+  debug("attempting to enable all jobs matching query %o", query);
+  try {
+    const { modifiedCount, matchedCount } = await this.db.collection.updateMany(query, {
+      $set: { disabled: false },
+    }) as UpdateResult;
+    debug(`${modifiedCount} jobs enabled`);
+    if(matchedCount !== modifiedCount) {
+      debug(`WARN: ${matchedCount} jobs matched query but ${modifiedCount} were modified`);
+    }
+    return modifiedCount;
+  } catch (error) {
+    debug("error trying to mark jobs as `enabled`");
+    throw error;
+  }
+};
+
 
 	/**
 	 * Set name of queue


### PR DESCRIPTION
I noticed my work was listed as a blocker on #1502, so here is my original implementation of the `enable` and `disable` methods ported to the agendaTS codebase.

* this code has been migrated over from agenda/agenda#1109
* migrates old methods from individual files to the top level Agenda Class
* test suite updated with original test suite content from original fork