### PR TITLE
Change docs deployment trigger from push to release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,8 @@
 name: Deploy Documentation
 
 on:
-  push:
-    branches: [main]
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
Updated the documentation deployment workflow to trigger on release publication instead of every push to the main branch.

## Key Changes
- Changed workflow trigger from `push` events on `main` branch to `release` events with `published` type
- This ensures documentation is only deployed when a new release is officially published, rather than on every commit to main

## Implementation Details
The workflow will now only execute when a GitHub release is published, providing better control over documentation deployment timing and reducing unnecessary workflow runs. The `workflow_dispatch` trigger remains available for manual deployments if needed.