### PR TITLE
feat(agenda): add timeout and abortSignal support to drain()

### DIFF
--- a/.changeset/free-pandas-know.md
+++ b/.changeset/free-pandas-know.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+configurable drain timeouts

--- a/README.md
+++ b/README.md
@@ -1158,6 +1158,43 @@ process.on('SIGTERM', graceful);
 process.on('SIGINT', graceful);
 ```
 
+**With timeout** - useful when you need to shutdown within a time limit (e.g., cloud platforms like Heroku give 30 seconds):
+
+```js
+async function graceful() {
+	const result = await agenda.drain(30000); // 30 second timeout
+	if (result.timedOut) {
+		console.log(`Shutdown timeout: ${result.running} jobs still running`);
+	}
+	process.exit(0);
+}
+```
+
+**With AbortSignal** - for external control over the drain operation:
+
+```js
+const controller = new AbortController();
+
+// Abort drain after 30 seconds
+setTimeout(() => controller.abort(), 30000);
+
+const result = await agenda.drain({ signal: controller.signal });
+if (result.aborted) {
+	console.log(`Drain aborted: ${result.running} jobs still running`);
+}
+```
+
+**DrainResult** - `drain()` returns information about what happened:
+
+```ts
+interface DrainResult {
+	completed: number;  // jobs that finished during drain
+	running: number;    // jobs still running (if timed out or aborted)
+	timedOut: boolean;  // true if timeout was reached
+	aborted: boolean;   // true if signal was aborted
+}
+```
+
 **Comparison of `stop()` vs `drain()`:**
 
 | Method | Running Jobs | New Jobs | Use Case |

--- a/packages/agenda/README.md
+++ b/packages/agenda/README.md
@@ -281,6 +281,17 @@ await agenda.stop();
 
 // Drain - waits for running jobs to complete before stopping
 await agenda.drain();
+
+// Drain with timeout (30 seconds) - for cloud platforms with shutdown deadlines
+const result = await agenda.drain(30000);
+if (result.timedOut) {
+    console.log(`${result.running} jobs still running after timeout`);
+}
+
+// Drain with AbortSignal - for external control
+const controller = new AbortController();
+setTimeout(() => controller.abort(), 30000);
+await agenda.drain({ signal: controller.signal });
 ```
 
 Use `drain()` for graceful shutdowns where you want in-progress jobs to finish their work.

--- a/packages/agenda/src/index.ts
+++ b/packages/agenda/src/index.ts
@@ -15,6 +15,7 @@ import type {
 	JobsOverview
 } from './types/JobQuery.js';
 import type { RemoveJobsOptions } from './types/JobRepository.js';
+import type { DrainOptions, DrainResult } from './types/DrainOptions.js';
 import { Job, JobWithId } from './Job.js';
 import { JobPriority, parsePriority } from './utils/priority.js';
 import { JobProcessor } from './JobProcessor.js';
