### PR TITLE
feat(koa-router): replace `koa-router` with `@koa/router`

### DIFF
--- a/.changeset/upset-areas-invent.md
+++ b/.changeset/upset-areas-invent.md
@@ -1,0 +1,5 @@
+---
+'agendash': patch
+---
+
+Replace deprecated dependency `koa-router` with `@koa/router`

--- a/packages/agendash/package.json
+++ b/packages/agendash/package.json
@@ -48,12 +48,12 @@
     "@fastify/static": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "@hapi/hapi": "^21.0.0",
     "@hapi/inert": "^7.0.0",
+    "@koa/router": "^15.0.0",
     "agenda": "workspace:*",
     "express": "^4.18.0 || ^5.0.0",
     "fastify": "^4.0.0 || ^5.0.0",
     "koa": "^2.14.0 || ^3.0.0",
     "koa-bodyparser": "^4.4.0",
-    "koa-router": "^12.0.0 || ^13.0.0",
     "koa-static": "^5.0.0"
   },
   "peerDependenciesMeta": {
@@ -63,7 +63,7 @@
     "koa": {
       "optional": true
     },
-    "koa-router": {
+    "@koa/router": {
       "optional": true
     },
     "koa-static": {
@@ -91,10 +91,10 @@
     "@fastify/static": "^8.3.0",
     "@hapi/hapi": "^21.4.9",
     "@hapi/inert": "^7.1.0",
+    "@koa/router": "^15.5.0",
     "@types/express": "^4.17.25",
     "@types/koa": "^2.15.0",
     "@types/koa-bodyparser": "^4.3.13",
-    "@types/koa-router": "^7.4.9",
     "@types/koa-static": "^4.0.4",
     "@types/node": "^22.19.18",
     "@types/supertest": "^6.0.3",
@@ -106,7 +106,6 @@
     "fastify": "^5.8.5",
     "koa": "^2.16.4",
     "koa-bodyparser": "^4.4.1",
-    "koa-router": "^13.1.1",
     "koa-static": "^5.0.0",
     "mongodb": "^6.21.0",
     "mongodb-memory-server": "^10.4.3",

--- a/packages/agendash/src/middlewares/koa.ts
+++ b/packages/agendash/src/middlewares/koa.ts
@@ -1,10 +1,18 @@
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { Agenda } from 'agenda';
 import type { Middleware, Context, Next } from 'koa';
 import { AgendashController } from '../AgendashController.js';
 import { cspHeader } from '../csp.js';
-import type { ApiQueryParams, CreateJobRequest, DeleteRequest, RequeueRequest, RetryRequest, PauseRequest, ResumeRequest } from '../types.js';
+import type {
+	ApiQueryParams,
+	CreateJobRequest,
+	DeleteRequest,
+	RequeueRequest,
+	RetryRequest,
+	PauseRequest,
+	ResumeRequest
+} from '../types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -55,7 +63,7 @@ export async function createKoaMiddlewareAsync(agenda: Agenda): Promise<Middlewa
 	const [{ default: koaStatic }, { default: bodyParser }, { default: Router }] = await Promise.all([
 		import('koa-static'),
 		import('koa-bodyparser'),
-		import('koa-router')
+		import('@koa/router')
 	]);
 
 	// Static files (deferred to run after routes)
@@ -67,7 +75,7 @@ export async function createKoaMiddlewareAsync(agenda: Agenda): Promise<Middlewa
 	// API routes
 	const router = new Router();
 
-	router.get('/api', async (ctx) => {
+	router.get('/api', async ctx => {
 		const query = ctx.query as Record<string, string | undefined>;
 		try {
 			const params: ApiQueryParams = {
@@ -86,7 +94,7 @@ export async function createKoaMiddlewareAsync(agenda: Agenda): Promise<Middlewa
 		}
 	});
 
-	router.post('/api/jobs/requeue', async (ctx) => {
+	router.post('/api/jobs/requeue', async ctx => {
 		try {
 			const { jobIds } = ctx.request.body as RequeueRequest;
 			ctx.body = await controller.requeueJobs(jobIds);
@@ -96,7 +104,7 @@ export async function createKoaMiddlewareAsync(agenda: Agenda): Promise<Middlewa
 		}
 	});
 
-	router.post('/api/jobs/retry', async (ctx) => {
+	router.post('/api/jobs/retry', async ctx => {
 		try {
 			const { jobIds } = ctx.request.body as RetryRequest;
 			ctx.body = await controller.retryJobs(jobIds);
@@ -106,7 +114,7 @@ export async function createKoaMiddlewareAsync(agenda: Agenda): Promise<Middlewa
 		}
 	});
 
-	router.post('/api/jobs/delete', async (ctx) => {
+	router.post('/api/jobs/delete', async ctx => {
 		try {
 			const { jobIds } = ctx.request.body as DeleteRequest;
 			ctx.body = await controller.deleteJobs(jobIds);
@@ -116,7 +124,7 @@ export async function createKoaMiddlewareAsync(agenda: Agenda): Promise<Middlewa
 		}
 	});
 
-	router.post('/api/jobs/create', async (ctx) => {
+	router.post('/api/jobs/create', async ctx => {
 		try {
 			const options = ctx.request.body as CreateJobRequest;
 			ctx.body = await controller.createJob(options);
@@ -126,7 +134,7 @@ export async function createKoaMiddlewareAsync(agenda: Agenda): Promise<Middlewa
 		}
 	});
 
-	router.post('/api/jobs/pause', async (ctx) => {
+	router.post('/api/jobs/pause', async ctx => {
 		try {
 			const { jobIds } = ctx.request.body as PauseRequest;
 			ctx.body = await controller.pauseJobs(jobIds);
@@ -136,7 +144,7 @@ export async function createKoaMiddlewareAsync(agenda: Agenda): Promise<Middlewa
 		}
 	});
 
-	router.post('/api/jobs/resume', async (ctx) => {
+	router.post('/api/jobs/resume', async ctx => {
 		try {
 			const { jobIds } = ctx.request.body as ResumeRequest;
 			ctx.body = await controller.resumeJobs(jobIds);
@@ -146,7 +154,7 @@ export async function createKoaMiddlewareAsync(agenda: Agenda): Promise<Middlewa
 		}
 	});
 
-	router.get('/api/stats', async (ctx) => {
+	router.get('/api/stats', async ctx => {
 		try {
 			const fullDetails = ctx.query.fullDetails === 'true';
 			ctx.body = await controller.getStats(fullDetails);
@@ -157,11 +165,14 @@ export async function createKoaMiddlewareAsync(agenda: Agenda): Promise<Middlewa
 	});
 
 	// SSE endpoint for real-time job state notifications
-	router.get('/api/events', async (ctx) => {
+	router.get('/api/events', async ctx => {
 		// Check if state notifications are available
 		if (!controller.hasStateNotifications()) {
 			ctx.status = 501;
-			ctx.body = { error: 'State notifications not available. Configure a notification channel that supports state subscriptions.' };
+			ctx.body = {
+				error:
+					'State notifications not available. Configure a notification channel that supports state subscriptions.'
+			};
 			return;
 		}
 
@@ -172,7 +183,7 @@ export async function createKoaMiddlewareAsync(agenda: Agenda): Promise<Middlewa
 		ctx.set('X-Accel-Buffering', 'no'); // Disable nginx buffering
 
 		// Use a passthrough stream for SSE
-		const { PassThrough } = await import('stream');
+		const { PassThrough } = await import('node:stream');
 		const stream = new PassThrough();
 		ctx.body = stream;
 
@@ -180,7 +191,7 @@ export async function createKoaMiddlewareAsync(agenda: Agenda): Promise<Middlewa
 		stream.write('event: connected\ndata: {"connected":true}\n\n');
 
 		// Subscribe to state notifications
-		const unsubscribe = controller.createStateStream((notification) => {
+		const unsubscribe = controller.createStateStream(notification => {
 			stream.write(`data: ${JSON.stringify(notification)}\n\n`);
 		});
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       '@hapi/inert':
         specifier: ^7.1.0
         version: 7.1.0
+      '@koa/router':
+        specifier: ^15.5.0
+        version: 15.5.0(koa@2.16.4)
       '@types/express':
         specifier: ^4.17.25
         version: 4.17.25
@@ -182,9 +185,6 @@ importers:
       '@types/koa-bodyparser':
         specifier: ^4.3.13
         version: 4.3.13
-      '@types/koa-router':
-        specifier: ^7.4.9
-        version: 7.4.9
       '@types/koa-static':
         specifier: ^4.0.4
         version: 4.0.4
@@ -218,9 +218,6 @@ importers:
       koa-bodyparser:
         specifier: ^4.4.1
         version: 4.4.1
-      koa-router:
-        specifier: ^13.1.1
-        version: 13.1.1
       koa-static:
         specifier: ^5.0.0
         version: 5.0.0
@@ -968,6 +965,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@koa/router@15.5.0':
+    resolution: {integrity: sha512-KSC0oG/5t6ITu5wqX4lJseA/dngoj14hEaohrLZEXtlUT2RRyJvwaJ0KV+5uQoaWrY3A8ClHOrBEU4g8dujn8Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      koa: ^2.0.0 || ^3.0.0
 
   '@lukeed/ms@2.0.2':
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
@@ -4121,6 +4124,16 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@koa/router@15.5.0(koa@2.16.4)':
+    dependencies:
+      debug: 4.4.3
+      http-errors: 2.0.1
+      koa: 2.16.4
+      koa-compose: 4.1.0
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@lukeed/ms@2.0.2': {}
 


### PR DESCRIPTION
## Description

`koa-router` has been deprecated for a long time, should use `@koa/router` instead.

Refer: https://github.com/koajs/router

**NOTE:** Other changes are auto-formatted by `prettier` plugin, this pull request only related with the dependency replacement.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Added changeset if needed (`pnpm changeset`)
- [ ] Updated documentation if needed
