### PR TITLE
fix: flaky MongoChangeStreamNotificationChannel test

### DIFF
--- a/.changeset/spicy-rocks-enjoy.md
+++ b/.changeset/spicy-rocks-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/mongo-backend': patch
+---
+
+flacky test


### PR DESCRIPTION
## Summary                                                                                                                                                                                                               
  - Replace fixed 100ms timeouts with polling-based `waitFor` helper for Change Stream tests                                                                                                                               
  - Change Streams have variable latency (oplog tailing), causing intermittent CI failures                                                                                                                                 
  - Increase timeout to 300ms for negative tests (expecting no notifications)                                                                                                                                              