### PR TITLE
fix: preserve error stacks in fail reason

### DIFF
--- a/.changeset/preserve-error-stacks.md
+++ b/.changeset/preserve-error-stacks.md
@@ -1,0 +1,5 @@
+---
+"agenda": patch
+---
+
+Preserve Error stack traces in `job.attrs.failReason` when jobs fail with an Error.

--- a/README.md
+++ b/README.md
@@ -1580,7 +1580,8 @@ await job.save();
 Sets `job.attrs.failedAt` to `now`, and sets `job.attrs.failReason` to `reason`.
 
 Optionally, `reason` can be an error, in which case `job.attrs.failReason` will
-be set to `error.message`
+be set to `error.stack`. If the error has no stack, Agenda falls back to
+`error.message`.
 
 ```js
 job.fail('insufficient disk space');

--- a/packages/agenda/src/Job.ts
+++ b/packages/agenda/src/Job.ts
@@ -332,7 +332,7 @@ export class Job<DATA = unknown | void> {
 	 * @param reason
 	 */
 	fail(reason: Error | string): this {
-		this.attrs.failReason = reason instanceof Error ? reason.message : reason;
+		this.attrs.failReason = reason instanceof Error ? reason.stack || reason.message : reason;
 		this.attrs.failCount = (this.attrs.failCount || 0) + 1;
 		const now = new Date();
 		this.attrs.failedAt = now;

--- a/packages/agenda/test/unit.test.ts
+++ b/packages/agenda/test/unit.test.ts
@@ -428,9 +428,18 @@ describe('Job Unit Tests', () => {
 	});
 
 	describe('fail', () => {
-		it('sets failReason from Error', () => {
+		it('sets failReason from Error stack', () => {
 			const job = new Job(agenda, { name: 'demo', type: 'normal' });
 			job.fail(new Error('Test error'));
+			expect(job.attrs.failReason).toContain('Error: Test error');
+			expect(job.attrs.failReason).toContain('at ');
+		});
+
+		it('falls back to Error message when stack is unavailable', () => {
+			const job = new Job(agenda, { name: 'demo', type: 'normal' });
+			const error = new Error('Test error');
+			error.stack = undefined;
+			job.fail(error);
 			expect(job.attrs.failReason).toBe('Test error');
 		});
 


### PR DESCRIPTION
## Summary

Preserves stack traces when a job fails with an `Error`.

Previously, `job.fail(error)` stored only `error.message` in `job.attrs.failReason`, which made Agendash and stored job state less useful for debugging. This change stores `error.stack` when available and falls back to `error.message` when a stack is unavailable.

String fail reasons are unchanged.

## Related

Helps address #1698.

## Changeset

Included a patch changeset for the `agenda` package.

## Verification

- `pnpm --filter agenda test`
- `pnpm --filter agenda build`
- `pnpm --filter agenda typecheck`
- `pnpm lint`
- `pnpm build`