@@ -875,19 +876,43 @@ export class Agenda extends EventEmitter {
 	 * Waits for all currently running jobs to finish before stopping.
 	 * This allows for a graceful shutdown where jobs complete their work.
 	 * Unlike stop(), this method waits for running jobs to complete instead of unlocking them.
-	 * @param closeConnection - Whether to close the database connection.
-	 *   Defaults to backend.ownsConnection (true if backend created the connection,
-	 *   false if connection was passed in by user).
+	 *
+	 * @param options - Drain options or timeout in milliseconds
+	 *   - `timeout`: Maximum time to wait for jobs to complete
+	 *   - `signal`: AbortSignal to cancel the drain operation
+	 *   - `closeConnection`: Whether to close the database connection (default: backend.ownsConnection)
+	 * @returns DrainResult with completion statistics
+	 *
+	 * @example
+	 * // Wait indefinitely for all jobs to complete
+	 * await agenda.drain();
+	 *
+	 * @example
+	 * // Wait up to 30 seconds
+	 * const result = await agenda.drain(30000);
+	 * if (result.timedOut) console.log(`${result.running} jobs still running`);
+	 *
+	 * @example
+	 * // Use AbortSignal for external control
+	 * const controller = new AbortController();
+	 * setTimeout(() => controller.abort(), 30000);
+	 * await agenda.drain({ signal: controller.signal });
 	 */
-	async drain(closeConnection?: boolean): Promise<void> {
+	async drain(
+		options?: number | (DrainOptions & { closeConnection?: boolean })
+	): Promise<DrainResult> {
 		if (!this.jobProcessor) {
 			log('Agenda.drain called, but agenda has never started!');
-			return;
+			return { completed: 0, running: 0, timedOut: false, aborted: false };
 		}
+
+		// Normalize options
+		const opts =
+			typeof options === 'number' ? { timeout: options } : options ?? {};
 
 		log('Agenda.drain called, waiting for jobs to finish');
 
-		await this.jobProcessor.drain();
+		const result = await this.jobProcessor.drain(opts);
 
 		// Disconnect notification channel if configured (we always disconnect since we connected it in start)
 		if (this.notificationChannel) {
@@ -896,7 +921,7 @@ export class Agenda extends EventEmitter {
 		}
 
 		// Determine whether to close backend connection
-		const shouldClose = closeConnection ?? this.backend.ownsConnection ?? true;
+		const shouldClose = opts.closeConnection ?? this.backend.ownsConnection ?? true;
 
 		// Disconnect the backend
 		if (shouldClose) {
@@ -905,6 +930,8 @@ export class Agenda extends EventEmitter {
 		}
 
 		this.jobProcessor = undefined;
+
+		return result;
 	}
 }
 
@@ -927,6 +954,8 @@ export * from './types/NotificationChannel.js';
 export * from './types/AgendaBackend.js';
 
 export * from './types/AgendaStatus.js';
+
+export * from './types/DrainOptions.js';
 
 export * from './notifications/index.js';
 

--- a/packages/agenda/src/types/DrainOptions.ts
+++ b/packages/agenda/src/types/DrainOptions.ts
@@ -1,0 +1,42 @@
+/**
+ * Options for the drain() method
+ */
+export interface DrainOptions {
+	/**
+	 * Maximum time in milliseconds to wait for jobs to complete.
+	 * If not specified, drain() will wait indefinitely.
+	 */
+	timeout?: number;
+
+	/**
+	 * AbortSignal to cancel the drain operation.
+	 * When aborted, drain() will resolve immediately with the current state.
+	 */
+	signal?: AbortSignal;
+}
+
+/**
+ * Result of the drain() operation
+ */
+export interface DrainResult {
+	/**
+	 * Number of jobs that completed during the drain
+	 */
+	completed: number;
+
+	/**
+	 * Number of jobs still running when drain finished
+	 * (only non-zero if timeout was hit or signal was aborted)
+	 */
+	running: number;
+
+	/**
+	 * Whether the drain finished because the timeout was reached
+	 */
+	timedOut: boolean;
+
+	/**
+	 * Whether the drain finished because the signal was aborted
+	 */
+	aborted: boolean;
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                               
  - Add configurable timeout and AbortSignal support to `drain()` for graceful shutdowns                                                                                                                                   
  - Add `DrainResult` return type with completion statistics                                                                                                                                                               
  - Add test for `job.touch(progress)` to verify progress persistence                                                                                                                                                      
                                                                                                                                                                                                                           
  ## Changes                                                                                                                                                                                                               
                                                                                                                                                                                                                           
  ### Enhanced `drain()` API (backwards compatible)                                                                                                                                                                        
  ```typescript                                                                                                                                                                                                            
  // All these work:                                                                                                                                                                                                       
  await agenda.drain();                              // wait indefinitely (existing behavior)                                                                                                                              
  await agenda.drain(30000);                         // timeout in ms                                                                                                                                                      
  await agenda.drain({ timeout: 30000 });            // options object                                                                                                                                                     
  await agenda.drain({ signal: controller.signal }); // AbortSignal                                                                                                                                                        
  await agenda.drain({ timeout: 30000, signal });    // both                                                                                                                                                               
                                                                                                                                                                                                                           
  New DrainResult return type                                                                                                                                                                                              
                                                                                                                                                                                                                           
  interface DrainResult {                                                                                                                                                                                                  
    completed: number;  // jobs that finished during drain                                                                                                                                                                 
    running: number;    // jobs still running (if timed out/aborted)                                                                                                                                                       
    timedOut: boolean;  // true if timeout was reached                                                                                                                                                                     
    aborted: boolean;   // true if signal was aborted                                                                                                                                                                      
  }                                                                                                                                                                                                                        
                                                                                                                                                                                                                           
  Motivation                                                                                                                                                                                                               
                                                                                                                                                                                                                           
  Cloud platforms like Heroku/Kubernetes give limited time (typically 30s) for graceful shutdown after SIGTERM. Without a timeout, drain() could hang indefinitely waiting for long-running jobs, causing forceful         
  termination. This aligns with patterns in other job queues like Bee-Queue (queue.close(timeout)) and Sidekiq (8s default timeout).                                                                                       
        