### PR TITLE
docs: document richer error context capture

### DIFF
--- a/.changeset/document-error-context.md
+++ b/.changeset/document-error-context.md
@@ -1,0 +1,5 @@
+---
+"agenda": patch
+---
+
+Document how to capture richer error context with fail event listeners.

--- a/README.md
+++ b/README.md
@@ -1697,6 +1697,24 @@ agenda.on('fail:send email', (err, job) => {
 });
 ```
 
+If you need richer error context, such as stack traces or structured metadata,
+capture it from the `fail` event and persist it outside Agenda:
+
+```js
+agenda.on('fail', async (err, job) => {
+	await saveJobError({
+		jobId: job.attrs._id,
+		jobName: job.attrs.name,
+		failedAt: job.attrs.failedAt,
+		message: err.message,
+		stack: err.stack
+	});
+});
+```
+
+`job.attrs.failReason` is stored with the job and is intended to stay small.
+Use external logging, monitoring, or your own error store for larger payloads.
+
 - `retry` - called when a job is scheduled for automatic retry (requires backoff strategy)
 - `retry:job name` - called when a specific job is scheduled for retry
 

--- a/packages/agenda/README.md
+++ b/packages/agenda/README.md
@@ -313,6 +313,20 @@ agenda.on('start:send email', (job) => { /* ... */ });
 agenda.on('fail:send email', (err, job) => { /* ... */ });
 ```
 
+Use `fail` listeners to capture richer error context, such as stack traces,
+without storing large payloads in `job.attrs.failReason`:
+
+```javascript
+agenda.on('fail', async (err, job) => {
+	await saveJobError({
+		jobId: job.attrs._id,
+		jobName: job.attrs.name,
+		message: err.message,
+		stack: err.stack
+	});
+});
+```
+
 ## Custom Backend
 
 For databases other than MongoDB, PostgreSQL, or Redis, implement `AgendaBackend`:


### PR DESCRIPTION
## Summary

Documents the recommended pattern for capturing richer error context from `fail` listeners instead of storing large payloads in `job.attrs.failReason`.

This follows the maintainer guidance from #1700: keep Agenda core lean, keep `failReason` small, and let users persist stack traces or structured metadata in their own logging/monitoring systems.

## Related

Follow-up to #1698 and #1700.

## Verification

- `git diff --cached --check`
- `pnpm changeset status --since origin/main`