### PR TITLE
fix(redis-backend): touch() not refreshing lock causes job to restart

### DIFF
--- a/.changeset/fix-redis-touch-lock.md
+++ b/.changeset/fix-redis-touch-lock.md
@@ -1,0 +1,5 @@
+---
+"@agendajs/redis-backend": patch
+---
+
+fix: touch() now correctly refreshes the lock in Redis, preventing long-running jobs from being re-picked up after lockLifetime elapses

--- a/packages/agenda/test/shared/agenda-test-suite.ts
+++ b/packages/agenda/test/shared/agenda-test-suite.ts
@@ -889,6 +889,36 @@ export function agendaTestSuite(config: AgendaTestConfig): void {
 					const result = await agenda.queryJobs({ id: jobId });
 					expect(result.jobs[0].progress).toBe(50);
 				});
+
+				it('should prevent long-running job from being re-locked after touch', async () => {
+					const lockLifetime = 500; // 500ms lock lifetime
+					let startCount = 0;
+
+					agenda.define(
+						'touch-relock-test',
+						async (job: Job) => {
+							startCount++;
+							// Run for 3x the lockLifetime, touching every 100ms
+							const iterations = Math.ceil((lockLifetime * 3) / 100);
+							for (let i = 0; i < iterations; i++) {
+								await delay(100);
+								await job.touch();
+							}
+						},
+						{ lockLifetime }
+					);
+
+					agenda.processEvery(200);
+					await agenda.start();
+					await agenda.now('touch-relock-test');
+
+					// Wait for 3x lockLifetime + buffer for the job to finish
+					await delay(lockLifetime * 3 + 500);
+					await agenda.stop();
+
+					// The job should have started exactly once — touch() keeps the lock alive
+					expect(startCount).toBe(1);
+				});
 			});
 
 			describe('fail', () => {
@@ -1497,7 +1527,14 @@ export function agendaTestSuite(config: AgendaTestConfig): void {
 					expect(agendaWithChannel.hasNotificationChannel()).toBe(true);
 				});
 
-				it('should accept notification channel via notifyVia method', async () => {
+				it('should accept notification channel via notifyVia method', async ({ skip }) => {
+					// Skip if backend already provides a notification channel,
+					// since Agenda picks it up automatically
+					if (backend.notificationChannel) {
+						skip();
+						return;
+					}
+
 					agendaWithChannel = new Agenda({ backend });
 					expect(agendaWithChannel.hasNotificationChannel()).toBe(false);
 
@@ -1560,6 +1597,112 @@ export function agendaTestSuite(config: AgendaTestConfig): void {
 				});
 			});
 		}
+
+		// Backend-provided notification channel tests
+		// Runs automatically when the backend provides a built-in notification channel
+		// (e.g., PostgresBackend with LISTEN/NOTIFY, RedisBackend with Pub/Sub)
+		describe('backend notification channel integration', () => {
+			let agendaWithNotify: Agenda;
+
+			afterEach(async () => {
+				if (agendaWithNotify) {
+					await agendaWithNotify.stop();
+					agendaWithNotify = undefined!;
+				}
+				await config.clearJobs(backend);
+			});
+
+			it('should automatically use the backend notification channel', async ({ skip }) => {
+				if (!backend.notificationChannel) {
+					skip();
+					return;
+				}
+
+				agendaWithNotify = new Agenda({ backend });
+				await agendaWithNotify.ready;
+
+				expect(agendaWithNotify.hasNotificationChannel()).toBe(true);
+			});
+
+			it('should process job immediately via backend notification channel with long processEvery', async ({ skip }) => {
+				if (!backend.notificationChannel) {
+					skip();
+					return;
+				}
+
+				// Simulate a real-world setup: 5 minute polling interval
+				// The notification channel should bypass the interval entirely
+				agendaWithNotify = new Agenda({
+					backend,
+					processEvery: 5 * 60 * 1000 // 5 minutes
+				});
+				await agendaWithNotify.ready;
+
+				let jobRan = false;
+				agendaWithNotify.define('notify-test-job', async () => {
+					jobRan = true;
+				});
+
+				await agendaWithNotify.start();
+
+				// Wait for the initial process() scan to complete so the processor is idle
+				await delay(200);
+
+				// Now schedule a job — the notification channel should trigger immediate pickup
+				const successPromise = waitForEvent(agendaWithNotify, 'success:notify-test-job', 5000);
+				await agendaWithNotify.now('notify-test-job');
+				await successPromise;
+
+				expect(jobRan).toBe(true);
+			});
+
+			it('should process job scheduled from a separate agenda instance via notification', async ({ skip }) => {
+				if (!backend.notificationChannel) {
+					skip();
+					return;
+				}
+
+				// Simulates the publisher/worker pattern with separate backends
+				// (as in a real multi-process deployment)
+				const publisherBackend = await config.createBackend();
+
+				const worker = new Agenda({
+					backend,
+					processEvery: 5 * 60 * 1000 // 5 minutes
+				});
+				await worker.ready;
+
+				let jobRan = false;
+				worker.define('cross-instance-job', async () => {
+					jobRan = true;
+				});
+
+				await worker.start();
+
+				// Wait for initial scan
+				await delay(200);
+
+				// Separate publisher instance — only schedules jobs, does NOT process them.
+				// This mirrors a common pattern: API server schedules, worker processes.
+				// The publisher does NOT define the job, so it won't try to lock/run it.
+				const publisher = new Agenda({ backend: publisherBackend });
+				await publisher.ready;
+
+				// Start publisher to connect its notification channel
+				await publisher.start();
+
+				// Schedule from the publisher — worker should pick it up via notification
+				const successPromise = waitForEvent(worker, 'success:cross-instance-job', 5000);
+				await publisher.now('cross-instance-job');
+				await successPromise;
+
+				expect(jobRan).toBe(true);
+
+				await publisher.stop();
+				await config.cleanupBackend(publisherBackend);
+				agendaWithNotify = worker; // let afterEach clean up
+			});
+		});
 
 		// Fork mode tests - skip if configured to skip or if forkHelper is not provided
 		if (!config.skip?.forkMode && config.forkHelper) {

--- a/packages/redis-backend/src/RedisJobRepository.ts
+++ b/packages/redis-backend/src/RedisJobRepository.ts
@@ -95,7 +95,9 @@ export class RedisJobRepository implements JobRepository {
 			nextRunAt: data.nextRunAt && data.nextRunAt !== 'null' ? new Date(data.nextRunAt) : null,
 			type: data.type as 'normal' | 'single',
 			lockedAt:
-				data.lockedAt && data.lockedAt !== 'null' ? new Date(data.lockedAt) : undefined,
+				data.lockedAtMs && data.lockedAtMs !== 'null'
+					? new Date(parseInt(data.lockedAtMs, 10))
+					: undefined,
 			lastFinishedAt:
 				data.lastFinishedAt && data.lastFinishedAt !== 'null'
 					? new Date(data.lastFinishedAt)
@@ -150,7 +152,7 @@ export class RedisJobRepository implements JobRepository {
 			priority: String(job.priority ?? 0),
 			nextRunAt: job.nextRunAt?.toISOString() || 'null',
 			type: job.type || 'normal',
-			lockedAt: job.lockedAt?.toISOString() || 'null',
+			lockedAtMs: job.lockedAt ? String(job.lockedAt.getTime()) : 'null',
 			lastFinishedAt: job.lastFinishedAt?.toISOString() || 'null',
 			failedAt: job.failedAt?.toISOString() || 'null',
 			failCount: job.failCount !== undefined ? String(job.failCount) : 'null',
@@ -526,7 +528,7 @@ export class RedisJobRepository implements JobRepository {
 		// Only unlock jobs which are not currently processed (nextRunAt is not null)
 		const nextRunAt = await this.redis.hget(this.key(`job:${jobId}`), 'nextRunAt');
 		if (nextRunAt && nextRunAt !== 'null') {
-			await this.redis.hset(this.key(`job:${jobId}`), 'lockedAt', 'null');
+			await this.redis.hset(this.key(`job:${jobId}`), 'lockedAtMs', 'null');
 		}
 	}
 
@@ -535,7 +537,7 @@ export class RedisJobRepository implements JobRepository {
 
 		for (const jobId of jobIds) {
 			const id = jobId.toString();
-			await this.redis.hset(this.key(`job:${id}`), 'lockedAt', 'null');
+			await this.redis.hset(this.key(`job:${id}`), 'lockedAtMs', 'null');
 		}
 	}
 
@@ -559,7 +561,7 @@ export class RedisJobRepository implements JobRepository {
 			}
 
 			// Check conditions
-			if (jobData.lockedAt !== 'null') {
+			if (jobData.lockedAtMs && jobData.lockedAtMs !== 'null') {
 				await this.redis.unwatch();
 				return undefined;
 			}
@@ -582,7 +584,7 @@ export class RedisJobRepository implements JobRepository {
 			// Lock the job atomically
 			const result = await this.redis
 				.multi()
-				.hset(this.key(`job:${jobId}`), 'lockedAt', now.toISOString())
+				.hset(this.key(`job:${jobId}`), 'lockedAtMs', String(now.getTime()))
 				.hset(this.key(`job:${jobId}`), 'lastModifiedBy', options?.lastModifiedBy ?? 'null')
 				.hset(this.key(`job:${jobId}`), 'updatedAt', now.toISOString())
 				.exec();
@@ -660,15 +662,14 @@ export class RedisJobRepository implements JobRepository {
 
 				-- Check if disabled
 				if data.disabled ~= 'true' then
-					local lockedAt = data.lockedAt
-					local nextRunAt = data.nextRunAt
 					local lockedAtMs = data.lockedAtMs
+					local nextRunAt = data.nextRunAt
 
 					-- Check if job is ready to run
 					local isUnlockedAndReady = false
 					local isStale = false
 
-					if lockedAt == 'null' or lockedAt == nil then
+					if not lockedAtMs or lockedAtMs == 'null' then
 						-- Job is unlocked
 						if nextRunAt and nextRunAt ~= 'null' then
 							-- We compare scores since they're based on nextRunAt
@@ -677,20 +678,18 @@ export class RedisJobRepository implements JobRepository {
 							end
 						end
 					else
-						-- Job is locked - check if stale using lockedAtMs field
-						if lockedAtMs and lockedAtMs ~= 'null' then
-							local lockedAtTime = tonumber(lockedAtMs)
-							if lockedAtTime and lockedAtTime <= lockDeadline then
-								isStale = true
-							end
+						-- Job is locked - check if stale
+						local lockedAtTime = tonumber(lockedAtMs)
+						if lockedAtTime and lockedAtTime <= lockDeadline then
+							isStale = true
 						end
 					end
 
 					if isUnlockedAndReady or isStale then
-						-- Lock the job atomically, also store lockedAtMs for efficient stale checks
+						-- Lock the job atomically
 						local lockTimeMs = redis.call('TIME')
 						local lockTimestamp = (lockTimeMs[1] * 1000) + math.floor(lockTimeMs[2] / 1000)
-						redis.call('HSET', jobKey, 'lockedAt', lockTime, 'lockedAtMs', tostring(lockTimestamp), 'lastModifiedBy', lastModifiedBy, 'updatedAt', lockTime)
+						redis.call('HSET', jobKey, 'lockedAtMs', tostring(lockTimestamp), 'lastModifiedBy', lastModifiedBy, 'updatedAt', lockTime)
 						return candidate.id
 					end
 				end
@@ -757,7 +756,7 @@ export class RedisJobRepository implements JobRepository {
 
 		// Update state fields
 		const updates: Record<string, string> = {
-			lockedAt: job.lockedAt?.toISOString() || 'null',
+			lockedAtMs: job.lockedAt ? String(job.lockedAt.getTime()) : 'null',
 			nextRunAt: job.nextRunAt?.toISOString() || 'null',
 			lastRunAt: job.lastRunAt?.toISOString() || 'null',
 			progress: job.progress !== undefined ? String(job.progress) : 'null',

--- a/packages/redis-backend/src/types.ts
+++ b/packages/redis-backend/src/types.ts
@@ -38,7 +38,7 @@ export interface RedisJobData {
 	priority: string;
 	nextRunAt: string | null;
 	type: 'normal' | 'single';
-	lockedAt: string | null;
+	lockedAtMs: string | null;
 	lastFinishedAt: string | null;
 	failedAt: string | null;
 	failCount: string | null;


### PR DESCRIPTION
## Summary

- **Bug**: In the Redis backend, `saveJobState()` (called by `touch()`) updated `lockedAt` (ISO string) but not `lockedAtMs` (epoch ms). The Lua stale-lock check in `getNextJobToRun` used `lockedAtMs`, so `touch()` never actually refreshed the lock — causing long-running jobs to be re-picked up after `lockLifetime` elapsed.
- **Fix**: Consolidated to `lockedAtMs` as single source of truth for lock state in Redis. Removed redundant `lockedAt` ISO string field. `hashToJob()` converts ms back to `Date` on read.
- Added regression test that verifies `touch()` prevents re-locking (fails without fix, passes with it).

Fixes #1683

## Test plan

- [x] New test `should prevent long-running job from being re-locked after touch` — verified it fails without fix, passes with fix on Redis
- [x] Full Redis backend test suite (209 tests pass)
- [x] Full MongoDB backend test suite (236 tests pass)