### PR TITLE
fix mongo data filtering for ObjectId values

### DIFF
--- a/.changeset/clean-bulldogs-occur.md
+++ b/.changeset/clean-bulldogs-occur.md
@@ -1,0 +1,5 @@
+---
+"@agendajs/mongo-backend": patch
+---
+
+fix mongo data filtering for ObjectId values

--- a/packages/mongo-backend/src/MongoJobRepository.ts
+++ b/packages/mongo-backend/src/MongoJobRepository.ts
@@ -39,6 +39,18 @@ function escapeRegex(str: string): string {
 }
 
 /**
+ * Check if a value is a plain object (not an array, date, or other non-plain type)
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	if (value === null || typeof value !== 'object') {
+		return false;
+	}
+
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null;
+}
+
+/**
  * Flatten a data filter object into MongoDB dot-notation keys.
  * This enables partial matching on the data subdocument.
  *
@@ -51,8 +63,8 @@ function flattenDataFilter(data: Record<string, unknown>, prefix = 'data'): Reco
 	const result: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(data)) {
 		const fullKey = `${prefix}.${key}`;
-		if (value !== null && typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date)) {
-			Object.assign(result, flattenDataFilter(value as Record<string, unknown>, fullKey));
+		if (isPlainObject(value)) {
+			Object.assign(result, flattenDataFilter(value, fullKey));
 		} else {
 			result[fullKey] = value;
 		}

--- a/packages/mongo-backend/test/mongo-backend.test.ts
+++ b/packages/mongo-backend/test/mongo-backend.test.ts
@@ -270,6 +270,78 @@ describe('MongoBackend', () => {
 			expect(afterRemove.total).toBe(0);
 		});
 
+		it('should support array values when filtering job data', async () => {
+			const tags = ['first', 'second'];
+
+			await backend.repository.saveJob({
+				name: 'array-data-test',
+				priority: 0,
+				nextRunAt: new Date(),
+				type: 'normal',
+				data: {
+					tags,
+					extra: 'field'
+				}
+			}, undefined);
+
+			const result = await backend.repository.queryJobs({
+				data: {
+					tags
+				}
+			});
+
+			expect(result.total).toBe(1);
+			expect(result.jobs[0].data).toEqual({
+				tags,
+				extra: 'field'
+			});
+
+			const removed = await backend.repository.removeJobs({
+				name: 'array-data-test',
+				data: {
+					tags
+				}
+			});
+
+			expect(removed).toBe(1);
+		});
+
+		it('should support Date values when filtering job data', async () => {
+			const scheduledAt = new Date('2026-05-05T12:36:42.952Z');
+
+			await backend.repository.saveJob({
+				name: 'date-data-test',
+				priority: 0,
+				nextRunAt: new Date(),
+				type: 'normal',
+				data: {
+					scheduledAt,
+					extra: 'field'
+				}
+			}, undefined);
+
+			const result = await backend.repository.queryJobs({
+				data: {
+					scheduledAt
+				}
+			});
+
+			expect(result.total).toBe(1);
+			expect(result.jobs[0].data).toEqual({
+				scheduledAt,
+				extra: 'field'
+			});
+
+			const removed = await backend.repository.removeJobs({
+				name: 'date-data-test',
+				data: {
+					scheduledAt
+				}
+			});
+
+			expect(removed).toBe(1);
+		});
+
 		it('should handle concurrent job locking with findOneAndUpdate', async () => {
 			await Promise.all([
 				backend.repository.saveJob({

--- a/packages/mongo-backend/test/mongo-backend.test.ts
+++ b/packages/mongo-backend/test/mongo-backend.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
-import { Db, MongoClient } from 'mongodb';
+import { Db, MongoClient, ObjectId } from 'mongodb';
 import { randomUUID } from 'crypto';
 import { InMemoryNotificationChannel } from 'agenda';
 import { MongoBackend, MongoJobRepository, MongoJobLogger } from '../src/index.js';
@@ -226,6 +226,48 @@ describe('MongoBackend', () => {
 
 			expect(result.total).toBe(1);
 			expect(result.jobs[0].data).toEqual({ searchField: 'searchValue', anotherField: 'anotherValue' });
+		});
+
+		it('should support ObjectId values when filtering job data', async () => {
+			const userId = new ObjectId();
+
+			await backend.repository.saveJob({
+				name: 'objectid-data-test',
+				priority: 0,
+				nextRunAt: new Date(),
+				type: 'normal',
+				data: {
+					userId,
+					extra: 'field'
+				}
+			}, undefined);
+
+			const result = await backend.repository.queryJobs({
+				data: {
+					userId
+				}
+			});
+
+			expect(result.total).toBe(1);
+			expect(result.jobs[0].data).toEqual({
+				userId,
+				extra: 'field'
+			});
+
+			const removed = await backend.repository.removeJobs({
+				name: 'objectid-data-test',
+				data: {
+					userId
+				}
+			});
+
+			expect(removed).toBe(1);
+
+			const afterRemove = await backend.repository.queryJobs({
+				name: 'objectid-data-test'
+			});
+
+			expect(afterRemove.total).toBe(0);
 		});
 
 		it('should handle concurrent job locking with findOneAndUpdate', async () => {


### PR DESCRIPTION
## Summary

Fixes Mongo backend filtering when job `data` contains BSON values such as `ObjectId`.

Previously, `flattenDataFilter()` recursively flattened any non-null object except `Date`. Since MongoDB `ObjectId` is also an object in JavaScript, filters like this did not match correctly:

```ts
{
  data: {
    userId: new ObjectId(...)
  }
}
```

Instead of preserving the value as:

```ts
{
  "data.userId": ObjectId(...)
}
```

the filter could incorrectly treat the `ObjectId` as a nested object.

## Changes

- Add an `isPlainObject()` helper.
- Only recursively flatten plain objects.
- Preserve `ObjectId` and other non-plain object values as terminal filter values.
- Add a regression test covering `queryJobs()` and `removeJobs()` with `ObjectId` inside job data.

## Related issue

Fixes #1702

## Test plan

```bash
pnpm --filter @agendajs/mongo-backend exec vitest run test/mongo-backend.test.ts -t "ObjectId values when filtering job data"
pnpm --filter @agendajs/mongo-backend exec vitest run test/mongo-backend.test.ts -t "MongoDB-specific features"
pnpm --filter @agendajs/mongo-backend typecheck
pnpm --filter @agendajs/mongo-backend build
```
The focused MongoDB-specific tests for this change pass.