### PR TITLE
fix: rename docs script and fix branch trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Deploy Documentation
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -37,7 +37,7 @@ jobs:
         run: pnpm build
 
       - name: Generate documentation
-        run: pnpm docs
+        run: pnpm run docs:build
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "changeset": "changeset",
-    "docs": "typedoc"
+    "docs:build": "typedoc"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.12",


### PR DESCRIPTION
- Rename `docs` to `docs:build` to avoid conflict with npm's built-in `npm docs` command which opens the package's npm page
- Fix workflow trigger to use `main` branch (not `master`)

https://claude.ai/code/session_01M9td9MqRb6B7m4TzpRrUye