### PR TITLE
Fix: add "default" export condition to all packages

### DIFF
--- a/.changeset/add-default-export-condition.md
+++ b/.changeset/add-default-export-condition.md
@@ -1,0 +1,12 @@
+---
+"agenda": patch
+"@agendajs/mongo-backend": patch
+"@agendajs/postgres-backend": patch
+"@agendajs/redis-backend": patch
+"agenda-rest": patch
+"agendash": patch
+---
+
+Add "default" export condition to all packages to support CommonJS require()
+
+The exports map only specified the "import" condition, which prevented CommonJS projects from using require() to load these packages. Node.js require() matches "require" or "default" conditions, not "import". With require(esm) now stable in Node.js 20.19+, 22.12+, and 24+, adding a "default" condition allows CJS projects to consume these ESM packages directly.

--- a/packages/agenda-rest/package.json
+++ b/packages/agenda-rest/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "bin": {

--- a/packages/agenda/package.json
+++ b/packages/agenda/package.json
@@ -8,11 +8,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./testing": {
       "types": "./test/shared/index.ts",
-      "import": "./test/shared/index.ts"
+      "import": "./test/shared/index.ts",
+      "default": "./test/shared/index.ts"
     }
   },
   "publishConfig": {

--- a/packages/agendash/package.json
+++ b/packages/agendash/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "publishConfig": {

--- a/packages/mongo-backend/package.json
+++ b/packages/mongo-backend/package.json
@@ -8,11 +8,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./testing": {
       "types": "./dist/testing.d.ts",
-      "import": "./dist/testing.js"
+      "import": "./dist/testing.js",
+      "default": "./dist/testing.js"
     }
   },
   "publishConfig": {

--- a/packages/postgres-backend/package.json
+++ b/packages/postgres-backend/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "publishConfig": {

--- a/packages/redis-backend/package.json
+++ b/packages/redis-backend/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
The exports map in all packages only specifies the "import" condition. This prevents CommonJS projects from using require() to load these packages, since Node.js require() matches "require" or "default" conditions — not "import".

With require(esm) now stable in Node.js 20.19+, 22.12+, and 24+, adding a "default" condition allows CJS projects to require() these ESM packages without needing workarounds (patches, dynamic import, or module name mappers).

The "default" condition points to the same dist files as "import", so there is no change in behavior for ESM consumers.

## Description

Brief description of changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Added changeset if needed (`pnpm changeset`)
- [ ] Updated documentation if needed
