### PR TITLE
Integration with external trigger

### DIFF
--- a/src/JobProcessor.ts
+++ b/src/JobProcessor.ts
@@ -98,9 +98,11 @@ export class JobProcessor {
 		private maxConcurrency: number,
 		private totalLockLimit: number,
 		private processEvery: number
-	) {
-		log('creating interval to call processJobs every [%dms]', processEvery);
-		this.processInterval = setInterval(() => this.process(), processEvery);
+	) {}
+
+	start(): void {
+		log('creating interval to call processJobs every [%dms]', this.processEvery);
+		this.processInterval = setInterval(() => this.process(), this.processEvery);
 		this.process();
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -538,6 +538,7 @@ export class Agenda extends EventEmitter {
 			this.attrs.processEvery
 		);
 
+		this.jobProcessor.start();
 		this.on('processJob', this.jobProcessor.process.bind(this.jobProcessor));
 	}
 


### PR DESCRIPTION
### Summary of Changes

This pull request removes the instantiation of JobProcessor within the Agenda constructor. This change enables calling the process() function externally, allowing integration with external triggers such as REST API calls, suitable for serverless functions.

### Changes Made

- Removed the instantiation of setInterval() from the JobProcessor constructor.

### Usage example

```javascript
const mongoConnectionString = 'mongodb://127.0.0.1/agenda';

const agenda = new Agenda({ db: { address: mongoConnectionString } });

agenda.define('delete old users', async job => {
	await User.remove({ lastLogIn: { $lt: twoDaysAgo } });
});

const options = {
	processEvery: 5000, //ignore
	maxConcurrency: 20,
	lockLimit: 0
};

agenda.every('3 minutes', 'delete old users');

const jobProcessor = new JobProcessor(agenda, options.maxConcurrency, options.lockLimit, options.processEvery);

app.get('/api/cron', (req, res) => {
    jobProcessor.start();

    return res.json({
        success: true
    })
})
```

This pull request addresses the need for greater flexibility in integrating Agenda.js with serverless architectures and other external triggers (example Vercel environment)