### PR TITLE
feat: Add unified container runtime utilities for Docker and Podman

### DIFF
--- a/packages/agenda/src/utils/container-runtime.ts
+++ b/packages/agenda/src/utils/container-runtime.ts
@@ -1,0 +1,192 @@
+/**
+ * Shared container runtime utilities for Docker and Podman
+ *
+ * This module provides a unified interface for working with both Docker and Podman,
+ * abstracting away the differences and providing common operations.
+ */
+
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execAsync = promisify(exec);
+
+export type RuntimeType = 'docker' | 'podman' | null;
+
+export interface ContainerConfig {
+	image: string;
+	env?: Record<string, string>;
+	ports?: Array<{ host: number; container: number }>;
+	tmpfs?: string[];
+	detached?: boolean;
+}
+
+/**
+ * Manages container runtime detection and operations for Docker and Podman
+ */
+export class ContainerRuntime {
+	private cachedRuntime: RuntimeType = null;
+	private cachedCompose: string | null = null;
+
+	/**
+	 * Detects whether Docker or Podman is available on the system
+	 * Results are cached after the first detection
+	 */
+	async detect(): Promise<{ runtime: RuntimeType; compose: string | null }> {
+		if (this.cachedRuntime !== null) {
+			return { runtime: this.cachedRuntime, compose: this.cachedCompose };
+		}
+
+		if (await this._isCommandAvailable('docker')) {
+			this.cachedRuntime = 'docker';
+			this.cachedCompose = (await this._isCommandAvailable('docker compose')) ? 'docker compose' : null;
+			return { runtime: this.cachedRuntime, compose: this.cachedCompose };
+		}
+
+		if (await this._isCommandAvailable('podman')) {
+			this.cachedRuntime = 'podman';
+			this.cachedCompose = (await this._isCommandAvailable('podman compose')) ? 'podman compose' : null;
+			return { runtime: this.cachedRuntime, compose: this.cachedCompose };
+		}
+
+		this.cachedRuntime = null;
+		this.cachedCompose = null;
+		return { runtime: null, compose: null };
+	}
+
+	/**
+	 * Get the detected runtime type
+	 */
+	async getRuntime(): Promise<RuntimeType> {
+		const { runtime } = await this.detect();
+		return runtime;
+	}
+
+	/**
+	 * Get the detected compose command
+	 */
+	async getCompose(): Promise<string | null> {
+		const { compose } = await this.detect();
+		return compose;
+	}
+
+	/**
+	 * Reset the cached runtime detection (useful for testing)
+	 */
+	reset(): void {
+		this.cachedRuntime = null;
+		this.cachedCompose = null;
+	}
+
+	/**
+	 * Start containers using docker-compose or podman-compose
+	 */
+	async startWithCompose(cwd: string): Promise<void> {
+		const compose = await this.getCompose();
+		if (!compose) {
+			throw new Error('No compose command available');
+		}
+		await execAsync(`${compose} up -d --wait`, { cwd });
+	}
+
+	/**
+	 * Stop containers using docker-compose or podman-compose
+	 */
+	async stopWithCompose(cwd: string): Promise<void> {
+		const compose = await this.getCompose();
+		if (!compose) {
+			throw new Error('No compose command available');
+		}
+		await execAsync(`${compose} down`, { cwd });
+	}
+
+	/**
+	 * Check if a container exists and is running
+	 */
+	async isContainerRunning(containerName: string): Promise<boolean> {
+		const runtime = await this.getRuntime();
+		if (!runtime) {
+			return false;
+		}
+
+		try {
+			const { stdout } = await execAsync(
+				`${runtime} inspect ${containerName} --format='{{.State.Running}}'`,
+				{ shell: '/bin/bash' }
+			);
+			const isRunning = stdout.trim() === "'true'" || stdout.trim() === 'true';
+			return isRunning;
+		} catch {
+			return false;
+		}
+	}
+
+	/**
+	 * Start an existing container
+	 */
+	async startContainer(containerName: string): Promise<void> {
+		const runtime = await this.getRuntime();
+		if (!runtime) {
+			throw new Error('No container runtime available');
+		}
+		await execAsync(`${runtime} start ${containerName}`, { shell: '/bin/bash' });
+	}
+
+	/**
+	 * Stop and remove a container
+	 */
+	async stopAndRemoveContainer(containerName: string): Promise<void> {
+		const runtime = await this.getRuntime();
+		if (!runtime) {
+			throw new Error('No container runtime available');
+		}
+		await execAsync(`${runtime} stop ${containerName}`, { shell: '/bin/bash' });
+		await execAsync(`${runtime} rm ${containerName}`, { shell: '/bin/bash' });
+	}
+
+	/**
+	 * Run a new container with the given configuration
+	 */
+	async runContainer(containerName: string, config: ContainerConfig): Promise<void> {
+		const runtime = await this.getRuntime();
+		if (!runtime) {
+			throw new Error('No container runtime available');
+		}
+
+		const envArgs = config.env
+			? Object.entries(config.env)
+					.map(([key, value]) => `-e ${key}=${value}`)
+					.join(' ')
+			: '';
+
+		const portArgs = config.ports
+			? config.ports.map((p) => `-p ${p.host}:${p.container}`).join(' ')
+			: '';
+
+		const tmpfsArgs = config.tmpfs ? config.tmpfs.map((path) => `--tmpfs ${path}`).join(' ') : '';
+
+		const detachedFlag = config.detached !== false ? '-d' : '';
+
+		const cmd = `${runtime} run ${detachedFlag} --name ${containerName} ${envArgs} ${portArgs} ${tmpfsArgs} ${config.image}`
+			.trim()
+			.replace(/\s+/g, ' ');
+
+		await execAsync(cmd, { shell: '/bin/bash' });
+	}
+
+	/**
+	 * Check if a command is available
+	 */
+	private async _isCommandAvailable(cmd: string): Promise<boolean> {
+		try {
+			await execAsync(`${cmd} --version`);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+}
+
+/**
+ * Singleton instance for convenience
+ */
+export const containerRuntime = new ContainerRuntime();

--- a/packages/agendash/dev-server-postgres.ts
+++ b/packages/agendash/dev-server-postgres.ts
@@ -1,6 +1,6 @@
 /**
  * Development server that runs both Vite (frontend) and Express API (backend) with PostgreSQL
- * Automatically starts a Docker container if PostgreSQL is not available.
+ * Automatically starts a Docker or Podman container if PostgreSQL is not available.
  *
  * Usage: pnpm --filter agendash dev:postgres
  * With custom connection: POSTGRES_URL=postgres://user:pass@localhost:5432/mydb pnpm --filter agendash dev:postgres
@@ -10,21 +10,177 @@ import express from 'express';
 import { createServer as createViteServer } from 'vite';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
-import { exec } from 'node:child_process';
-import { promisify } from 'node:util';
 import { Pool } from 'pg';
 import { Agenda } from 'agenda';
 import { PostgresBackend } from '@agendajs/postgres-backend';
 import { createExpressMiddleware } from './src/middlewares/express.js';
+import { containerRuntime } from 'agenda/dist/utils/container-runtime';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const execAsync = promisify(exec);
 
 const DEFAULT_POSTGRES_URL = 'postgresql://agenda:agenda@localhost:5433/agenda_dev';
 const CONTAINER_NAME = 'agendash-postgres-dev';
 let containerStartedByUs = false;
 
-async function isPostgresReady(url: string): Promise<boolean> {
+async function startDevServer() {
+	const postgresUrl = await _ensurePostgres();
+
+	// PostgresBackend provides both storage AND real-time notifications via LISTEN/NOTIFY
+	const backend = new PostgresBackend({ connectionString: postgresUrl });
+
+	const agenda = new Agenda({
+		backend,
+		name: 'agendash-dev-postgres',
+		logging: true
+	});
+
+	agenda.on('error', (err) => {
+		console.error('Agenda error:', err);
+	});
+
+	// Define some test jobs
+	agenda.define('test-job', async (job) => {
+		console.log(`Running test-job with data:`, job.attrs.data);
+	});
+
+	agenda.define('failing-job', async () => {
+		throw new Error('This job always fails');
+	});
+
+	agenda.define('slow-job', async () => {
+		await new Promise((resolve) => setTimeout(resolve, 5000));
+		console.log('Slow job completed');
+	});
+
+	agenda.define('long-running-job', async () => {
+		console.log('Long running job started...');
+		await new Promise((resolve) => setTimeout(resolve, 60000)); // 1 minute
+		console.log('Long running job completed');
+	});
+
+	agenda.define('progress-job', async (job) => {
+		console.log('Progress job started...');
+		const steps = 10;
+		for (let i = 1; i <= steps; i++) {
+			await new Promise((resolve) => setTimeout(resolve, 3000)); // 3 seconds per step
+			const progress = Math.round((i / steps) * 100);
+			await job.touch(progress);
+			console.log(`Progress job: ${progress}%`);
+		}
+		console.log('Progress job completed');
+	});
+
+	// Restart progress-job when it completes (reuse the same job)
+	agenda.on('success:progress-job', async (job) => {
+		console.log('Progress job succeeded, rescheduling...');
+		job.schedule('now');
+		await job.save();
+	});
+
+	agenda.define('future-job', async (job) => {
+		console.log('Future job executed:', job.attrs.data);
+	});
+
+	await agenda.start();
+	console.log('Agenda started with PostgreSQL backend (LISTEN/NOTIFY enabled for real-time updates)');
+
+	// Fill with 10,000 jobs if FILL_JOBS is set
+	if (process.env.FILL_JOBS === 'true') {
+		await _fillWithJobs(agenda, 10000);
+	}
+
+	// Schedule some recurring jobs for testing
+	await agenda.every('1 minute', 'test-job', { example: 'data' });
+
+	// Schedule a long-running job that starts immediately
+	await agenda.now('long-running-job');
+
+	// Schedule a job that updates its progress
+	await agenda.now('progress-job');
+
+	// Schedule a job far in the future (1 year from now)
+	const oneYearFromNow = new Date();
+	oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1);
+	await agenda.schedule(oneYearFromNow, 'future-job', { scheduled: 'for next year' });
+
+	// Schedule another job 1 month from now
+	const oneMonthFromNow = new Date();
+	oneMonthFromNow.setMonth(oneMonthFromNow.getMonth() + 1);
+	await agenda.schedule(oneMonthFromNow, 'future-job', { scheduled: 'for next month' });
+
+	const app = express();
+
+	// Create Vite server in middleware mode for frontend hot-reloading
+	const vite = await createViteServer({
+		configFile: resolve(__dirname, 'client/vite.config.ts'),
+		server: {
+			middlewareMode: true
+		},
+		appType: 'spa'
+	});
+
+	// API routes (skip static files - Vite handles frontend in dev mode)
+	app.use('/', createExpressMiddleware(agenda, { skipStaticFiles: true }));
+
+	// Use Vite for frontend (handles HMR and serves all non-API requests)
+	app.use(vite.middlewares);
+
+	const port = parseInt(process.env.PORT || '3001', 10);
+
+	app.listen(port, () => {
+		console.log(`\n  Agendash dev server (PostgreSQL) running at:`);
+		console.log(`  > http://localhost:${port}`);
+		console.log(`  > Real-time updates: ENABLED (via PostgreSQL LISTEN/NOTIFY)\n`);
+	});
+
+	// Graceful shutdown
+	process.on('SIGINT', async () => {
+		console.log('\nShutting down...');
+		await agenda.stop();
+		await vite.close();
+		await backend.disconnect();
+		await _stopDockerContainer();
+		process.exit(0);
+	});
+}
+
+async function _ensurePostgres(): Promise<string> {
+	const testUrl = process.env.POSTGRES_URL || DEFAULT_POSTGRES_URL;
+
+	// First, check if PostgreSQL is already available
+	if (await _isPostgresReady(testUrl)) {
+		console.log('✓ Connected to PostgreSQL');
+		return testUrl;
+	}
+
+	// PostgreSQL not available - try to start container
+	console.log('PostgreSQL not available, attempting to start container...');
+
+	const runtime = await containerRuntime.getRuntime();
+
+	if (!runtime) {
+		throw new Error(
+			'PostgreSQL is not available and no container runtime (Docker or Podman) is installed.\n' +
+				'Please either:\n' +
+				'  1. Install Docker or Podman\n' +
+				'  2. Set POSTGRES_URL to an existing PostgreSQL database'
+		);
+	}
+
+	if (!(await _startDockerContainer())) {
+		throw new Error(`Failed to start PostgreSQL container with ${runtime}.`);
+	}
+
+	console.log('⏳ Waiting for PostgreSQL to be ready');
+	if (await _waitForPostgres(testUrl)) {
+		console.log('\n✓ PostgreSQL is ready');
+		return testUrl;
+	}
+
+	throw new Error('PostgreSQL container started but failed to become ready in time.');
+}
+
+async function _isPostgresReady(url: string): Promise<boolean> {
 	const pool = new Pool({ connectionString: url, connectionTimeoutMillis: 2000 });
 	try {
 		await pool.query('SELECT 1');
@@ -36,60 +192,72 @@ async function isPostgresReady(url: string): Promise<boolean> {
 	}
 }
 
-async function isDockerAvailable(): Promise<boolean> {
-	try {
-		// First check if docker command exists
-		await execAsync('which docker', { shell: '/bin/bash' });
-		// Then verify Docker daemon is running
-		const { stdout } = await execAsync('docker info 2>&1 | head -1', { shell: '/bin/bash', timeout: 10000 });
-		return stdout.includes('Client');
-	} catch (error) {
-		console.error('Docker check failed:', (error as Error).message);
-		return false;
+async function _startContainer() {
+	const runtime = await containerRuntime.getRuntime();
+	if (!runtime) {
+		throw new Error('No container runtime available');
 	}
+	await containerRuntime.startContainer(CONTAINER_NAME);
+	console.log('✓ PostgreSQL container started');
 }
 
-async function startDockerContainer(): Promise<boolean> {
-	console.log('🐳 Starting PostgreSQL Docker container...');
+async function _startNewContainer() {
+	const runtime = await containerRuntime.getRuntime();
+	if (!runtime) {
+		throw new Error('No container runtime available');
+	}
+
+	await containerRuntime.runContainer(CONTAINER_NAME, {
+		image: 'postgres:16-alpine',
+		env: {
+			POSTGRES_USER: 'agenda',
+			POSTGRES_PASSWORD: 'agenda',
+			POSTGRES_DB: 'agenda_dev'
+		},
+		ports: [{ host: 5433, container: 5432 }],
+		tmpfs: ['/var/lib/postgresql/data'],
+		detached: true
+	});
+
+	containerStartedByUs = true;
+	console.log('✓ PostgreSQL container started');
+	return true;
+}
+
+async function _startDockerContainer(): Promise<boolean> {
+	const runtime = await containerRuntime.getRuntime();
+
+	if (!runtime) {
+		return false;
+	}
+
+	console.log(`🐳 Starting PostgreSQL container with ${runtime}...`);
 	try {
-		// Check if container already exists
+		// Check if container already exists and is running
+		if (await containerRuntime.isContainerRunning(CONTAINER_NAME)) {
+			console.log('✓ PostgreSQL container is already running');
+			return true;
+		}
+
+		// Try to start existing container
 		try {
-			const { stdout } = await execAsync(`docker inspect ${CONTAINER_NAME} --format='{{.State.Running}}'`, { shell: '/bin/bash' });
-			if (stdout.trim() === "'true'" || stdout.trim() === 'true') {
-				console.log('✓ PostgreSQL container is already running');
-				return true;
-			}
-			// Container exists but not running, start it
-			await execAsync(`docker start ${CONTAINER_NAME}`, { shell: '/bin/bash' });
-			console.log('✓ PostgreSQL container started');
+			await _startContainer();
 			return true;
 		} catch {
 			// Container doesn't exist, create it
 		}
 
 		// Start a new container (using port 5433 to avoid conflicts with system PostgreSQL)
-		await execAsync(
-			`docker run -d --name ${CONTAINER_NAME} ` +
-				`-e POSTGRES_USER=agenda ` +
-				`-e POSTGRES_PASSWORD=agenda ` +
-				`-e POSTGRES_DB=agenda_dev ` +
-				`-p 5433:5432 ` +
-				`--tmpfs /var/lib/postgresql/data ` +
-				`postgres:16-alpine`,
-			{ shell: '/bin/bash' }
-		);
-		containerStartedByUs = true;
-		console.log('✓ PostgreSQL container started');
-		return true;
+		return await _startNewContainer();
 	} catch (error) {
-		console.error('Failed to start Docker container:', (error as Error).message);
+		console.error(`Failed to start container with ${runtime}:`, (error as Error).message);
 		return false;
 	}
 }
 
-async function waitForPostgres(url: string, maxAttempts = 30): Promise<boolean> {
+async function _waitForPostgres(url: string, maxAttempts = 30): Promise<boolean> {
 	for (let i = 0; i < maxAttempts; i++) {
-		if (await isPostgresReady(url)) {
+		if (await _isPostgresReady(url)) {
 			return true;
 		}
 		process.stdout.write('.');
@@ -98,54 +266,28 @@ async function waitForPostgres(url: string, maxAttempts = 30): Promise<boolean> 
 	return false;
 }
 
-async function stopDockerContainer(): Promise<void> {
-	if (containerStartedByUs) {
-		console.log('\n🐳 Stopping PostgreSQL Docker container...');
-		try {
-			await execAsync(`docker stop ${CONTAINER_NAME}`, { shell: '/bin/bash' });
-			await execAsync(`docker rm ${CONTAINER_NAME}`, { shell: '/bin/bash' });
-			console.log('✓ PostgreSQL container stopped and removed');
-		} catch (error) {
-			console.error('Failed to stop container:', (error as Error).message);
-		}
+async function _stopDockerContainer(): Promise<void> {
+	if (!containerStartedByUs) {
+		return;
+	}
+
+	const runtime = await containerRuntime.getRuntime();
+	console.log(`\n🐳 Stopping PostgreSQL container (${runtime})...`);
+
+	if (!runtime) {
+		return;
+	}
+
+	try {
+		await containerRuntime.stopAndRemoveContainer(CONTAINER_NAME);
+		console.log('✓ PostgreSQL container stopped and removed');
+	} catch (error) {
+		console.error('Failed to stop container:', (error as Error).message);
 	}
 }
 
-async function ensurePostgres(): Promise<string> {
-	const testUrl = process.env.POSTGRES_URL || DEFAULT_POSTGRES_URL;
 
-	// First, check if PostgreSQL is already available
-	if (await isPostgresReady(testUrl)) {
-		console.log('✓ Connected to PostgreSQL');
-		return testUrl;
-	}
-
-	// PostgreSQL not available - try to start Docker container
-	console.log('PostgreSQL not available, attempting to start Docker container...');
-
-	if (!(await isDockerAvailable())) {
-		throw new Error(
-			'PostgreSQL is not available and Docker is not installed.\n' +
-				'Please either:\n' +
-				'  1. Install Docker\n' +
-				'  2. Set POSTGRES_URL to an existing PostgreSQL database'
-		);
-	}
-
-	if (!(await startDockerContainer())) {
-		throw new Error('Failed to start PostgreSQL Docker container.');
-	}
-
-	console.log('⏳ Waiting for PostgreSQL to be ready');
-	if (await waitForPostgres(testUrl)) {
-		console.log('\n✓ PostgreSQL is ready');
-		return testUrl;
-	}
-
-	throw new Error('PostgreSQL container started but failed to become ready in time.');
-}
-
-async function fillWithJobs(agenda: Agenda, count: number): Promise<void> {
+async function _fillWithJobs(agenda: Agenda, count: number): Promise<void> {
 	console.log(`\nFilling database with ${count} jobs...`);
 	const startTime = Date.now();
 
@@ -221,127 +363,6 @@ async function fillWithJobs(agenda: Agenda, count: number): Promise<void> {
 	console.log(`\n  Completed in ${elapsed}s\n`);
 }
 
-async function startDevServer() {
-	const postgresUrl = await ensurePostgres();
-
-	// PostgresBackend provides both storage AND real-time notifications via LISTEN/NOTIFY
-	const backend = new PostgresBackend({ connectionString: postgresUrl });
-
-	const agenda = new Agenda({
-		backend,
-		name: 'agendash-dev-postgres',
-		logging: true
-	});
-
-	agenda.on('error', (err) => {
-		console.error('Agenda error:', err);
-	});
-
-	// Define some test jobs
-	agenda.define('test-job', async (job) => {
-		console.log(`Running test-job with data:`, job.attrs.data);
-	});
-
-	agenda.define('failing-job', async () => {
-		throw new Error('This job always fails');
-	});
-
-	agenda.define('slow-job', async () => {
-		await new Promise((resolve) => setTimeout(resolve, 5000));
-		console.log('Slow job completed');
-	});
-
-	agenda.define('long-running-job', async () => {
-		console.log('Long running job started...');
-		await new Promise((resolve) => setTimeout(resolve, 60000)); // 1 minute
-		console.log('Long running job completed');
-	});
-
-	agenda.define('progress-job', async (job) => {
-		console.log('Progress job started...');
-		const steps = 10;
-		for (let i = 1; i <= steps; i++) {
-			await new Promise((resolve) => setTimeout(resolve, 3000)); // 3 seconds per step
-			const progress = Math.round((i / steps) * 100);
-			await job.touch(progress);
-			console.log(`Progress job: ${progress}%`);
-		}
-		console.log('Progress job completed');
-	});
-
-	// Restart progress-job when it completes (reuse the same job)
-	agenda.on('success:progress-job', async (job) => {
-		console.log('Progress job succeeded, rescheduling...');
-		job.schedule('now');
-		await job.save();
-	});
-
-	agenda.define('future-job', async (job) => {
-		console.log('Future job executed:', job.attrs.data);
-	});
-
-	await agenda.start();
-	console.log('Agenda started with PostgreSQL backend (LISTEN/NOTIFY enabled for real-time updates)');
-
-	// Fill with 10,000 jobs if FILL_JOBS is set
-	if (process.env.FILL_JOBS === 'true') {
-		await fillWithJobs(agenda, 10000);
-	}
-
-	// Schedule some recurring jobs for testing
-	await agenda.every('1 minute', 'test-job', { example: 'data' });
-
-	// Schedule a long-running job that starts immediately
-	await agenda.now('long-running-job');
-
-	// Schedule a job that updates its progress
-	await agenda.now('progress-job');
-
-	// Schedule a job far in the future (1 year from now)
-	const oneYearFromNow = new Date();
-	oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1);
-	await agenda.schedule(oneYearFromNow, 'future-job', { scheduled: 'for next year' });
-
-	// Schedule another job 1 month from now
-	const oneMonthFromNow = new Date();
-	oneMonthFromNow.setMonth(oneMonthFromNow.getMonth() + 1);
-	await agenda.schedule(oneMonthFromNow, 'future-job', { scheduled: 'for next month' });
-
-	const app = express();
-
-	// Create Vite server in middleware mode for frontend hot-reloading
-	const vite = await createViteServer({
-		configFile: resolve(__dirname, 'client/vite.config.ts'),
-		server: {
-			middlewareMode: true
-		},
-		appType: 'spa'
-	});
-
-	// API routes (skip static files - Vite handles frontend in dev mode)
-	app.use('/', createExpressMiddleware(agenda, { skipStaticFiles: true }));
-
-	// Use Vite for frontend (handles HMR and serves all non-API requests)
-	app.use(vite.middlewares);
-
-	const port = parseInt(process.env.PORT || '3001', 10);
-
-	app.listen(port, () => {
-		console.log(`\n  Agendash dev server (PostgreSQL) running at:`);
-		console.log(`  > http://localhost:${port}`);
-		console.log(`  > Real-time updates: ENABLED (via PostgreSQL LISTEN/NOTIFY)\n`);
-	});
-
-	// Graceful shutdown
-	process.on('SIGINT', async () => {
-		console.log('\nShutting down...');
-		await agenda.stop();
-		await vite.close();
-		await backend.disconnect();
-		await stopDockerContainer();
-		process.exit(0);
-	});
-}
 
 startDevServer().catch((err) => {
 	console.error('Failed to start dev server:', err);

--- a/packages/postgres-backend/test/setup.ts
+++ b/packages/postgres-backend/test/setup.ts
@@ -2,19 +2,83 @@
  * Test setup for PostgreSQL backend tests
  *
  * This file is automatically loaded by vitest before running tests.
- * It automatically starts a Docker container if no PostgreSQL connection is available.
+ * It automatically starts a Docker or Podman container if no PostgreSQL connection is available.
  */
 
-import { exec } from 'node:child_process';
-import { promisify } from 'node:util';
 import { Pool } from 'pg';
-
-const execAsync = promisify(exec);
+import { containerRuntime } from '../../agenda/dist/utils/container-runtime.js';
 
 const DEFAULT_TEST_URL = 'postgresql://agenda:agenda@localhost:5432/agenda_test';
+const COMPOSE_CWD = new URL('.', import.meta.url).pathname.replace('/test/', '');
+
 let containerStartedByUs = false;
 
-async function isPostgresReady(url: string): Promise<boolean> {
+export async function setup() {
+	const testUrl = process.env.POSTGRES_TEST_URL || DEFAULT_TEST_URL;
+
+	if (await _isPostgresReady(testUrl)) {
+		console.log('\n✓ Connected to PostgreSQL test database\n');
+		process.env.POSTGRES_TEST_URL = testUrl;
+		return;
+	}
+
+	console.log('\n⚠️  PostgreSQL not available, attempting to start container...');
+
+	const { runtime, compose } = await containerRuntime.detect();
+
+	if (!runtime) {
+		throw new Error(
+			'PostgreSQL is not available and no container runtime (Docker or Podman) is installed.\n' +
+				'Please either:\n' +
+				'  1. Install Docker or Podman\n' +
+				'  2. Set POSTGRES_TEST_URL to an existing PostgreSQL database'
+		);
+	}
+
+	if (!compose) {
+		const suggestion = runtime === 'docker'
+			? 'the Docker Compose plugin (usually included with Docker Desktop)'
+			: 'podman compose (or install Docker as an alternative)';
+		throw new Error(
+			`${runtime} is installed but compose is not available.\n` +
+				`Please install ${suggestion} or set POSTGRES_TEST_URL to an existing PostgreSQL database`
+		);
+	}
+
+	if (!(await _startContainer())) {
+		throw new Error('Failed to start PostgreSQL container.\nPlease check your container runtime is working.');
+	}
+
+	console.log('⏳ Waiting for PostgreSQL to be ready...');
+	if (await _waitForPostgres(testUrl)) {
+		console.log('✓ PostgreSQL is ready\n');
+		process.env.POSTGRES_TEST_URL = testUrl;
+		return;
+	}
+
+	throw new Error(
+		'PostgreSQL container started but failed to become ready in time.\n' +
+			'Check container logs with: docker/podman compose logs'
+	);
+}
+
+export async function teardown() {
+	if (!containerStartedByUs) {
+		return;
+	}
+
+	const compose = await containerRuntime.getCompose();
+
+	if (!compose) {
+		return;
+	}
+
+	console.log('\n🐳 Stopping PostgreSQL container...');
+	await containerRuntime.stopWithCompose(COMPOSE_CWD);
+	console.log('✓ PostgreSQL container stopped\n');
+}
+
+async function _isPostgresReady(url: string): Promise<boolean> {
 	const pool = new Pool({ connectionString: url, connectionTimeoutMillis: 2000 });
 	try {
 		await pool.query('SELECT 1');
@@ -26,34 +90,29 @@ async function isPostgresReady(url: string): Promise<boolean> {
 	}
 }
 
-async function isDockerAvailable(): Promise<boolean> {
-	try {
-		await execAsync('docker --version');
-		return true;
-	} catch {
+async function _startContainer(): Promise<boolean> {
+	const { runtime, compose } = await containerRuntime.detect();
+
+	if (!runtime || !compose) {
 		return false;
 	}
-}
 
-async function startDockerContainer(): Promise<boolean> {
-	console.log('🐳 Starting PostgreSQL Docker container...');
+	console.log(`🐳 Starting PostgreSQL container with ${runtime}...`);
+
 	try {
-		// Start container with docker compose
-		await execAsync('docker compose up -d --wait', {
-			cwd: new URL('.', import.meta.url).pathname.replace('/test/', '')
-		});
+		await containerRuntime.startWithCompose(COMPOSE_CWD);
 		containerStartedByUs = true;
 		console.log('✓ PostgreSQL container started');
 		return true;
 	} catch (error) {
-		console.error('Failed to start Docker container:', (error as Error).message);
+		console.error('Failed to start container:', (error as Error).message);
 		return false;
 	}
 }
 
-async function waitForPostgres(url: string, maxAttempts = 30): Promise<boolean> {
+async function _waitForPostgres(url: string, maxAttempts = 30): Promise<boolean> {
 	for (let i = 0; i < maxAttempts; i++) {
-		if (await isPostgresReady(url)) {
+		if (await _isPostgresReady(url)) {
 			return true;
 		}
 		await new Promise(resolve => setTimeout(resolve, 1000));
@@ -61,59 +120,3 @@ async function waitForPostgres(url: string, maxAttempts = 30): Promise<boolean> 
 	return false;
 }
 
-export async function setup() {
-	const testUrl = process.env.POSTGRES_TEST_URL || DEFAULT_TEST_URL;
-
-	// First, check if PostgreSQL is already available
-	if (await isPostgresReady(testUrl)) {
-		console.log('\n✓ Connected to PostgreSQL test database\n');
-		process.env.POSTGRES_TEST_URL = testUrl;
-		return;
-	}
-
-	// PostgreSQL not available - try to start Docker container
-	console.log('\n⚠️  PostgreSQL not available, attempting to start Docker container...');
-
-	if (!(await isDockerAvailable())) {
-		throw new Error(
-			'PostgreSQL is not available and Docker is not installed.\n' +
-				'Please either:\n' +
-				'  1. Install Docker and run: pnpm docker:up\n' +
-				'  2. Set POSTGRES_TEST_URL to an existing PostgreSQL database'
-		);
-	}
-
-	if (!(await startDockerContainer())) {
-		throw new Error(
-			'Failed to start PostgreSQL Docker container.\n' +
-				'Please check Docker is running and try: pnpm docker:up'
-		);
-	}
-
-	console.log('⏳ Waiting for PostgreSQL to be ready...');
-	if (await waitForPostgres(testUrl)) {
-		console.log('✓ PostgreSQL is ready\n');
-		process.env.POSTGRES_TEST_URL = testUrl;
-		return;
-	}
-
-	throw new Error(
-		'PostgreSQL container started but failed to become ready in time.\n' +
-			'Check container logs with: pnpm docker:logs'
-	);
-}
-
-export async function teardown() {
-	// Stop the container if we started it
-	if (containerStartedByUs) {
-		console.log('\n🐳 Stopping PostgreSQL Docker container...');
-		try {
-			await execAsync('docker compose down', {
-				cwd: new URL('.', import.meta.url).pathname.replace('/test/', '')
-			});
-			console.log('✓ PostgreSQL container stopped\n');
-		} catch (error) {
-			console.error('Failed to stop container:', (error as Error).message);
-		}
-	}
-}


### PR DESCRIPTION
## Add Podman support for container runtime

## Description

Adds automatic Podman detection and support alongside Docker. The runtime is auto-detected—Docker is preferred, Podman is used as fallback if Docker is unavailable. No configuration required.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [ ] Added changeset if needed (`pnpm changeset`) (I dont think we should bump as its only for dev)
- [ ] Updated documentation if needed

### Changes
- New `container-runtime.ts` abstraction layer for runtime detection
- Updated test setup files in `postgres-backend` and `redis-backend` to support both Docker and Podman

### Files to review
- `packages/agenda/src/utils/container-runtime.ts`
- `packages/postgres-backend/test/setup.ts`
- `packages/redis-backend/test/setup.ts`

### How to test
```bash
# Run tests (will auto-detect Docker or Podman)
pnpm test

# On macOS, ensure Podman VM is running first:
podman machine init && podman machine start
```

⚠️ **Testing help needed**: This was tested with Podman. Please test with Docker to confirm Docker compatibility is preserved.

### Notes
- Non-breaking change; Docker compatibility fully preserved
- Automatically falls back to Podman if Docker is unavailable
- Test setup already handles both runtimes transparently

