### PR TITLE
allow relative path hosting of agendash

### DIFF
--- a/.changeset/itchy-cats-stick.md
+++ b/.changeset/itchy-cats-stick.md
@@ -1,0 +1,5 @@
+---
+'agendash': patch
+---
+
+relative path for assets

--- a/packages/agendash/client/index.html
+++ b/packages/agendash/client/index.html
@@ -4,10 +4,9 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Agendash</title>
-		<link rel="manifest" href="/site.webmanifest" />
 	</head>
 	<body>
 		<div id="app"></div>
-		<script type="module" src="/src/main.ts"></script>
+		<script type="module" src="./src/main.ts"></script>
 	</body>
 </html>

--- a/packages/agendash/client/public/site.webmanifest
+++ b/packages/agendash/client/public/site.webmanifest
@@ -1,8 +1,0 @@
-{
-  "name": "Agendash",
-  "short_name": "Agendash",
-  "icons": [],
-  "theme_color": "#343a40",
-  "background_color": "#ffffff",
-  "display": "standalone"
-}

--- a/packages/agendash/client/vite.config.ts
+++ b/packages/agendash/client/vite.config.ts
@@ -4,6 +4,7 @@ import { resolve } from 'path';
 
 export default defineConfig({
 	plugins: [vue()],
+	base: './',
 	root: resolve(__dirname),
 	build: {
 		outDir: resolve(__dirname, '../public'),

--- a/packages/agendash/public/site.webmanifest
+++ b/packages/agendash/public/site.webmanifest
@@ -1,8 +1,0 @@
-{
-  "name": "Agendash",
-  "short_name": "Agendash",
-  "icons": [],
-  "theme_color": "#343a40",
-  "background_color": "#ffffff",
-  "display": "standalone"
-}


### PR DESCRIPTION
## Description

fixes hosting agendash under sub paths (e.g. /admin/agenda or so)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Added changeset if needed (`pnpm changeset`)

