### PR TITLE
Refactor: Remove 'I' prefix from interface names across codebase

### DIFF
--- a/packages/agenda-rest/src/server.ts
+++ b/packages/agenda-rest/src/server.ts
@@ -3,16 +3,16 @@ import Router from 'koa-router';
 import bodyParser from 'koa-bodyparser';
 import type { Job } from 'agenda';
 import type {
-	IAgendaRestConfig,
-	IJobDefinitionRequest,
-	IScheduleJobRequest,
-	ICancelJobRequest
+	AgendaRestConfig,
+	JobDefinitionRequest,
+	ScheduleJobRequest,
+	CancelJobRequest
 } from './types.js';
 
 /**
  * Job definitions stored in memory (for webhook-style jobs)
  */
-interface IStoredJobDefinition {
+interface StoredJobDefinition {
 	name: string;
 	url?: string;
 	method?: string;
@@ -28,7 +28,7 @@ interface IStoredJobDefinition {
 /**
  * Create a Koa application for the agenda-rest API
  */
-export function createServer(config: IAgendaRestConfig): Koa {
+export function createServer(config: AgendaRestConfig): Koa {
 	const { agenda, apiKey } = config;
 
 	if (!agenda) {
@@ -39,7 +39,7 @@ export function createServer(config: IAgendaRestConfig): Koa {
 	const router = new Router({ prefix: '/api' });
 
 	// In-memory job definitions (for webhook-style job configs)
-	const jobDefinitions = new Map<string, IStoredJobDefinition>();
+	const jobDefinitions = new Map<string, StoredJobDefinition>();
 
 	// Middleware for API key authentication
 	const authenticate = async (ctx: Koa.Context, next: Koa.Next) => {
@@ -105,7 +105,7 @@ export function createServer(config: IAgendaRestConfig): Koa {
 
 	// POST /api/job - Create a new job definition
 	router.post('/job', authenticate, async (ctx) => {
-		const body = ctx.request.body as IJobDefinitionRequest;
+		const body = ctx.request.body as JobDefinitionRequest;
 
 		if (!body.name) {
 			ctx.status = 400;
@@ -128,7 +128,7 @@ export function createServer(config: IAgendaRestConfig): Koa {
 	// PUT /api/job/:jobName - Update a job definition
 	router.put('/job/:jobName', authenticate, async (ctx) => {
 		const { jobName } = ctx.params;
-		const body = ctx.request.body as Partial<IJobDefinitionRequest>;
+		const body = ctx.request.body as Partial<JobDefinitionRequest>;
 
 		if (!jobDefinitions.has(jobName)) {
 			ctx.status = 404;
@@ -161,7 +161,7 @@ export function createServer(config: IAgendaRestConfig): Koa {
 
 	// POST /api/job/now - Run a job immediately
 	router.post('/job/now', authenticate, async (ctx) => {
-		const body = ctx.request.body as IScheduleJobRequest;
+		const body = ctx.request.body as ScheduleJobRequest;
 
 		if (!body.name) {
 			ctx.status = 400;
@@ -186,7 +186,7 @@ export function createServer(config: IAgendaRestConfig): Koa {
 
 	// POST /api/job/once - Schedule a job to run once at a specific time
 	router.post('/job/once', authenticate, async (ctx) => {
-		const body = ctx.request.body as IScheduleJobRequest;
+		const body = ctx.request.body as ScheduleJobRequest;
 
 		if (!body.name) {
 			ctx.status = 400;
@@ -217,7 +217,7 @@ export function createServer(config: IAgendaRestConfig): Koa {
 
 	// POST /api/job/every - Schedule a recurring job
 	router.post('/job/every', authenticate, async (ctx) => {
-		const body = ctx.request.body as IScheduleJobRequest;
+		const body = ctx.request.body as ScheduleJobRequest;
 
 		if (!body.name) {
 			ctx.status = 400;
@@ -248,7 +248,7 @@ export function createServer(config: IAgendaRestConfig): Koa {
 
 	// POST /api/job/cancel - Cancel matching jobs
 	router.post('/job/cancel', authenticate, async (ctx) => {
-		const body = ctx.request.body as ICancelJobRequest;
+		const body = ctx.request.body as CancelJobRequest;
 
 		if (!body.name && !body.data) {
 			ctx.status = 400;

--- a/packages/agenda-rest/src/types.ts
+++ b/packages/agenda-rest/src/types.ts
@@ -1,7 +1,7 @@
 /**
  * Configuration options for the agenda-rest server
  */
-export interface IAgendaRestConfig {
+export interface AgendaRestConfig {
 	/** Agenda instance to use */
 	agenda?: import('agenda').Agenda;
 	/** MongoDB connection URI */
@@ -21,7 +21,7 @@ export interface IAgendaRestConfig {
 /**
  * Job definition request body
  */
-export interface IJobDefinitionRequest {
+export interface JobDefinitionRequest {
 	name: string;
 	url?: string;
 	method?: string;
@@ -37,7 +37,7 @@ export interface IJobDefinitionRequest {
 /**
  * Schedule job request body
  */
-export interface IScheduleJobRequest {
+export interface ScheduleJobRequest {
 	name: string;
 	data?: unknown;
 	interval?: string;
@@ -47,7 +47,7 @@ export interface IScheduleJobRequest {
 /**
  * Cancel job request body
  */
-export interface ICancelJobRequest {
+export interface CancelJobRequest {
 	name?: string;
 	data?: unknown;
 }
@@ -55,16 +55,16 @@ export interface ICancelJobRequest {
 /**
  * API response types
  */
-export interface IApiSuccessResponse {
+export interface ApiSuccessResponse {
 	success: boolean;
 	message?: string;
 }
 
-export interface IApiErrorResponse {
+export interface ApiErrorResponse {
 	error: string;
 }
 
-export interface IJobListResponse {
+export interface JobListResponse {
 	jobs: Array<{
 		name: string;
 		url?: string;

--- a/packages/agenda/src/Job.ts
+++ b/packages/agenda/src/Job.ts
@@ -3,7 +3,7 @@ import debug from 'debug';
 import { ChildProcess, fork } from 'child_process';
 import type { Agenda } from './index.js';
 import type { DefinitionProcessor } from './types/JobDefinition.js';
-import { IJobParameters, datefields, TJobDatefield, JobId } from './types/JobParameters.js';
+import { JobParameters, datefields, TJobDatefield, JobId } from './types/JobParameters.js';
 import { JobPriority, parsePriority } from './utils/priority.js';
 import { computeFromInterval, computeFromRepeatAt } from './utils/nextRunAt.js';
 
@@ -13,7 +13,7 @@ const log = debug('agenda:job');
  * @class
  */
 export class Job<DATA = unknown | void> {
-	readonly attrs: IJobParameters<DATA>;
+	readonly attrs: JobParameters<DATA>;
 
 	/** this flag is set to true, if a job got canceled (e.g. due to a timeout or other exception),
 	 * you can use it for long running tasks to periodically check if canceled is true,
@@ -53,7 +53,7 @@ export class Job<DATA = unknown | void> {
 	 */
 	constructor(
 		agenda: Agenda,
-		args: Partial<IJobParameters<void>> & {
+		args: Partial<JobParameters<void>> & {
 			name: string;
 			type: 'normal' | 'single';
 		},
@@ -61,7 +61,7 @@ export class Job<DATA = unknown | void> {
 	);
 	constructor(
 		agenda: Agenda,
-		args: Partial<IJobParameters<DATA>> & {
+		args: Partial<JobParameters<DATA>> & {
 			name: string;
 			type: 'normal' | 'single';
 			data: DATA;
@@ -70,7 +70,7 @@ export class Job<DATA = unknown | void> {
 	);
 	constructor(
 		readonly agenda: Agenda,
-		args: Partial<IJobParameters<DATA>> & {
+		args: Partial<JobParameters<DATA>> & {
 			name: string;
 			type: 'normal' | 'single';
 			data: DATA;
@@ -90,8 +90,8 @@ export class Job<DATA = unknown | void> {
 	/**
 	 * Given a job, turn it into an JobParameters object
 	 */
-	toJson(): IJobParameters {
-		const result = {} as IJobParameters;
+	toJson(): JobParameters {
+		const result = {} as JobParameters;
 		const attrs = this.attrs as unknown as Record<string, unknown>;
 
 		for (const key of Object.keys(attrs)) {
@@ -170,8 +170,8 @@ export class Job<DATA = unknown | void> {
 	 * @param opts
 	 */
 	unique(
-		unique: Required<IJobParameters<DATA>>['unique'],
-		opts?: IJobParameters['uniqueOpts']
+		unique: Required<JobParameters<DATA>>['unique'],
+		opts?: JobParameters['uniqueOpts']
 	): this {
 		this.attrs.unique = unique;
 		this.attrs.uniqueOpts = opts;
@@ -511,4 +511,4 @@ export class Job<DATA = unknown | void> {
 	}
 }
 
-export type JobWithId = Job & { attrs: IJobParameters & { _id: JobId } };
+export type JobWithId = Job & { attrs: JobParameters & { _id: JobId } };

--- a/packages/agenda/src/JobProcessingQueue.ts
+++ b/packages/agenda/src/JobProcessingQueue.ts
@@ -1,5 +1,5 @@
 import type { Job, JobWithId } from './Job.js';
-import type { IJobParameters } from './types/JobParameters.js';
+import type { JobParameters } from './types/JobParameters.js';
 import type { Agenda } from './index.js';
 /**
  * @class
@@ -100,8 +100,8 @@ export class JobProcessingQueue {
 				  }
 				| undefined;
 		},
-		handledJobs: IJobParameters['_id'][]
-	): (JobWithId & { attrs: IJobParameters & { nextRunAt?: Date | null } }) | undefined {
+		handledJobs: JobParameters['_id'][]
+	): (JobWithId & { attrs: JobParameters & { nextRunAt?: Date | null } }) | undefined {
 		const next = (Object.keys(this._queue) as unknown as number[]).reverse().find(i => {
 			const def = this.agenda.definitions[this._queue[i].attrs.name];
 			const status = jobStatus[this._queue[i].attrs.name];
@@ -121,7 +121,7 @@ export class JobProcessingQueue {
 		});
 
 		return next !== undefined
-			? (this._queue[next] as JobWithId & { attrs: IJobParameters & { nextRunAt: Date } })
+			? (this._queue[next] as JobWithId & { attrs: JobParameters & { nextRunAt: Date } })
 			: undefined;
 	}
 }

--- a/packages/agenda/src/JobProcessor.ts
+++ b/packages/agenda/src/JobProcessor.ts
@@ -1,10 +1,10 @@
 import debug from 'debug';
 import packageJson from '../package.json' with { type: 'json' };
-import type { IAgendaJobStatus, IAgendaStatus } from './types/AgendaStatus.js';
-import type { IJobDefinition } from './types/JobDefinition.js';
+import type { AgendaJobStatus, AgendaStatus } from './types/AgendaStatus.js';
+import type { JobDefinition } from './types/JobDefinition.js';
 import type { Agenda, JobWithId } from './index.js';
-import type { IJobParameters } from './types/JobParameters.js';
-import type { INotificationChannel, IJobNotification } from './types/NotificationChannel.js';
+import type { JobParameters } from './types/JobParameters.js';
+import type { NotificationChannel, JobNotification } from './types/NotificationChannel.js';
 import { Job } from './Job.js';
 import { JobProcessingQueue } from './JobProcessingQueue.js';
 const delay = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
@@ -26,8 +26,8 @@ export class JobProcessor {
 
 	private localQueueProcessing = 0;
 
-	async getStatus(fullDetails = false): Promise<IAgendaStatus> {
-		const jobStatus = Object.keys(this.jobStatus).reduce<IAgendaJobStatus>((obj, key) => {
+	async getStatus(fullDetails = false): Promise<AgendaStatus> {
+		const jobStatus = Object.keys(this.jobStatus).reduce<AgendaJobStatus>((obj, key) => {
 			const status = this.jobStatus[key];
 			obj[key] = {
 				running: status?.running ?? 0,
@@ -35,7 +35,7 @@ export class JobProcessor {
 				config: this.agenda.definitions[key]
 			};
 			return obj;
-		}, {} as IAgendaJobStatus);
+		}, {} as AgendaJobStatus);
 
 		return {
 			version: agendaVersion,
@@ -85,7 +85,7 @@ export class JobProcessor {
 
 	private processInterval?: ReturnType<typeof setInterval>;
 
-	private notificationChannel?: INotificationChannel;
+	private notificationChannel?: NotificationChannel;
 
 	private notificationUnsubscribe?: () => void;
 
@@ -94,7 +94,7 @@ export class JobProcessor {
 		private maxConcurrency: number,
 		private totalLockLimit: number,
 		private processEvery: number,
-		notificationChannel?: INotificationChannel
+		notificationChannel?: NotificationChannel
 	) {
 		this.notificationChannel = notificationChannel;
 		this.jobQueue = new JobProcessingQueue(this.agenda);
@@ -190,7 +190,7 @@ export class JobProcessor {
 	/**
 	 * Handle incoming job notification - triggers immediate processing
 	 */
-	private async handleNotification(notification: IJobNotification): Promise<void> {
+	private async handleNotification(notification: JobNotification): Promise<void> {
 		if (!this.isRunning) {
 			log.extend('handleNotification')('JobProcessor not running, ignoring notification');
 			return;
@@ -288,7 +288,7 @@ export class JobProcessor {
 
 	private async findAndLockNextJob(
 		jobName: string,
-		definition: IJobDefinition
+		definition: JobDefinition
 	): Promise<JobWithId | undefined> {
 		const lockDeadline = new Date(Date.now().valueOf() - definition.lockLifetime);
 		log.extend('findAndLockNextJob')(
@@ -385,7 +385,7 @@ export class JobProcessor {
 	 * handledJobs keeps list of already processed jobs
 	 * @returns {undefined}
 	 */
-	private async jobProcessing(handledJobs: IJobParameters['_id'][] = []) {
+	private async jobProcessing(handledJobs: JobParameters['_id'][] = []) {
 		// Ensure we have jobs
 		if (this.jobQueue.length === 0) {
 			return;

--- a/packages/agenda/src/notifications/BaseNotificationChannel.ts
+++ b/packages/agenda/src/notifications/BaseNotificationChannel.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from 'events';
 import type {
-	INotificationChannel,
-	INotificationChannelConfig,
-	IJobNotification,
+	NotificationChannel,
+	NotificationChannelConfig,
+	JobNotification,
 	NotificationHandler,
 	NotificationChannelState
 } from '../types/NotificationChannel.js';
@@ -10,7 +10,7 @@ import type {
 /**
  * Internal config type with all properties required
  */
-interface IResolvedNotificationChannelConfig {
+interface ResolvedNotificationChannelConfig {
 	channelName: string;
 	reconnect: {
 		enabled: boolean;
@@ -24,15 +24,15 @@ interface IResolvedNotificationChannelConfig {
  * Abstract base class for notification channels.
  * Provides common functionality like state management and reconnection logic.
  */
-export abstract class BaseNotificationChannel extends EventEmitter implements INotificationChannel {
+export abstract class BaseNotificationChannel extends EventEmitter implements NotificationChannel {
 	protected _state: NotificationChannelState = 'disconnected';
 	protected handlers = new Set<NotificationHandler>();
 	protected reconnectAttempts = 0;
 	protected reconnectTimeout?: ReturnType<typeof setTimeout>;
 
-	protected readonly config: IResolvedNotificationChannelConfig;
+	protected readonly config: ResolvedNotificationChannelConfig;
 
-	constructor(config: INotificationChannelConfig = {}) {
+	constructor(config: NotificationChannelConfig = {}) {
 		super();
 		this.config = {
 			channelName: config.channelName ?? 'agenda:jobs',
@@ -58,7 +58,7 @@ export abstract class BaseNotificationChannel extends EventEmitter implements IN
 
 	abstract connect(): Promise<void>;
 	abstract disconnect(): Promise<void>;
-	abstract publish(notification: IJobNotification): Promise<void>;
+	abstract publish(notification: JobNotification): Promise<void>;
 
 	subscribe(handler: NotificationHandler): () => void {
 		this.handlers.add(handler);
@@ -67,7 +67,7 @@ export abstract class BaseNotificationChannel extends EventEmitter implements IN
 		};
 	}
 
-	protected async notifyHandlers(notification: IJobNotification): Promise<void> {
+	protected async notifyHandlers(notification: JobNotification): Promise<void> {
 		const promises: Promise<void>[] = [];
 		for (const handler of this.handlers) {
 			try {

--- a/packages/agenda/src/notifications/InMemoryNotificationChannel.ts
+++ b/packages/agenda/src/notifications/InMemoryNotificationChannel.ts
@@ -1,6 +1,6 @@
 import type {
-	INotificationChannelConfig,
-	IJobNotification
+	NotificationChannelConfig,
+	JobNotification
 } from '../types/NotificationChannel.js';
 import { BaseNotificationChannel } from './BaseNotificationChannel.js';
 
@@ -9,7 +9,7 @@ import { BaseNotificationChannel } from './BaseNotificationChannel.js';
  * Notifications are delivered synchronously within the same process.
  */
 export class InMemoryNotificationChannel extends BaseNotificationChannel {
-	constructor(config: INotificationChannelConfig = {}) {
+	constructor(config: NotificationChannelConfig = {}) {
 		super(config);
 	}
 
@@ -24,7 +24,7 @@ export class InMemoryNotificationChannel extends BaseNotificationChannel {
 		this.setState('disconnected');
 	}
 
-	async publish(notification: IJobNotification): Promise<void> {
+	async publish(notification: JobNotification): Promise<void> {
 		if (this._state !== 'connected') {
 			throw new Error('Cannot publish: channel not connected');
 		}

--- a/packages/agenda/src/types/AgendaBackend.ts
+++ b/packages/agenda/src/types/AgendaBackend.ts
@@ -1,5 +1,5 @@
-import type { IJobRepository } from './JobRepository.js';
-import type { INotificationChannel } from './NotificationChannel.js';
+import type { JobRepository } from './JobRepository.js';
+import type { NotificationChannel } from './NotificationChannel.js';
 
 /**
  * Unified backend interface for Agenda.
@@ -13,19 +13,19 @@ import type { INotificationChannel } from './NotificationChannel.js';
  * - PostgresBackend: provides repository + notificationChannel (LISTEN/NOTIFY)
  * - Custom: mix storage from one system, notifications from another
  */
-export interface IAgendaBackend {
+export interface AgendaBackend {
 	/**
 	 * The job repository for storage operations.
 	 * This is required - every backend must provide storage.
 	 */
-	readonly repository: IJobRepository;
+	readonly repository: JobRepository;
 
 	/**
 	 * Optional notification channel for real-time job notifications.
 	 * If provided, Agenda will use this for immediate job processing.
 	 * If not provided, Agenda falls back to periodic polling.
 	 */
-	readonly notificationChannel?: INotificationChannel;
+	readonly notificationChannel?: NotificationChannel;
 
 	/**
 	 * Whether the backend owns its database connection.

--- a/packages/agenda/src/types/AgendaConfig.ts
+++ b/packages/agenda/src/types/AgendaConfig.ts
@@ -1,4 +1,4 @@
-export interface IAgendaConfig {
+export interface AgendaConfig {
 	name?: string;
 
 	defaultConcurrency: number;

--- a/packages/agenda/src/types/AgendaStatus.ts
+++ b/packages/agenda/src/types/AgendaStatus.ts
@@ -1,15 +1,15 @@
-import type { IJobParameters } from './JobParameters.js';
-import type { IJobDefinition } from './JobDefinition.js';
+import type { JobParameters } from './JobParameters.js';
+import type { JobDefinition } from './JobDefinition.js';
 
-export interface IAgendaJobStatus {
+export interface AgendaJobStatus {
 	[name: string]: {
 		running: number;
 		locked: number;
-		config: IJobDefinition;
+		config: JobDefinition;
 	};
 }
 
-export interface IAgendaStatus {
+export interface AgendaStatus {
 	version: string;
 	queueName: string | undefined;
 	totalQueueSizeDB: number;
@@ -21,8 +21,8 @@ export interface IAgendaStatus {
 	internal: {
 		localQueueProcessing: number;
 	};
-	jobStatus?: IAgendaJobStatus;
-	queuedJobs: number | IJobParameters[];
-	runningJobs: number | IJobParameters[];
-	lockedJobs: number | IJobParameters[];
+	jobStatus?: AgendaJobStatus;
+	queuedJobs: number | JobParameters[];
+	runningJobs: number | JobParameters[];
+	lockedJobs: number | JobParameters[];
 }

--- a/packages/agenda/src/types/JobDefinition.ts
+++ b/packages/agenda/src/types/JobDefinition.ts
@@ -1,6 +1,6 @@
 import type { Job } from '../Job.js';
 
-export interface IJobDefinition<DATA = unknown> {
+export interface JobDefinition<DATA = unknown> {
 	/** max number of locked jobs of this kind */
 	lockLimit: number;
 	/** lock lifetime in milliseconds */

--- a/packages/agenda/src/types/JobParameters.ts
+++ b/packages/agenda/src/types/JobParameters.ts
@@ -11,7 +11,7 @@ export function toJobId(id: string): JobId {
 	return id as JobId;
 }
 
-export interface IJobParameters<DATA = unknown | void> {
+export interface JobParameters<DATA = unknown | void> {
 	/** Job ID */
 	_id?: JobId;
 
@@ -54,7 +54,7 @@ export interface IJobParameters<DATA = unknown | void> {
 }
 
 export type TJobDatefield = keyof Pick<
-	IJobParameters,
+	JobParameters,
 	'lastRunAt' | 'lastFinishedAt' | 'nextRunAt' | 'failedAt' | 'lockedAt'
 >;
 

--- a/packages/agenda/src/types/JobQuery.ts
+++ b/packages/agenda/src/types/JobQuery.ts
@@ -1,4 +1,4 @@
-import type { IJobParameters, JobId } from './JobParameters.js';
+import type { JobParameters, JobId } from './JobParameters.js';
 import type { SortDirection } from './DbOptions.js';
 
 /**
@@ -10,7 +10,7 @@ export type JobState = 'running' | 'scheduled' | 'queued' | 'completed' | 'faile
 /**
  * Overview statistics for a single job name
  */
-export interface IJobsOverview {
+export interface JobsOverview {
 	name: string;
 	total: number;
 	running: number;
@@ -24,7 +24,7 @@ export interface IJobsOverview {
 /**
  * Job with computed state
  */
-export interface IJobWithState<DATA = unknown> extends IJobParameters<DATA> {
+export interface JobWithState<DATA = unknown> extends JobParameters<DATA> {
 	_id: JobId;
 	state: JobState;
 }
@@ -32,7 +32,7 @@ export interface IJobWithState<DATA = unknown> extends IJobParameters<DATA> {
 /**
  * Sort options for job queries (database-agnostic)
  */
-export interface IJobsSort {
+export interface JobsSort {
 	nextRunAt?: SortDirection;
 	lastRunAt?: SortDirection;
 	lastFinishedAt?: SortDirection;
@@ -44,7 +44,7 @@ export interface IJobsSort {
 /**
  * Database-agnostic query options for jobs
  */
-export interface IJobsQueryOptions {
+export interface JobsQueryOptions {
 	/** Filter by job name */
 	name?: string;
 	/** Filter by job names (multiple) */
@@ -62,7 +62,7 @@ export interface IJobsQueryOptions {
 	/** Include disabled jobs (default: true) */
 	includeDisabled?: boolean;
 	/** Sort order */
-	sort?: IJobsSort;
+	sort?: JobsSort;
 	/** Number of jobs to skip (pagination) */
 	skip?: number;
 	/** Maximum number of jobs to return */
@@ -72,8 +72,8 @@ export interface IJobsQueryOptions {
 /**
  * Result of jobs query with state computation
  */
-export interface IJobsResult<DATA = unknown> {
-	jobs: IJobWithState<DATA>[];
+export interface JobsResult<DATA = unknown> {
+	jobs: JobWithState<DATA>[];
 	/** Total count (before pagination, after state filter) */
 	total: number;
 }
@@ -81,7 +81,7 @@ export interface IJobsResult<DATA = unknown> {
 /**
  * Compute the state for a job based on its timestamps
  */
-export function computeJobState(job: IJobParameters, now: Date = new Date()): JobState {
+export function computeJobState(job: JobParameters, now: Date = new Date()): JobState {
 	const { lockedAt, lastFinishedAt, failedAt, nextRunAt, repeatInterval } = job;
 
 	// Running: currently locked and processing

--- a/packages/agenda/src/types/JobRepository.ts
+++ b/packages/agenda/src/types/JobRepository.ts
@@ -1,10 +1,10 @@
-import type { IJobParameters, JobId } from './JobParameters.js';
-import type { IJobsQueryOptions, IJobsResult, IJobsOverview } from './JobQuery.js';
+import type { JobParameters, JobId } from './JobParameters.js';
+import type { JobsQueryOptions, JobsResult, JobsOverview } from './JobQuery.js';
 
 /**
  * Options passed to repository methods that modify jobs
  */
-export interface IJobRepositoryOptions {
+export interface JobRepositoryOptions {
 	/** Name to set as lastModifiedBy on the job */
 	lastModifiedBy?: string;
 }
@@ -12,7 +12,7 @@ export interface IJobRepositoryOptions {
 /**
  * Options for removing jobs (database-agnostic)
  */
-export interface IRemoveJobsOptions {
+export interface RemoveJobsOptions {
 	/** Remove job by ID */
 	id?: JobId | string;
 	/** Remove jobs by IDs */
@@ -31,7 +31,7 @@ export interface IRemoveJobsOptions {
  * Database-agnostic job repository interface.
  * Implementations can be created for MongoDB, PostgreSQL, etc.
  */
-export interface IJobRepository {
+export interface JobRepository {
 	/**
 	 * Connect to the database
 	 */
@@ -40,12 +40,12 @@ export interface IJobRepository {
 	/**
 	 * Query jobs with filtering, pagination, and state computation
 	 */
-	queryJobs(options?: IJobsQueryOptions): Promise<IJobsResult>;
+	queryJobs(options?: JobsQueryOptions): Promise<JobsResult>;
 
 	/**
 	 * Get overview statistics for all job types
 	 */
-	getJobsOverview(): Promise<IJobsOverview[]>;
+	getJobsOverview(): Promise<JobsOverview[]>;
 
 	/**
 	 * Get all distinct job names
@@ -55,7 +55,7 @@ export interface IJobRepository {
 	/**
 	 * Get a single job by ID
 	 */
-	getJobById(id: string): Promise<IJobParameters | null>;
+	getJobById(id: string): Promise<JobParameters | null>;
 
 	/**
 	 * Get count of jobs ready to run (nextRunAt < now)
@@ -66,34 +66,34 @@ export interface IJobRepository {
 	 * Remove jobs matching the given options
 	 * @returns Number of jobs removed
 	 */
-	removeJobs(options: IRemoveJobsOptions): Promise<number>;
+	removeJobs(options: RemoveJobsOptions): Promise<number>;
 
 	/**
 	 * Save a job (insert or update)
 	 */
 	saveJob<DATA = unknown>(
-		job: IJobParameters<DATA>,
-		options: IJobRepositoryOptions | undefined
-	): Promise<IJobParameters<DATA>>;
+		job: JobParameters<DATA>,
+		options: JobRepositoryOptions | undefined
+	): Promise<JobParameters<DATA>>;
 
 	/**
 	 * Update job state fields (lockedAt, lastRunAt, progress, etc.)
 	 */
-	saveJobState(job: IJobParameters, options: IJobRepositoryOptions | undefined): Promise<void>;
+	saveJobState(job: JobParameters, options: JobRepositoryOptions | undefined): Promise<void>;
 
 	/**
 	 * Attempt to lock a job for processing
 	 * @returns The locked job data, or undefined if lock failed
 	 */
 	lockJob(
-		job: IJobParameters,
-		options: IJobRepositoryOptions | undefined
-	): Promise<IJobParameters | undefined>;
+		job: JobParameters,
+		options: JobRepositoryOptions | undefined
+	): Promise<JobParameters | undefined>;
 
 	/**
 	 * Unlock a single job
 	 */
-	unlockJob(job: IJobParameters): Promise<void>;
+	unlockJob(job: JobParameters): Promise<void>;
 
 	/**
 	 * Unlock multiple jobs by ID
@@ -108,6 +108,6 @@ export interface IJobRepository {
 		nextScanAt: Date,
 		lockDeadline: Date,
 		now: Date | undefined,
-		options: IJobRepositoryOptions | undefined
-	): Promise<IJobParameters | undefined>;
+		options: JobRepositoryOptions | undefined
+	): Promise<JobParameters | undefined>;
 }

--- a/packages/agenda/src/types/NotificationChannel.ts
+++ b/packages/agenda/src/types/NotificationChannel.ts
@@ -3,7 +3,7 @@ import type { JobId } from './JobParameters.js';
 /**
  * Notification payload sent when a job is saved/updated
  */
-export interface IJobNotification {
+export interface JobNotification {
 	jobId: JobId;
 	jobName: string;
 	nextRunAt: Date | null;
@@ -15,7 +15,7 @@ export interface IJobNotification {
 /**
  * Handler function for processing job notifications
  */
-export type NotificationHandler = (notification: IJobNotification) => void | Promise<void>;
+export type NotificationHandler = (notification: JobNotification) => void | Promise<void>;
 
 /**
  * Possible states of a notification channel
@@ -25,7 +25,7 @@ export type NotificationChannelState = 'disconnected' | 'connecting' | 'connecte
 /**
  * Configuration options for notification channels
  */
-export interface INotificationChannelConfig {
+export interface NotificationChannelConfig {
 	channelName?: string;
 	reconnect?: {
 		enabled: boolean;
@@ -39,7 +39,7 @@ export interface INotificationChannelConfig {
  * Interface for notification channels that enable cross-process job notifications.
  * Implementations can use Redis, PostgreSQL LISTEN/NOTIFY, or other pub/sub systems.
  */
-export interface INotificationChannel {
+export interface NotificationChannel {
 	/**
 	 * Current state of the channel
 	 */
@@ -66,7 +66,7 @@ export interface INotificationChannel {
 	 * Publish a job notification
 	 * @param notification - The notification to publish
 	 */
-	publish(notification: IJobNotification): Promise<void>;
+	publish(notification: JobNotification): Promise<void>;
 
 	/**
 	 * Register an event listener

--- a/packages/agenda/src/utils/nextRunAt.ts
+++ b/packages/agenda/src/utils/nextRunAt.ts
@@ -4,7 +4,7 @@ import debug from 'debug';
 import { CronExpressionParser } from 'cron-parser';
 import humanInterval from 'human-interval';
 import { isValidDate } from './isValidDate.js';
-import type { IJobParameters } from '../types/JobParameters.js';
+import type { JobParameters } from '../types/JobParameters.js';
 
 const log = debug('agenda:nextRunAt');
 
@@ -19,7 +19,7 @@ export function isValidHumanInterval(value: unknown): value is string {
 /**
  * Internal method that computes the interval
  */
-export const computeFromInterval = (attrs: IJobParameters<unknown>): Date => {
+export const computeFromInterval = (attrs: JobParameters<unknown>): Date => {
 	const previousNextRunAt = attrs.nextRunAt || new Date();
 	log('[%s:%s] computing next run via interval [%s]', attrs.name, attrs._id, attrs.repeatInterval);
 
@@ -81,7 +81,7 @@ export const computeFromInterval = (attrs: IJobParameters<unknown>): Date => {
 /**
  * Internal method to compute next run time from the repeat string
  */
-export function computeFromRepeatAt(attrs: IJobParameters<unknown>): Date {
+export function computeFromRepeatAt(attrs: JobParameters<unknown>): Date {
 	const lastRun = attrs.lastRunAt || new Date();
 	const repeatAt = attrs.repeatAt;
 	if (!repeatAt) {

--- a/packages/agenda/test/shared/agenda-test-suite.ts
+++ b/packages/agenda/test/shared/agenda-test-suite.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
 import type { ForkOptions } from 'child_process';
-import type { IAgendaBackend, INotificationChannel } from '../../src/index.js';
+import type { AgendaBackend, NotificationChannel } from '../../src/index.js';
 import { Agenda } from '../../src/index.js';
 import { Job } from '../../src/Job.js';
 import { delay, waitForEvent, waitForEvents } from './test-utils.js';
@@ -17,15 +17,15 @@ export interface AgendaTestConfig {
 	/** Name for the test suite */
 	name: string;
 	/** Factory to create a fresh backend instance */
-	createBackend: () => Promise<IAgendaBackend>;
+	createBackend: () => Promise<AgendaBackend>;
 	/** Cleanup function called after tests */
-	cleanupBackend: (backend: IAgendaBackend) => Promise<void>;
+	cleanupBackend: (backend: AgendaBackend) => Promise<void>;
 	/** Clear all jobs between tests */
-	clearJobs: (backend: IAgendaBackend) => Promise<void>;
+	clearJobs: (backend: AgendaBackend) => Promise<void>;
 	/** Optional notification channel factory */
-	createNotificationChannel?: () => Promise<INotificationChannel>;
+	createNotificationChannel?: () => Promise<NotificationChannel>;
 	/** Cleanup notification channel */
-	cleanupNotificationChannel?: (channel: INotificationChannel) => Promise<void>;
+	cleanupNotificationChannel?: (channel: NotificationChannel) => Promise<void>;
 	/** Fork mode configuration (required if forkMode tests are enabled) */
 	forkHelper?: ForkHelperConfig;
 	/** Skip specific tests if not supported */
@@ -36,7 +36,7 @@ export interface AgendaTestConfig {
 
 export function agendaTestSuite(config: AgendaTestConfig): void {
 	describe(`${config.name} - Agenda Integration`, () => {
-		let backend: IAgendaBackend;
+		let backend: AgendaBackend;
 		let agenda: Agenda;
 
 		const jobProcessor = () => {};
@@ -1338,7 +1338,7 @@ export function agendaTestSuite(config: AgendaTestConfig): void {
 		// Notification channel integration tests - only run if channel is provided
 		if (config.createNotificationChannel) {
 			describe('notification channel integration', () => {
-				let notificationChannel: INotificationChannel;
+				let notificationChannel: NotificationChannel;
 				let agendaWithChannel: Agenda;
 
 				beforeEach(async () => {

--- a/packages/agenda/test/shared/full-test-suite.ts
+++ b/packages/agenda/test/shared/full-test-suite.ts
@@ -26,7 +26,7 @@
  * ```
  */
 
-import type { IAgendaBackend, INotificationChannel } from '../../src/index.js';
+import type { AgendaBackend, NotificationChannel } from '../../src/index.js';
 import { repositoryTestSuite } from './repository-test-suite.js';
 import { agendaTestSuite, type ForkHelperConfig } from './agenda-test-suite.js';
 import { jobProcessorTestSuite } from './jobprocessor-test-suite.js';
@@ -36,15 +36,15 @@ export interface FullAgendaTestConfig {
 	/** Name for the test suite (e.g., 'MongoDB', 'PostgreSQL') */
 	name: string;
 	/** Factory to create a fresh backend instance */
-	createBackend: () => Promise<IAgendaBackend>;
+	createBackend: () => Promise<AgendaBackend>;
 	/** Cleanup function called after tests */
-	cleanupBackend: (backend: IAgendaBackend) => Promise<void>;
+	cleanupBackend: (backend: AgendaBackend) => Promise<void>;
 	/** Clear all jobs between tests */
-	clearJobs: (backend: IAgendaBackend) => Promise<void>;
+	clearJobs: (backend: AgendaBackend) => Promise<void>;
 	/** Optional notification channel factory for testing notification integration */
-	createNotificationChannel?: () => Promise<INotificationChannel>;
+	createNotificationChannel?: () => Promise<NotificationChannel>;
 	/** Cleanup notification channel */
-	cleanupNotificationChannel?: (channel: INotificationChannel) => Promise<void>;
+	cleanupNotificationChannel?: (channel: NotificationChannel) => Promise<void>;
 	/** Fork mode configuration (backend-specific fork helper) */
 	forkHelper?: ForkHelperConfig;
 	/** Skip specific test suites */

--- a/packages/agenda/test/shared/jobprocessor-test-suite.ts
+++ b/packages/agenda/test/shared/jobprocessor-test-suite.ts
@@ -17,7 +17,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
-import type { IAgendaBackend } from '../../src/index.js';
+import type { AgendaBackend } from '../../src/index.js';
 import { Agenda } from '../../src/index.js';
 import { delay } from './test-utils.js';
 
@@ -25,11 +25,11 @@ export interface JobProcessorTestConfig {
 	/** Name for the test suite */
 	name: string;
 	/** Factory to create a fresh backend instance */
-	createBackend: () => Promise<IAgendaBackend>;
+	createBackend: () => Promise<AgendaBackend>;
 	/** Cleanup function called after tests */
-	cleanupBackend: (backend: IAgendaBackend) => Promise<void>;
+	cleanupBackend: (backend: AgendaBackend) => Promise<void>;
 	/** Clear all jobs between tests */
-	clearJobs: (backend: IAgendaBackend) => Promise<void>;
+	clearJobs: (backend: AgendaBackend) => Promise<void>;
 }
 
 /**
@@ -37,7 +37,7 @@ export interface JobProcessorTestConfig {
  */
 export function jobProcessorTestSuite(config: JobProcessorTestConfig): void {
 	describe(`${config.name} - JobProcessor`, () => {
-		let backend: IAgendaBackend;
+		let backend: AgendaBackend;
 		let agenda: Agenda;
 
 		beforeAll(async () => {

--- a/packages/agenda/test/shared/notification-channel-test-suite.ts
+++ b/packages/agenda/test/shared/notification-channel-test-suite.ts
@@ -1,8 +1,8 @@
 /**
- * Shared test suite for INotificationChannel implementations
+ * Shared test suite for NotificationChannel implementations
  *
  * This file exports test suite factories that can be used to test any
- * INotificationChannel implementation (InMemory, PostgreSQL LISTEN/NOTIFY, Redis, etc.)
+ * NotificationChannel implementation (InMemory, PostgreSQL LISTEN/NOTIFY, Redis, etc.)
  *
  * Usage:
  * ```typescript
@@ -22,7 +22,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import type { INotificationChannel, IJobNotification, JobId } from '../../src/index.js';
+import type { NotificationChannel, JobNotification, JobId } from '../../src/index.js';
 import { toJobId } from '../../src/index.js';
 import { delay } from './test-utils.js';
 
@@ -30,9 +30,9 @@ export interface NotificationChannelTestConfig {
 	/** Name for the test suite */
 	name: string;
 	/** Factory to create a fresh channel instance (not connected) */
-	createChannel: () => Promise<INotificationChannel>;
+	createChannel: () => Promise<NotificationChannel>;
 	/** Cleanup function called after each test */
-	cleanupChannel: (channel: INotificationChannel) => Promise<void>;
+	cleanupChannel: (channel: NotificationChannel) => Promise<void>;
 	/** Delay in ms to wait for notifications to propagate (default: 100) */
 	propagationDelay?: number;
 }
@@ -40,7 +40,7 @@ export interface NotificationChannelTestConfig {
 /**
  * Helper to create a test notification
  */
-function createTestNotification(overrides: Partial<IJobNotification> = {}): IJobNotification {
+function createTestNotification(overrides: Partial<JobNotification> = {}): JobNotification {
 	return {
 		jobId: toJobId('test-job-id') as JobId,
 		jobName: 'test-job',
@@ -52,13 +52,13 @@ function createTestNotification(overrides: Partial<IJobNotification> = {}): IJob
 }
 
 /**
- * Creates a test suite for INotificationChannel implementations
+ * Creates a test suite for NotificationChannel implementations
  */
 export function notificationChannelTestSuite(config: NotificationChannelTestConfig): void {
 	const propagationDelay = config.propagationDelay ?? 100;
 
-	describe(`${config.name} - INotificationChannel`, () => {
-		let channel: INotificationChannel;
+	describe(`${config.name} - NotificationChannel`, () => {
+		let channel: NotificationChannel;
 
 		beforeEach(async () => {
 			channel = await config.createChannel();
@@ -107,7 +107,7 @@ export function notificationChannelTestSuite(config: NotificationChannelTestConf
 			});
 
 			it('should publish and receive notifications', async () => {
-				const received: IJobNotification[] = [];
+				const received: JobNotification[] = [];
 
 				channel.subscribe(notification => {
 					received.push(notification);
@@ -127,8 +127,8 @@ export function notificationChannelTestSuite(config: NotificationChannelTestConf
 			});
 
 			it('should support multiple subscribers', async () => {
-				const received1: IJobNotification[] = [];
-				const received2: IJobNotification[] = [];
+				const received1: JobNotification[] = [];
+				const received2: JobNotification[] = [];
 
 				channel.subscribe(n => { received1.push(n); });
 				channel.subscribe(n => { received2.push(n); });
@@ -141,7 +141,7 @@ export function notificationChannelTestSuite(config: NotificationChannelTestConf
 			});
 
 			it('should allow unsubscribing', async () => {
-				const received: IJobNotification[] = [];
+				const received: JobNotification[] = [];
 
 				const unsubscribe = channel.subscribe(notification => {
 					received.push(notification);
@@ -162,7 +162,7 @@ export function notificationChannelTestSuite(config: NotificationChannelTestConf
 			});
 
 			it('should preserve notification data through serialization', async () => {
-				const received: IJobNotification[] = [];
+				const received: JobNotification[] = [];
 				channel.subscribe(n => { received.push(n); });
 
 				const originalDate = new Date('2024-01-15T10:30:00.000Z');
@@ -186,7 +186,7 @@ export function notificationChannelTestSuite(config: NotificationChannelTestConf
 			});
 
 			it('should handle null nextRunAt', async () => {
-				const received: IJobNotification[] = [];
+				const received: JobNotification[] = [];
 				channel.subscribe(n => { received.push(n); });
 
 				await channel.publish(createTestNotification({ nextRunAt: null }));
@@ -197,7 +197,7 @@ export function notificationChannelTestSuite(config: NotificationChannelTestConf
 			});
 
 			it('should handle multiple rapid notifications', async () => {
-				const received: IJobNotification[] = [];
+				const received: JobNotification[] = [];
 				channel.subscribe(n => { received.push(n); });
 
 				const count = 5;

--- a/packages/agenda/test/shared/repository-test-suite.ts
+++ b/packages/agenda/test/shared/repository-test-suite.ts
@@ -1,8 +1,8 @@
 /**
- * Shared test suite for IJobRepository implementations
+ * Shared test suite for JobRepository implementations
  *
  * This file exports test suite factories that can be used to test any
- * IJobRepository implementation (MongoDB, PostgreSQL, etc.)
+ * JobRepository implementation (MongoDB, PostgreSQL, etc.)
  *
  * Usage:
  * ```typescript
@@ -23,17 +23,17 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import type { IJobRepository, IJobParameters } from '../../src/index.js';
+import type { JobRepository, JobParameters } from '../../src/index.js';
 
 export interface RepositoryTestConfig {
 	/** Name for the test suite */
 	name: string;
 	/** Factory to create a fresh repository instance */
-	createRepository: () => Promise<IJobRepository>;
+	createRepository: () => Promise<JobRepository>;
 	/** Cleanup function called after each test */
-	cleanupRepository: (repo: IJobRepository) => Promise<void>;
+	cleanupRepository: (repo: JobRepository) => Promise<void>;
 	/** Optional: clear all jobs between tests (if not provided, uses removeJobs) */
-	clearJobs?: (repo: IJobRepository) => Promise<void>;
+	clearJobs?: (repo: JobRepository) => Promise<void>;
 	/** Skip specific tests if not supported by the backend */
 	skip?: {
 		uniqueConstraints?: boolean;
@@ -42,11 +42,11 @@ export interface RepositoryTestConfig {
 }
 
 /**
- * Creates a test suite for IJobRepository implementations
+ * Creates a test suite for JobRepository implementations
  */
 export function repositoryTestSuite(config: RepositoryTestConfig): void {
-	describe(`${config.name} - IJobRepository`, () => {
-		let repo: IJobRepository;
+	describe(`${config.name} - JobRepository`, () => {
+		let repo: JobRepository;
 
 		const clearJobs = async () => {
 			if (config.clearJobs) {
@@ -72,7 +72,7 @@ export function repositoryTestSuite(config: RepositoryTestConfig): void {
 
 		describe('saveJob', () => {
 			it('should save a new job and assign an ID', async () => {
-				const job: IJobParameters = {
+				const job: JobParameters = {
 					name: 'test-job',
 					priority: 10,
 					nextRunAt: new Date(),
@@ -90,7 +90,7 @@ export function repositoryTestSuite(config: RepositoryTestConfig): void {
 			});
 
 			it('should update an existing job', async () => {
-				const job: IJobParameters = {
+				const job: JobParameters = {
 					name: 'update-test',
 					priority: 5,
 					nextRunAt: new Date(),
@@ -111,7 +111,7 @@ export function repositoryTestSuite(config: RepositoryTestConfig): void {
 			});
 
 			it('should handle single type jobs (upsert by name)', async () => {
-				const job1: IJobParameters = {
+				const job1: JobParameters = {
 					name: 'single-job',
 					priority: 5,
 					nextRunAt: new Date(Date.now() + 60000),
@@ -121,7 +121,7 @@ export function repositoryTestSuite(config: RepositoryTestConfig): void {
 
 				const saved1 = await repo.saveJob(job1, undefined);
 
-				const job2: IJobParameters = {
+				const job2: JobParameters = {
 					name: 'single-job',
 					priority: 10,
 					nextRunAt: new Date(Date.now() + 120000),
@@ -140,7 +140,7 @@ export function repositoryTestSuite(config: RepositoryTestConfig): void {
 			});
 
 			it('should preserve disabled flag', async () => {
-				const job: IJobParameters = {
+				const job: JobParameters = {
 					name: 'disabled-job',
 					priority: 0,
 					nextRunAt: new Date(),

--- a/packages/agenda/test/shared/retry-test-suite.ts
+++ b/packages/agenda/test/shared/retry-test-suite.ts
@@ -17,18 +17,18 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
-import type { IAgendaBackend } from '../../src/index.js';
+import type { AgendaBackend } from '../../src/index.js';
 import { Agenda } from '../../src/index.js';
 
 export interface RetryTestConfig {
 	/** Name for the test suite */
 	name: string;
 	/** Factory to create a fresh backend instance */
-	createBackend: () => Promise<IAgendaBackend>;
+	createBackend: () => Promise<AgendaBackend>;
 	/** Cleanup function called after tests */
-	cleanupBackend: (backend: IAgendaBackend) => Promise<void>;
+	cleanupBackend: (backend: AgendaBackend) => Promise<void>;
 	/** Clear all jobs between tests */
-	clearJobs: (backend: IAgendaBackend) => Promise<void>;
+	clearJobs: (backend: AgendaBackend) => Promise<void>;
 }
 
 /**
@@ -36,7 +36,7 @@ export interface RetryTestConfig {
  */
 export function retryTestSuite(config: RetryTestConfig): void {
 	describe(`${config.name} - Retry`, () => {
-		let backend: IAgendaBackend;
+		let backend: AgendaBackend;
 		let agenda: Agenda;
 
 		beforeAll(async () => {

--- a/packages/agenda/test/unit.test.ts
+++ b/packages/agenda/test/unit.test.ts
@@ -5,13 +5,13 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Agenda, Job, toJobId } from '../src/index.js';
-import type { IAgendaBackend, IJobRepository, IJobParameters } from '../src/index.js';
+import type { AgendaBackend, JobRepository, JobParameters } from '../src/index.js';
 
 /**
  * Minimal mock repository that satisfies the interface without real storage.
  * Used for unit tests that don't need actual database operations.
  */
-class MockJobRepository implements IJobRepository {
+class MockJobRepository implements JobRepository {
 	async connect(): Promise<void> {}
 	async queryJobs() {
 		return { jobs: [], total: 0 };
@@ -31,7 +31,7 @@ class MockJobRepository implements IJobRepository {
 	async removeJobs() {
 		return 0;
 	}
-	async saveJob<DATA = unknown>(job: IJobParameters<DATA>): Promise<IJobParameters<DATA>> {
+	async saveJob<DATA = unknown>(job: JobParameters<DATA>): Promise<JobParameters<DATA>> {
 		return { ...job, _id: job._id || toJobId('mock-id') };
 	}
 	async saveJobState() {}
@@ -48,7 +48,7 @@ class MockJobRepository implements IJobRepository {
 /**
  * Minimal mock backend for unit tests
  */
-class MockBackend implements IAgendaBackend {
+class MockBackend implements AgendaBackend {
 	readonly repository = new MockJobRepository();
 	async connect(): Promise<void> {}
 	async disconnect(): Promise<void> {}

--- a/packages/agendash/src/AgendashController.ts
+++ b/packages/agendash/src/AgendashController.ts
@@ -1,14 +1,14 @@
-import type { Agenda, JobState, IJobWithState, IJobsOverview } from 'agenda';
+import type { Agenda, JobState, JobWithState, JobsOverview } from 'agenda';
 import type {
-	IAgendashController,
-	IApiQueryParams,
-	IApiResponse,
-	ICreateJobRequest,
-	ICreateJobResponse,
-	IDeleteResponse,
-	IRequeueResponse,
-	IFrontendJob,
-	IFrontendOverview
+	AgendashController as IAgendashController,
+	ApiQueryParams,
+	ApiResponse,
+	CreateJobRequest,
+	CreateJobResponse,
+	DeleteResponse,
+	RequeueResponse,
+	FrontendJob,
+	FrontendOverview
 } from './types.js';
 
 /**
@@ -25,7 +25,7 @@ export class AgendashController implements IAgendashController {
 	/**
 	 * Transform a job from the new API format to the frontend format
 	 */
-	private transformJob(job: IJobWithState): IFrontendJob {
+	private transformJob(job: JobWithState): FrontendJob {
 		return {
 			job: {
 				_id: String(job._id),
@@ -54,7 +54,7 @@ export class AgendashController implements IAgendashController {
 	/**
 	 * Transform overview from new API format to frontend format
 	 */
-	private transformOverview(overviews: IJobsOverview[]): IFrontendOverview[] {
+	private transformOverview(overviews: JobsOverview[]): FrontendOverview[] {
 		// Calculate totals for "All Jobs" entry
 		const totals = overviews.reduce(
 			(acc, o) => ({
@@ -69,12 +69,12 @@ export class AgendashController implements IAgendashController {
 			{ total: 0, running: 0, scheduled: 0, queued: 0, completed: 0, failed: 0, repeating: 0 }
 		);
 
-		const allJobsEntry: IFrontendOverview = {
+		const allJobsEntry: FrontendOverview = {
 			displayName: 'All Jobs',
 			...totals
 		};
 
-		const jobOverviews: IFrontendOverview[] = overviews.map((o) => ({
+		const jobOverviews: FrontendOverview[] = overviews.map((o) => ({
 			displayName: o.name,
 			total: o.total,
 			running: o.running,
@@ -91,7 +91,7 @@ export class AgendashController implements IAgendashController {
 	/**
 	 * Get jobs with overview and filtering
 	 */
-	async getJobs(params: IApiQueryParams): Promise<IApiResponse> {
+	async getJobs(params: ApiQueryParams): Promise<ApiResponse> {
 		const { name, state, search, skip = 0, limit = 50 } = params;
 
 		const [overview, result] = await Promise.all([
@@ -121,7 +121,7 @@ export class AgendashController implements IAgendashController {
 	/**
 	 * Requeue jobs by creating new instances
 	 */
-	async requeueJobs(ids: string[]): Promise<IRequeueResponse> {
+	async requeueJobs(ids: string[]): Promise<RequeueResponse> {
 		if (!ids || ids.length === 0) {
 			return { requeuedCount: 0 };
 		}
@@ -140,7 +140,7 @@ export class AgendashController implements IAgendashController {
 	/**
 	 * Delete jobs by ID
 	 */
-	async deleteJobs(ids: string[]): Promise<IDeleteResponse> {
+	async deleteJobs(ids: string[]): Promise<DeleteResponse> {
 		if (!ids || ids.length === 0) {
 			return { deleted: false, deletedCount: 0 };
 		}
@@ -155,7 +155,7 @@ export class AgendashController implements IAgendashController {
 	/**
 	 * Create a new job
 	 */
-	async createJob(options: ICreateJobRequest): Promise<ICreateJobResponse> {
+	async createJob(options: CreateJobRequest): Promise<CreateJobResponse> {
 		const { jobName, jobSchedule, jobRepeatEvery, jobData } = options;
 
 		if (!jobName) {

--- a/packages/agendash/src/middlewares/express.ts
+++ b/packages/agendash/src/middlewares/express.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'url';
 import type { Agenda } from 'agenda';
 import { AgendashController } from '../AgendashController.js';
 import { cspHeader } from '../csp.js';
-import type { IApiQueryParams, ICreateJobRequest, IDeleteRequest, IRequeueRequest } from '../types.js';
+import type { ApiQueryParams, CreateJobRequest, DeleteRequest, RequeueRequest } from '../types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -44,7 +44,7 @@ export function createExpressMiddleware(agenda: Agenda): Router {
 	router.get('/api', async (req, res) => {
 		try {
 			const query = req.query as Record<string, string | undefined>;
-			const params: IApiQueryParams = {
+			const params: ApiQueryParams = {
 				name: query.job,
 				state: query.state,
 				search: query.q,
@@ -62,7 +62,7 @@ export function createExpressMiddleware(agenda: Agenda): Router {
 
 	router.post('/api/jobs/requeue', async (req, res) => {
 		try {
-			const { jobIds } = req.body as IRequeueRequest;
+			const { jobIds } = req.body as RequeueRequest;
 			const result = await controller.requeueJobs(jobIds);
 			res.json(result);
 		} catch (error) {
@@ -72,7 +72,7 @@ export function createExpressMiddleware(agenda: Agenda): Router {
 
 	router.post('/api/jobs/delete', async (req, res) => {
 		try {
-			const { jobIds } = req.body as IDeleteRequest;
+			const { jobIds } = req.body as DeleteRequest;
 			const result = await controller.deleteJobs(jobIds);
 			res.json(result);
 		} catch (error) {
@@ -82,7 +82,7 @@ export function createExpressMiddleware(agenda: Agenda): Router {
 
 	router.post('/api/jobs/create', async (req, res) => {
 		try {
-			const options = req.body as ICreateJobRequest;
+			const options = req.body as CreateJobRequest;
 			const result = await controller.createJob(options);
 			res.json(result);
 		} catch (error) {

--- a/packages/agendash/src/middlewares/fastify.ts
+++ b/packages/agendash/src/middlewares/fastify.ts
@@ -4,7 +4,7 @@ import type { Agenda } from 'agenda';
 import type { FastifyInstance, FastifyPluginCallback, FastifyRequest, FastifyReply } from 'fastify';
 import { AgendashController } from '../AgendashController.js';
 import { cspHeader } from '../csp.js';
-import type { IApiQueryParams, ICreateJobRequest, IDeleteRequest, IRequeueRequest } from '../types.js';
+import type { ApiQueryParams, CreateJobRequest, DeleteRequest, RequeueRequest } from '../types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -55,7 +55,7 @@ export function createFastifyPlugin(agenda: Agenda): FastifyPluginCallback {
 			async (request: FastifyRequest<{ Querystring: ApiQuerystring }>, reply: FastifyReply) => {
 				try {
 					const { job, state, q, property, isObjectId, skip, limit } = request.query;
-					const params: IApiQueryParams = {
+					const params: ApiQueryParams = {
 						name: job,
 						state,
 						search: q,
@@ -74,9 +74,9 @@ export function createFastifyPlugin(agenda: Agenda): FastifyPluginCallback {
 			}
 		);
 
-		instance.post<{ Body: IRequeueRequest }>(
+		instance.post<{ Body: RequeueRequest }>(
 			'/api/jobs/requeue',
-			async (request: FastifyRequest<{ Body: IRequeueRequest }>, reply: FastifyReply) => {
+			async (request: FastifyRequest<{ Body: RequeueRequest }>, reply: FastifyReply) => {
 				try {
 					const { jobIds } = request.body;
 					const result = await controller.requeueJobs(jobIds);
@@ -89,9 +89,9 @@ export function createFastifyPlugin(agenda: Agenda): FastifyPluginCallback {
 			}
 		);
 
-		instance.post<{ Body: IDeleteRequest }>(
+		instance.post<{ Body: DeleteRequest }>(
 			'/api/jobs/delete',
-			async (request: FastifyRequest<{ Body: IDeleteRequest }>, reply: FastifyReply) => {
+			async (request: FastifyRequest<{ Body: DeleteRequest }>, reply: FastifyReply) => {
 				try {
 					const { jobIds } = request.body;
 					const result = await controller.deleteJobs(jobIds);
@@ -104,9 +104,9 @@ export function createFastifyPlugin(agenda: Agenda): FastifyPluginCallback {
 			}
 		);
 
-		instance.post<{ Body: ICreateJobRequest }>(
+		instance.post<{ Body: CreateJobRequest }>(
 			'/api/jobs/create',
-			async (request: FastifyRequest<{ Body: ICreateJobRequest }>, reply: FastifyReply) => {
+			async (request: FastifyRequest<{ Body: CreateJobRequest }>, reply: FastifyReply) => {
 				try {
 					const result = await controller.createJob(request.body);
 					return reply.send(result);

--- a/packages/agendash/src/middlewares/hapi.ts
+++ b/packages/agendash/src/middlewares/hapi.ts
@@ -4,7 +4,7 @@ import type { Agenda } from 'agenda';
 import type { Server, Plugin, Request, ResponseToolkit } from '@hapi/hapi';
 import { AgendashController } from '../AgendashController.js';
 import { cspHeader } from '../csp.js';
-import type { IApiQueryParams, ICreateJobRequest, IDeleteRequest, IRequeueRequest } from '../types.js';
+import type { ApiQueryParams, CreateJobRequest, DeleteRequest, RequeueRequest } from '../types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -82,7 +82,7 @@ export function createHapiPlugin(agenda: Agenda): Plugin<AgendashHapiOptions> {
 				handler: async (request: Request, h: ResponseToolkit) => {
 					try {
 						const query = request.query as ApiQuery;
-						const params: IApiQueryParams = {
+						const params: ApiQueryParams = {
 							name: query.job,
 							state: query.state,
 							search: query.q,
@@ -108,7 +108,7 @@ export function createHapiPlugin(agenda: Agenda): Plugin<AgendashHapiOptions> {
 				path: '/api/jobs/requeue',
 				handler: async (request: Request, h: ResponseToolkit) => {
 					try {
-						const { jobIds } = request.payload as IRequeueRequest;
+						const { jobIds } = request.payload as RequeueRequest;
 						return await controller.requeueJobs(jobIds);
 					} catch (error) {
 						return h
@@ -126,7 +126,7 @@ export function createHapiPlugin(agenda: Agenda): Plugin<AgendashHapiOptions> {
 				path: '/api/jobs/delete',
 				handler: async (request: Request, h: ResponseToolkit) => {
 					try {
-						const { jobIds } = request.payload as IDeleteRequest;
+						const { jobIds } = request.payload as DeleteRequest;
 						const result = await controller.deleteJobs(jobIds);
 						if (result.deleted) {
 							return h.response(result);
@@ -148,7 +148,7 @@ export function createHapiPlugin(agenda: Agenda): Plugin<AgendashHapiOptions> {
 				path: '/api/jobs/create',
 				handler: async (request: Request, h: ResponseToolkit) => {
 					try {
-						const options = request.payload as ICreateJobRequest;
+						const options = request.payload as CreateJobRequest;
 						return await controller.createJob(options);
 					} catch (error) {
 						return h

--- a/packages/agendash/src/middlewares/koa.ts
+++ b/packages/agendash/src/middlewares/koa.ts
@@ -4,7 +4,7 @@ import type { Agenda } from 'agenda';
 import type { Middleware, Context, Next } from 'koa';
 import { AgendashController } from '../AgendashController.js';
 import { cspHeader } from '../csp.js';
-import type { IApiQueryParams, ICreateJobRequest, IDeleteRequest, IRequeueRequest } from '../types.js';
+import type { ApiQueryParams, CreateJobRequest, DeleteRequest, RequeueRequest } from '../types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -70,7 +70,7 @@ export async function createKoaMiddlewareAsync(agenda: Agenda): Promise<Middlewa
 	router.get('/api', async (ctx) => {
 		const query = ctx.query as Record<string, string | undefined>;
 		try {
-			const params: IApiQueryParams = {
+			const params: ApiQueryParams = {
 				name: query.job,
 				state: query.state,
 				search: query.q,
@@ -88,7 +88,7 @@ export async function createKoaMiddlewareAsync(agenda: Agenda): Promise<Middlewa
 
 	router.post('/api/jobs/requeue', async (ctx) => {
 		try {
-			const { jobIds } = ctx.request.body as IRequeueRequest;
+			const { jobIds } = ctx.request.body as RequeueRequest;
 			ctx.body = await controller.requeueJobs(jobIds);
 		} catch (error) {
 			ctx.status = 404;
@@ -98,7 +98,7 @@ export async function createKoaMiddlewareAsync(agenda: Agenda): Promise<Middlewa
 
 	router.post('/api/jobs/delete', async (ctx) => {
 		try {
-			const { jobIds } = ctx.request.body as IDeleteRequest;
+			const { jobIds } = ctx.request.body as DeleteRequest;
 			ctx.body = await controller.deleteJobs(jobIds);
 		} catch (error) {
 			ctx.status = 404;
@@ -108,7 +108,7 @@ export async function createKoaMiddlewareAsync(agenda: Agenda): Promise<Middlewa
 
 	router.post('/api/jobs/create', async (ctx) => {
 		try {
-			const options = ctx.request.body as ICreateJobRequest;
+			const options = ctx.request.body as CreateJobRequest;
 			ctx.body = await controller.createJob(options);
 		} catch (error) {
 			ctx.status = 400;

--- a/packages/agendash/src/types.ts
+++ b/packages/agendash/src/types.ts
@@ -3,7 +3,7 @@ import type { Agenda } from 'agenda';
 /**
  * Query parameters for the API
  */
-export interface IApiQueryParams {
+export interface ApiQueryParams {
 	/** Filter by job name */
 	name?: string;
 	/** Filter by computed state */
@@ -23,7 +23,7 @@ export interface IApiQueryParams {
 /**
  * Frontend job data structure (nested under 'job' key)
  */
-export interface IFrontendJobData {
+export interface FrontendJobData {
 	_id: string;
 	name: string;
 	data?: unknown;
@@ -42,8 +42,8 @@ export interface IFrontendJobData {
 /**
  * Frontend job structure with state flags
  */
-export interface IFrontendJob {
-	job: IFrontendJobData;
+export interface FrontendJob {
+	job: FrontendJobData;
 	running: boolean;
 	scheduled: boolean;
 	queued: boolean;
@@ -55,7 +55,7 @@ export interface IFrontendJob {
 /**
  * Frontend overview structure with displayName
  */
-export interface IFrontendOverview {
+export interface FrontendOverview {
 	displayName: string;
 	total: number;
 	running: number;
@@ -69,9 +69,9 @@ export interface IFrontendOverview {
 /**
  * Response from the API
  */
-export interface IApiResponse {
-	overview: IFrontendOverview[];
-	jobs: IFrontendJob[];
+export interface ApiResponse {
+	overview: FrontendOverview[];
+	jobs: FrontendJob[];
 	total: number;
 	totalPages: number;
 }
@@ -79,28 +79,28 @@ export interface IApiResponse {
 /**
  * Options for requeuing jobs
  */
-export interface IRequeueRequest {
+export interface RequeueRequest {
 	jobIds: string[];
 }
 
 /**
  * Response from requeue operation
  */
-export interface IRequeueResponse {
+export interface RequeueResponse {
 	requeuedCount: number;
 }
 
 /**
  * Options for deleting jobs
  */
-export interface IDeleteRequest {
+export interface DeleteRequest {
 	jobIds: string[];
 }
 
 /**
  * Response from delete operation
  */
-export interface IDeleteResponse {
+export interface DeleteResponse {
 	deleted: boolean;
 	deletedCount?: number;
 }
@@ -108,7 +108,7 @@ export interface IDeleteResponse {
 /**
  * Options for creating a job
  */
-export interface ICreateJobRequest {
+export interface CreateJobRequest {
 	jobName: string;
 	jobSchedule?: string;
 	jobRepeatEvery?: string;
@@ -118,18 +118,18 @@ export interface ICreateJobRequest {
 /**
  * Response from create operation
  */
-export interface ICreateJobResponse {
+export interface CreateJobResponse {
 	created: boolean;
 }
 
 /**
  * Agendash controller interface
  */
-export interface IAgendashController {
-	getJobs(params: IApiQueryParams): Promise<IApiResponse>;
-	requeueJobs(ids: string[]): Promise<IRequeueResponse>;
-	deleteJobs(ids: string[]): Promise<IDeleteResponse>;
-	createJob(options: ICreateJobRequest): Promise<ICreateJobResponse>;
+export interface AgendashController {
+	getJobs(params: ApiQueryParams): Promise<ApiResponse>;
+	requeueJobs(ids: string[]): Promise<RequeueResponse>;
+	deleteJobs(ids: string[]): Promise<DeleteResponse>;
+	createJob(options: CreateJobRequest): Promise<CreateJobResponse>;
 }
 
 /**

--- a/packages/mongo-backend/src/MongoBackend.ts
+++ b/packages/mongo-backend/src/MongoBackend.ts
@@ -1,6 +1,6 @@
-import type { IAgendaBackend, IJobRepository, INotificationChannel } from 'agenda';
+import type { AgendaBackend, JobRepository, NotificationChannel } from 'agenda';
 import { MongoJobRepository } from './MongoJobRepository.js';
-import type { IMongoBackendConfig } from './types.js';
+import type { MongoBackendConfig } from './types.js';
 
 /**
  * MongoDB backend for Agenda.
@@ -20,7 +20,7 @@ import type { IMongoBackendConfig } from './types.js';
  * const agenda = new Agenda({ backend });
  * ```
  */
-export class MongoBackend implements IAgendaBackend {
+export class MongoBackend implements AgendaBackend {
 	private _repository: MongoJobRepository;
 	private _ownsConnection: boolean;
 
@@ -29,9 +29,9 @@ export class MongoBackend implements IAgendaBackend {
 	 * For real-time notifications with MongoDB, use a separate notification
 	 * channel like Redis pub/sub.
 	 */
-	readonly notificationChannel: INotificationChannel | undefined = undefined;
+	readonly notificationChannel: NotificationChannel | undefined = undefined;
 
-	constructor(private config: IMongoBackendConfig) {
+	constructor(private config: MongoBackendConfig) {
 		// Determine if we own the connection (not passed in by user)
 		this._ownsConnection = !('mongo' in config);
 		this._repository = new MongoJobRepository({
@@ -45,7 +45,7 @@ export class MongoBackend implements IAgendaBackend {
 		});
 	}
 
-	get repository(): IJobRepository {
+	get repository(): JobRepository {
 		return this._repository;
 	}
 

--- a/packages/mongo-backend/src/index.ts
+++ b/packages/mongo-backend/src/index.ts
@@ -33,7 +33,7 @@
 export { MongoBackend } from './MongoBackend.js';
 export { MongoJobRepository } from './MongoJobRepository.js';
 
-export type { IMongoBackendConfig, IMongoJobRepositoryConfig, IMongoDbConfig } from './types.js';
+export type { MongoBackendConfig, MongoJobRepositoryConfig, MongoDbConfig } from './types.js';
 
 // Re-export mongodb types that users might need
 export type { Db, MongoClientOptions } from 'mongodb';

--- a/packages/mongo-backend/src/types.ts
+++ b/packages/mongo-backend/src/types.ts
@@ -18,7 +18,7 @@ export type MongoConnectionConfig =
 			options?: MongoClientOptions;
 	  };
 
-export type IMongoBackendConfig = MongoConnectionConfig & {
+export type MongoBackendConfig = MongoConnectionConfig & {
 	/** Collection name for jobs (default: 'agendaJobs') */
 	collection?: string;
 
@@ -32,7 +32,7 @@ export type IMongoBackendConfig = MongoConnectionConfig & {
 /**
  * Database configuration options used internally by the repository
  */
-export interface IMongoDbConfig {
+export interface MongoDbConfig {
 	ensureIndex?: boolean;
 	sort?: {
 		[key: string]: SortDirection;
@@ -42,7 +42,7 @@ export interface IMongoDbConfig {
 /**
  * Configuration options for MongoJobRepository
  */
-export type IMongoJobRepositoryConfig = IMongoDbConfig &
+export type MongoJobRepositoryConfig = MongoDbConfig &
 	(
 		| {
 				/** MongoDB connection string */

--- a/packages/postgres-backend/src/PostgresBackend.ts
+++ b/packages/postgres-backend/src/PostgresBackend.ts
@@ -1,8 +1,8 @@
 import debug from 'debug';
-import type { IAgendaBackend, IJobRepository, INotificationChannel } from 'agenda';
+import type { AgendaBackend, JobRepository, NotificationChannel } from 'agenda';
 import { PostgresJobRepository } from './PostgresJobRepository.js';
 import { PostgresNotificationChannel } from './PostgresNotificationChannel.js';
-import type { IPostgresBackendConfig } from './types.js';
+import type { PostgresBackendConfig } from './types.js';
 
 const log = debug('agenda:postgres:backend');
 
@@ -43,13 +43,13 @@ const log = debug('agenda:postgres:backend');
  * await agenda.every('5 minutes', 'myJob');
  * ```
  */
-export class PostgresBackend implements IAgendaBackend {
+export class PostgresBackend implements AgendaBackend {
 	private _repository: PostgresJobRepository;
 	private _notificationChannel?: PostgresNotificationChannel;
-	private config: IPostgresBackendConfig;
+	private config: PostgresBackendConfig;
 	private _ownsConnection: boolean;
 
-	constructor(config: IPostgresBackendConfig) {
+	constructor(config: PostgresBackendConfig) {
 		this.config = config;
 
 		// Determine if we own the connection (not passed in by user)
@@ -80,7 +80,7 @@ export class PostgresBackend implements IAgendaBackend {
 	/**
 	 * The job repository for storage operations
 	 */
-	get repository(): IJobRepository {
+	get repository(): JobRepository {
 		return this._repository;
 	}
 
@@ -96,7 +96,7 @@ export class PostgresBackend implements IAgendaBackend {
 	 * The notification channel for real-time notifications via LISTEN/NOTIFY
 	 * Returns undefined if notifications are disabled
 	 */
-	get notificationChannel(): INotificationChannel | undefined {
+	get notificationChannel(): NotificationChannel | undefined {
 		return this._notificationChannel;
 	}
 

--- a/packages/postgres-backend/src/PostgresNotificationChannel.ts
+++ b/packages/postgres-backend/src/PostgresNotificationChannel.ts
@@ -1,6 +1,6 @@
 import debug from 'debug';
 import { Pool, PoolClient } from 'pg';
-import type { IJobNotification, INotificationChannelConfig, JobId } from 'agenda';
+import type { JobNotification, NotificationChannelConfig, JobId } from 'agenda';
 import { BaseNotificationChannel, toJobId } from 'agenda';
 
 const log = debug('agenda:postgres:notification');
@@ -8,7 +8,7 @@ const log = debug('agenda:postgres:notification');
 /**
  * Configuration for PostgresNotificationChannel
  */
-export interface IPostgresNotificationChannelConfig extends INotificationChannelConfig {
+export interface PostgresNotificationChannelConfig extends NotificationChannelConfig {
 	/** PostgreSQL connection pool (shared with repository) */
 	pool?: Pool;
 	/** PostgreSQL connection string (if not sharing pool) */
@@ -27,7 +27,7 @@ export class PostgresNotificationChannel extends BaseNotificationChannel {
 	private connectionString?: string;
 	private listenClient?: PoolClient;
 
-	constructor(config: IPostgresNotificationChannelConfig = {}) {
+	constructor(config: PostgresNotificationChannelConfig = {}) {
 		super(config);
 
 		if (config.pool) {
@@ -153,7 +153,7 @@ export class PostgresNotificationChannel extends BaseNotificationChannel {
 		this.setState('disconnected');
 	}
 
-	async publish(notification: IJobNotification): Promise<void> {
+	async publish(notification: JobNotification): Promise<void> {
 		if (this._state !== 'connected') {
 			throw new Error('Cannot publish: channel not connected');
 		}
@@ -174,7 +174,7 @@ export class PostgresNotificationChannel extends BaseNotificationChannel {
 	/**
 	 * Serialize notification to JSON string for NOTIFY payload
 	 */
-	private serializeNotification(notification: IJobNotification): string {
+	private serializeNotification(notification: JobNotification): string {
 		return JSON.stringify({
 			jobId: notification.jobId,
 			jobName: notification.jobName,
@@ -188,7 +188,7 @@ export class PostgresNotificationChannel extends BaseNotificationChannel {
 	/**
 	 * Parse notification from JSON string received via LISTEN
 	 */
-	private parseNotification(payload: string): IJobNotification {
+	private parseNotification(payload: string): JobNotification {
 		const data = JSON.parse(payload);
 
 		return {

--- a/packages/postgres-backend/src/index.ts
+++ b/packages/postgres-backend/src/index.ts
@@ -29,8 +29,8 @@ export { PostgresBackend } from './PostgresBackend.js';
 export { PostgresJobRepository } from './PostgresJobRepository.js';
 export { PostgresNotificationChannel } from './PostgresNotificationChannel.js';
 
-export type { IPostgresBackendConfig, IPostgresJobRow } from './types.js';
-export type { IPostgresNotificationChannelConfig } from './PostgresNotificationChannel.js';
+export type { PostgresBackendConfig, PostgresJobRow } from './types.js';
+export type { PostgresNotificationChannelConfig } from './PostgresNotificationChannel.js';
 
 // Re-export schema utilities for advanced use cases
 export {

--- a/packages/postgres-backend/src/types.ts
+++ b/packages/postgres-backend/src/types.ts
@@ -4,7 +4,7 @@ import type { SortDirection } from 'agenda';
 /**
  * Configuration options for PostgresBackend
  */
-export interface IPostgresBackendConfig {
+export interface PostgresBackendConfig {
 	/** PostgreSQL connection string (e.g., 'postgresql://user:pass@host:5432/db') */
 	connectionString?: string;
 
@@ -36,7 +36,7 @@ export interface IPostgresBackendConfig {
 /**
  * Internal row type matching PostgreSQL column names
  */
-export interface IPostgresJobRow {
+export interface PostgresJobRow {
 	id: string;
 	name: string;
 	priority: number;

--- a/packages/redis-backend/src/RedisBackend.ts
+++ b/packages/redis-backend/src/RedisBackend.ts
@@ -1,8 +1,8 @@
 import debug from 'debug';
-import type { IAgendaBackend, IJobRepository, INotificationChannel } from 'agenda';
+import type { AgendaBackend, JobRepository, NotificationChannel } from 'agenda';
 import { RedisJobRepository } from './RedisJobRepository.js';
 import { RedisNotificationChannel } from './RedisNotificationChannel.js';
-import type { IRedisBackendConfig } from './types.js';
+import type { RedisBackendConfig } from './types.js';
 
 const log = debug('agenda:redis:backend');
 
@@ -43,13 +43,13 @@ const log = debug('agenda:redis:backend');
  * await agenda.every('5 minutes', 'myJob');
  * ```
  */
-export class RedisBackend implements IAgendaBackend {
+export class RedisBackend implements AgendaBackend {
 	private _repository: RedisJobRepository;
 	private _notificationChannel: RedisNotificationChannel;
-	private config: IRedisBackendConfig;
+	private config: RedisBackendConfig;
 	private _ownsConnection: boolean;
 
-	constructor(config: IRedisBackendConfig) {
+	constructor(config: RedisBackendConfig) {
 		this.config = config;
 
 		// Determine if we own the connection (not passed in by user)
@@ -75,14 +75,14 @@ export class RedisBackend implements IAgendaBackend {
 	/**
 	 * The job repository for storage operations
 	 */
-	get repository(): IJobRepository {
+	get repository(): JobRepository {
 		return this._repository;
 	}
 
 	/**
 	 * The notification channel for real-time notifications via Pub/Sub
 	 */
-	get notificationChannel(): INotificationChannel {
+	get notificationChannel(): NotificationChannel {
 		return this._notificationChannel;
 	}
 

--- a/packages/redis-backend/src/RedisNotificationChannel.ts
+++ b/packages/redis-backend/src/RedisNotificationChannel.ts
@@ -1,7 +1,7 @@
 import debug from 'debug';
 import { Redis } from 'ioredis';
 import type { RedisOptions } from 'ioredis';
-import type { IJobNotification, INotificationChannelConfig, JobId } from 'agenda';
+import type { JobNotification, NotificationChannelConfig, JobId } from 'agenda';
 import { BaseNotificationChannel, toJobId } from 'agenda';
 
 const log = debug('agenda:redis:notification');
@@ -9,7 +9,7 @@ const log = debug('agenda:redis:notification');
 /**
  * Configuration for RedisNotificationChannel
  */
-export interface IRedisNotificationChannelConfig extends INotificationChannelConfig {
+export interface RedisNotificationChannelConfig extends NotificationChannelConfig {
 	/** Redis client for publishing (shared with repository) */
 	redis?: Redis;
 	/** Redis connection URL (if not sharing client) */
@@ -34,7 +34,7 @@ export class RedisNotificationChannel extends BaseNotificationChannel {
 	private connectionString?: string;
 	private redisOptions?: RedisOptions;
 
-	constructor(config: IRedisNotificationChannelConfig = {}) {
+	constructor(config: RedisNotificationChannelConfig = {}) {
 		super(config);
 
 		if (config.redis) {
@@ -167,7 +167,7 @@ export class RedisNotificationChannel extends BaseNotificationChannel {
 		this.setState('disconnected');
 	}
 
-	async publish(notification: IJobNotification): Promise<void> {
+	async publish(notification: JobNotification): Promise<void> {
 		if (this._state !== 'connected') {
 			throw new Error('Cannot publish: channel not connected');
 		}
@@ -185,7 +185,7 @@ export class RedisNotificationChannel extends BaseNotificationChannel {
 	/**
 	 * Serialize notification to JSON string for Redis Pub/Sub
 	 */
-	private serializeNotification(notification: IJobNotification): string {
+	private serializeNotification(notification: JobNotification): string {
 		return JSON.stringify({
 			jobId: notification.jobId,
 			jobName: notification.jobName,
@@ -199,7 +199,7 @@ export class RedisNotificationChannel extends BaseNotificationChannel {
 	/**
 	 * Parse notification from JSON string received via Pub/Sub
 	 */
-	private parseNotification(payload: string): IJobNotification {
+	private parseNotification(payload: string): JobNotification {
 		const data = JSON.parse(payload);
 
 		return {

--- a/packages/redis-backend/src/index.ts
+++ b/packages/redis-backend/src/index.ts
@@ -29,5 +29,5 @@ export { RedisBackend } from './RedisBackend.js';
 export { RedisJobRepository } from './RedisJobRepository.js';
 export { RedisNotificationChannel } from './RedisNotificationChannel.js';
 
-export type { IRedisBackendConfig, IRedisJobData } from './types.js';
-export type { IRedisNotificationChannelConfig } from './RedisNotificationChannel.js';
+export type { RedisBackendConfig, RedisJobData } from './types.js';
+export type { RedisNotificationChannelConfig } from './RedisNotificationChannel.js';

--- a/packages/redis-backend/src/types.ts
+++ b/packages/redis-backend/src/types.ts
@@ -4,7 +4,7 @@ import type { SortDirection } from 'agenda';
 /**
  * Configuration options for RedisBackend
  */
-export interface IRedisBackendConfig {
+export interface RedisBackendConfig {
 	/** Redis connection URL (e.g., 'redis://localhost:6379') */
 	connectionString?: string;
 
@@ -31,7 +31,7 @@ export interface IRedisBackendConfig {
  * Internal job storage type for Redis
  * All fields are stored as strings in Redis hashes
  */
-export interface IRedisJobData {
+export interface RedisJobData {
 	id: string;
 	name: string;
 	priority: string;


### PR DESCRIPTION
## Summary
This PR removes the 'I' prefix convention from all interface names throughout the codebase, following modern TypeScript naming conventions. This is a large refactoring that improves code readability and aligns with current best practices.

## Key Changes
- **agenda-rest package**: Renamed interfaces like `IAgendaRestConfig` → `AgendaRestConfig`, `IJobDefinitionRequest` → `JobDefinitionRequest`, etc.
- **agenda package**: Updated core interfaces including:
  - `IJobParameters` → `JobParameters`
  - `IJobDefinition` → `JobDefinition`
  - `IAgendaConfig` → `AgendaConfig`
  - `IAgendaBackend` → `AgendaBackend`
  - `IJobRepository` → `JobRepository`
  - `INotificationChannel` → `NotificationChannel`
  - `IAgendaStatus` → `AgendaStatus`
  - `IJobsQueryOptions` → `JobsQueryOptions`
  - `IJobsResult` → `JobsResult`
  - `IJobsOverview` → `JobsOverview`
  - And many more throughout the types directory
- **agendash package**: Renamed interfaces like `IApiQueryParams` → `ApiQueryParams`, `IFrontendJob` → `FrontendJob`, `IAgendashController` → `AgendashController`, etc.
- **Notification channels**: Updated `BaseNotificationChannel`, `InMemoryNotificationChannel` and related types
- **All usages**: Updated all references to these interfaces across the codebase in implementations, function signatures, and type annotations

## Implementation Details
- This is a pure refactoring with no functional changes
- All interface names have been consistently updated across all packages
- Internal interfaces (like `IStoredJobDefinition` → `StoredJobDefinition`) were also updated for consistency
- The changes maintain backward compatibility at the runtime level but are breaking changes for TypeScript consumers