### PR TITLE
Add cancelAll() method and refactor data filtering logic

### DIFF
--- a/.changeset/cancel-all-method.md
+++ b/.changeset/cancel-all-method.md
@@ -1,0 +1,8 @@
+---
+"agenda": patch
+"@agendajs/mongo-backend": patch
+"@agendajs/postgres-backend": patch
+"@agendajs/redis-backend": patch
+---
+
+Add `cancelAll()` method to remove all jobs unconditionally. Also fix Redis backend ignoring `data` filter when combined with `name` in `cancel()`.

--- a/README.md
+++ b/README.md
@@ -1252,19 +1252,30 @@ const { jobs, total } = await agenda.queryJobs({ name: 'printAnalyticsReport', l
 
 ### cancel(options)
 
-Cancels any jobs matching the passed query options, and removes them from the database. Returns a Promise resolving to the number of cancelled jobs, or rejecting on error.
+Cancels any jobs matching the passed query options, and removes them from the database. Returns a Promise resolving to the number of cancelled jobs, or rejecting on error. At least one filter option must be provided — passing an empty object `cancel({})` is a safe no-op and removes nothing.
 
 Options:
 - `id` / `ids` — Match by job ID(s)
 - `name` / `names` — Match by job name(s)
 - `notNames` — Exclude jobs matching these names
-- `data` — Match by job data
+- `data` — Match by job data (can be combined with `name` to narrow the filter)
 
 ```js
 const numRemoved = await agenda.cancel({ name: 'printAnalyticsReport' });
+
+// Cancel only jobs with specific data
+const numRemoved = await agenda.cancel({ name: 'sendEmail', data: { userId: 123 } });
 ```
 
 This functionality can also be achieved by first retrieving all the jobs from the database using `agenda.queryJobs()`, looping through the resulting array and calling `job.remove()` on each. It is however preferable to use `agenda.cancel()` for this use case, as this ensures the operation is atomic.
+
+### cancelAll()
+
+Removes **all** jobs from the database unconditionally. Use with caution — this cannot be undone. Returns a Promise resolving to the number of removed jobs.
+
+```js
+const numRemoved = await agenda.cancelAll();
+```
 
 ### disable(options)
 
@@ -1288,9 +1299,9 @@ Similar to `agenda.cancel()`, this functionality can be achieved with a combinat
 
 ### purge()
 
-Removes all jobs in the database without defined behaviors. Useful if you change a definition name and want to remove old jobs. Returns a Promise resolving to the number of removed jobs, or rejecting on error.
+Removes all **orphaned** jobs — jobs whose names do not match any currently defined job. Useful if you rename a job definition and want to clean up old entries. Returns a Promise resolving to the number of removed jobs, or rejecting on error.
 
-_IMPORTANT:_ Do not run this before you finish defining all of your jobs. If you do, you will nuke your database of jobs.
+_IMPORTANT:_ Do not run this before you finish defining all of your jobs, otherwise jobs without a definition will be removed.
 
 ```js
 const numRemoved = await agenda.purge();

--- a/packages/agenda/README.md
+++ b/packages/agenda/README.md
@@ -252,8 +252,12 @@ await agenda.every('0 * * * *', 'my-job'); // Cron syntax
 ### Job Control
 
 ```javascript
-// Cancel jobs (removes from database)
+// Cancel jobs matching a filter (removes from database)
 await agenda.cancel({ name: 'my-job' });
+await agenda.cancel({ name: 'my-job', data: { userId: 123 } });
+
+// Cancel ALL jobs unconditionally
+await agenda.cancelAll();
 
 // Disable/enable jobs globally (by query)
 await agenda.disable({ name: 'my-job' });  // Disable all jobs matching query

--- a/packages/agenda/src/index.ts
+++ b/packages/agenda/src/index.ts
@@ -697,13 +697,31 @@ export class Agenda extends EventEmitter {
 	}
 
 	/**
-	 * Removes all jobs from queue
+	 * Removes all orphaned jobs (jobs whose names are not currently defined).
 	 * @note: Only use after defining your jobs
 	 */
 	async purge(): Promise<number> {
 		const definedNames = Object.keys(this.definitions);
 		log('Agenda.purge(%o)', definedNames);
 		return this.cancel({ notNames: definedNames });
+	}
+
+	/**
+	 * Removes ALL jobs from the database unconditionally.
+	 * Use with caution — this cannot be undone.
+	 * @returns Number of jobs removed
+	 */
+	async cancelAll(): Promise<number> {
+		log('Agenda.cancelAll()');
+		await this.ready;
+		try {
+			const removed = await this.db.purgeAllJobs();
+			log('%s jobs cancelled', removed);
+			return removed;
+		} catch (error) {
+			log('error trying to cancel all jobs from database');
+			throw error;
+		}
 	}
 
 	/**

--- a/packages/agenda/src/types/JobRepository.ts
+++ b/packages/agenda/src/types/JobRepository.ts
@@ -122,4 +122,10 @@ export interface JobRepository {
 	 * @returns Number of jobs enabled
 	 */
 	enableJobs(options: RemoveJobsOptions): Promise<number>;
+
+	/**
+	 * Remove ALL jobs from the database unconditionally.
+	 * @returns Number of jobs removed
+	 */
+	purgeAllJobs(): Promise<number>;
 }

--- a/packages/agenda/test/decorators.test.ts
+++ b/packages/agenda/test/decorators.test.ts
@@ -57,6 +57,9 @@ class MockJobRepository implements JobRepository {
 	async enableJobs() {
 		return 0;
 	}
+	async purgeAllJobs() {
+		return 0;
+	}
 }
 
 /**

--- a/packages/agenda/test/shared/agenda-test-suite.ts
+++ b/packages/agenda/test/shared/agenda-test-suite.ts
@@ -243,6 +243,33 @@ export function agendaTestSuite(config: AgendaTestConfig): void {
 				expect(result.jobs.length).toBe(1);
 				expect(result.jobs[0].name).toBe('keep-test');
 			});
+
+			it('should cancel only jobs matching both name and data filter', async () => {
+				await agenda.now('cancel-data-test', { userId: 1 });
+				await agenda.now('cancel-data-test', { userId: 2 });
+				await agenda.now('cancel-data-test', { userId: 3 });
+
+				const cancelled = await agenda.cancel({ name: 'cancel-data-test', data: { userId: 2 } });
+				expect(cancelled).toBe(1);
+
+				const result = await agenda.queryJobs({ name: 'cancel-data-test' });
+				expect(result.jobs.length).toBe(2);
+				const remaining = result.jobs.map(j => (j.data as { userId: number }).userId).sort();
+				expect(remaining).toEqual([1, 3]);
+			});
+
+			it('should cancel jobs matching data filter with nested objects', async () => {
+				await agenda.now('cancel-nested-test', { org: { id: 'abc' }, type: 'sync' });
+				await agenda.now('cancel-nested-test', { org: { id: 'def' }, type: 'sync' });
+				await agenda.now('cancel-nested-test', { org: { id: 'abc' }, type: 'backup' });
+
+				const cancelled = await agenda.cancel({ name: 'cancel-nested-test', data: { org: { id: 'abc' } } });
+				expect(cancelled).toBe(2);
+
+				const result = await agenda.queryJobs({ name: 'cancel-nested-test' });
+				expect(result.jobs.length).toBe(1);
+				expect((result.jobs[0].data as { org: { id: string } }).org.id).toBe('def');
+			});
 		});
 
 		describe('job disable/enable', () => {

--- a/packages/agenda/test/shared/agenda-test-suite.ts
+++ b/packages/agenda/test/shared/agenda-test-suite.ts
@@ -641,6 +641,28 @@ export function agendaTestSuite(config: AgendaTestConfig): void {
 			});
 		});
 
+		describe('cancelAll()', () => {
+			it('should remove all jobs from the database', async () => {
+				await agenda.now('cancelAll-test-1');
+				await agenda.now('cancelAll-test-2');
+				await agenda.now('cancelAll-test-3');
+
+				const before = await agenda.queryJobs({});
+				expect(before.total).toBe(3);
+
+				const removed = await agenda.cancelAll();
+				expect(removed).toBe(3);
+
+				const after = await agenda.queryJobs({});
+				expect(after.total).toBe(0);
+			});
+
+			it('should return 0 when no jobs exist', async () => {
+				const removed = await agenda.cancelAll();
+				expect(removed).toBe(0);
+			});
+		});
+
 		describe('unique constraint', () => {
 			it('should modify one job when unique matches', async () => {
 				const job1 = await agenda

--- a/packages/agenda/test/state-notifications.test.ts
+++ b/packages/agenda/test/state-notifications.test.ts
@@ -42,6 +42,9 @@ class MockJobRepository implements JobRepository {
 	async enableJobs() {
 		return 0;
 	}
+	async purgeAllJobs() {
+		return 0;
+	}
 	async saveJob<DATA = unknown>(job: JobParameters<DATA>): Promise<JobParameters<DATA>> {
 		return { ...job, _id: job._id || toJobId('mock-id') };
 	}

--- a/packages/agenda/test/unit.test.ts
+++ b/packages/agenda/test/unit.test.ts
@@ -38,6 +38,9 @@ class MockJobRepository implements JobRepository {
 	async enableJobs() {
 		return 0;
 	}
+	async purgeAllJobs() {
+		return 0;
+	}
 	async saveJob<DATA = unknown>(job: JobParameters<DATA>): Promise<JobParameters<DATA>> {
 		return { ...job, _id: job._id || toJobId('mock-id') };
 	}

--- a/packages/mongo-backend/src/MongoJobRepository.ts
+++ b/packages/mongo-backend/src/MongoJobRepository.ts
@@ -428,6 +428,11 @@ export class MongoJobRepository implements JobRepository {
 		return result.modifiedCount;
 	}
 
+	async purgeAllJobs(): Promise<number> {
+		const result = await this.collection.deleteMany({});
+		return result.deletedCount;
+	}
+
 	async unlockJob(job: JobParameters): Promise<void> {
 		if (!job._id) return;
 		// only unlock jobs which are not currently processed (nextRunAt is not null)

--- a/packages/postgres-backend/src/PostgresJobRepository.ts
+++ b/packages/postgres-backend/src/PostgresJobRepository.ts
@@ -464,6 +464,11 @@ export class PostgresJobRepository implements JobRepository {
 		return result.rowCount || 0;
 	}
 
+	async purgeAllJobs(): Promise<number> {
+		const result = await this.pool.query(`DELETE FROM "${this.tableName}"`);
+		return result.rowCount || 0;
+	}
+
 	async unlockJob(job: JobParameters): Promise<void> {
 		if (!job._id) return;
 

--- a/packages/redis-backend/src/RedisJobRepository.ts
+++ b/packages/redis-backend/src/RedisJobRepository.ts
@@ -392,18 +392,19 @@ export class RedisJobRepository implements JobRepository {
 			const excludeIds = new Set(await this.redis.sunion(...excludeSets));
 			jobIds = allIds.filter((id: string) => !excludeIds.has(id));
 		} else if (options.data !== undefined) {
-			// Need to scan all jobs for data match
-			const allIds = await this.redis.smembers(this.key('jobs:all'));
-			const searchDataStr = JSON.stringify(options.data);
-			for (const jobId of allIds) {
-				const jobData = await this.redis.hget(this.key(`job:${jobId}`), 'data');
-				if (jobData && jobData.includes(searchDataStr.slice(1, -1))) {
-					jobIds.push(jobId);
-				}
-			}
+			// No name/id filter — scan all jobs for data match
+			jobIds = await this.filterJobIdsByData(
+				await this.redis.smembers(this.key('jobs:all')),
+				options.data
+			);
 		} else {
 			// No criteria - don't delete anything
 			return 0;
+		}
+
+		// Apply data filter as a secondary filter when combined with name/id filters
+		if (options.data !== undefined && (options.name || options.names || options.notNames || options.id || options.ids)) {
+			jobIds = await this.filterJobIdsByData(jobIds, options.data);
 		}
 
 		if (jobIds.length === 0) {
@@ -424,43 +425,57 @@ export class RedisJobRepository implements JobRepository {
 	}
 
 	/**
+	 * Filter job IDs by matching against their stored data field.
+	 * Uses a substring match on the JSON-serialized data.
+	 */
+	private async filterJobIdsByData(jobIds: string[], dataFilter: unknown): Promise<string[]> {
+		const searchDataStr = JSON.stringify(dataFilter);
+		const matching: string[] = [];
+		for (const jobId of jobIds) {
+			const jobData = await this.redis.hget(this.key(`job:${jobId}`), 'data');
+			if (jobData && jobData.includes(searchDataStr.slice(1, -1))) {
+				matching.push(jobId);
+			}
+		}
+		return matching;
+	}
+
+	/**
 	 * Get job IDs matching the given options
 	 */
 	private async getJobIdsFromOptions(options: RemoveJobsOptions): Promise<string[]> {
+		let jobIds: string[] = [];
+
 		if (options.id) {
-			return [options.id.toString()];
-		}
-		if (options.ids && options.ids.length > 0) {
-			return options.ids.map((id: JobId | string) => id.toString());
-		}
-		if (options.name) {
-			return this.redis.smembers(this.key(`jobs:by_name:${options.name}`));
-		}
-		if (options.names && options.names.length > 0) {
+			jobIds = [options.id.toString()];
+		} else if (options.ids && options.ids.length > 0) {
+			jobIds = options.ids.map((id: JobId | string) => id.toString());
+		} else if (options.name) {
+			jobIds = await this.redis.smembers(this.key(`jobs:by_name:${options.name}`));
+		} else if (options.names && options.names.length > 0) {
 			const sets = options.names.map((n: string) => this.key(`jobs:by_name:${n}`));
-			return this.redis.sunion(...sets);
-		}
-		if (options.notNames && options.notNames.length > 0) {
+			jobIds = await this.redis.sunion(...sets);
+		} else if (options.notNames && options.notNames.length > 0) {
 			const allIds = await this.redis.smembers(this.key('jobs:all'));
 			const excludeSets = options.notNames.map((n: string) => this.key(`jobs:by_name:${n}`));
 			const excludeIds = new Set(await this.redis.sunion(...excludeSets));
-			return allIds.filter((id: string) => !excludeIds.has(id));
+			jobIds = allIds.filter((id: string) => !excludeIds.has(id));
+		} else if (options.data !== undefined) {
+			// No name/id filter — scan all jobs for data match
+			return this.filterJobIdsByData(
+				await this.redis.smembers(this.key('jobs:all')),
+				options.data
+			);
+		} else {
+			return [];
 		}
+
+		// Apply data filter as a secondary filter when combined with name/id filters
 		if (options.data !== undefined) {
-			// Need to scan all jobs for data match
-			const allIds = await this.redis.smembers(this.key('jobs:all'));
-			const searchDataStr = JSON.stringify(options.data);
-			const matchingIds: string[] = [];
-			for (const jobId of allIds) {
-				const jobData = await this.redis.hget(this.key(`job:${jobId}`), 'data');
-				if (jobData && jobData.includes(searchDataStr.slice(1, -1))) {
-					matchingIds.push(jobId);
-				}
-			}
-			return matchingIds;
+			jobIds = await this.filterJobIdsByData(jobIds, options.data);
 		}
-		// No criteria - return empty array
-		return [];
+
+		return jobIds;
 	}
 
 	async disableJobs(options: RemoveJobsOptions): Promise<number> {

--- a/packages/redis-backend/src/RedisJobRepository.ts
+++ b/packages/redis-backend/src/RedisJobRepository.ts
@@ -516,6 +516,25 @@ export class RedisJobRepository implements JobRepository {
 		return modified;
 	}
 
+	async purgeAllJobs(): Promise<number> {
+		const allIds = await this.redis.smembers(this.key('jobs:all'));
+		if (allIds.length === 0) {
+			return 0;
+		}
+
+		let removed = 0;
+		for (const jobId of allIds) {
+			const jobData = await this.redis.hgetall(this.key(`job:${jobId}`));
+			if (!jobData || Object.keys(jobData).length === 0) continue;
+
+			const job = this.hashToJob(jobData);
+			await this.deleteJob(jobId, job.name, job.type);
+			removed++;
+		}
+
+		return removed;
+	}
+
 	private async deleteJob(id: string, name: string, type: string): Promise<void> {
 		const pipeline = this.redis.pipeline();
 


### PR DESCRIPTION
## Description

This PR adds a new `cancelAll()` method to unconditionally remove all jobs from the database, and refactors the data filtering logic in job repositories to reduce code duplication and improve maintainability.

### Key Changes

1. **New `cancelAll()` method**: Added to `Agenda` class and implemented across all job repository backends (Redis, MongoDB, PostgreSQL). This method removes ALL jobs unconditionally and should be used with caution.

2. **Refactored data filtering**: Extracted the data matching logic into a reusable `filterJobIdsByData()` private method in `RedisJobRepository` to eliminate code duplication.

3. **Improved filter composition**: Fixed the logic for combining multiple filter criteria (name/id filters with data filters) by applying data filtering as a secondary filter when combined with other criteria.

4. **Updated interface**: Added `purgeAllJobs()` method to the `JobRepository` interface and implemented it in all backends.

5. **Test coverage**: Added comprehensive tests for:
   - Cancelling jobs matching both name and data filters
   - Cancelling jobs with nested object data filters
   - The new `cancelAll()` method behavior

### Motivation

- Provides a way to completely clear the job queue when needed
- Reduces code duplication in data filtering logic
- Improves correctness of combined filter operations
- Makes the codebase more maintainable

## Type of Change

- [x] New feature
- [x] Code refactoring

## Checklist

- [x] Tests pass (new tests added for `cancelAll()` and combined filters)
- [x] Linting passes
- [x] Updated interface and all implementations
- [x] Added JSDoc comments for new public methods

https://claude.ai/code/session_01JqnVrUycpUkjHYMfw4RwG3