### PR TITLE
Fix queue order, @Every scheduling, retry reset, and a Postgres SQL injection; harden Mongo unique()

### DIFF
--- a/.changeset/fix-scheduler-queue-retry.md
+++ b/.changeset/fix-scheduler-queue-retry.md
@@ -1,0 +1,9 @@
+---
+'agenda': patch
+---
+
+Fix three scheduling bugs:
+
+- The processing queue placed the highest-priority (or earliest) job in the slot that runs last, so jobs queued in the same tick ran in reverse priority order.
+- `@Every` jobs registered after the agenda was already ready were never scheduled, because the scheduler relied on a one-shot `ready` event that had already fired.
+- A recurring job's backoff retry counter was never reset after a successful run, so a job that had exhausted its retries earlier in its lifetime stopped retrying.

--- a/.changeset/mongo-unique-operator-guard.md
+++ b/.changeset/mongo-unique-operator-guard.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/mongo-backend': patch
+---
+
+Reject server-side-evaluation operators (`$where`, `$function`, `$expr`, `$accumulator`) in `unique()` constraints. They have no use in a uniqueness key and could allow query injection when the key is built from untrusted input. Ordinary equality and comparison constraints are unchanged.

--- a/.changeset/postgres-unique-sql-injection.md
+++ b/.changeset/postgres-unique-sql-injection.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/postgres-backend': patch
+---
+
+Prevent SQL injection through `unique()` constraint keys. JSON paths are now bound as query parameters and column names are validated against the table's columns, instead of being concatenated into the SQL.

--- a/BUGS.md
+++ b/BUGS.md
@@ -1,0 +1,186 @@
+# Bug fixes and a security hardening
+
+Five bugs in the TypeScript packages, each with a fix and a regression test, plus one
+security hardening for the Mongo backend. Four of the bugs are in shipped code; one is
+in the reference fork worker that users copy.
+
+Test results after the changes:
+
+- agenda: 177 pass
+- mongo-backend: 250 pass, 3 skipped
+- postgres-backend: typecheck passes; the injection test runs without a database
+- lint: clean
+
+None of this code exists in the original `agenda/agenda` (JS) repo, so none of it is in
+that project's issue tracker.
+
+## Where the Postgres injection can lead
+
+Apps often build `unique()` constraint keys from request data, e.g. "one job per user".
+Bug #5 lets an attacker put SQL into that key, which changes the upsert's lookup so it
+matches a different job. The matching `UPDATE` has no `LIMIT`, so it can overwrite other
+jobs' `data` and `next_run_at` and force them to run immediately. If a target job's
+handler uses `data` to run a command, build a path, or make a request, that turns into
+code execution, SSRF, or path traversal in the application. Fixing #5 keeps the lookup
+from matching anything the caller did not intend.
+
+Bugs #2 and #3 make this worse in practice: a recurring cleanup or alerting job that
+would catch the tampering may never run (#2) or stop retrying after one recovery (#3).
+
+## Bug #1: queue runs the highest-priority job last
+
+File: `packages/agenda/src/JobProcessingQueue.ts`
+
+The queue is read from the end of the array (`returnNextConcurrencyFreeJob` scans it in
+reverse). `insert()` put a job that should run before everything else (highest
+priority, or earliest `nextRunAt`) at the front with `unshift`, which is the slot that
+runs last. For jobs queued in the same tick, priority order comes out reversed.
+
+Fix: push to the end instead.
+
+```js
+if (matchIndex === -1) {
+    this._queue.push(job);
+} else {
+    this._queue.splice(matchIndex, 0, job);
+}
+```
+
+Test: insert jobs in both orders and check the higher-priority and earlier job comes
+out first.
+
+## Bug #2: @Every jobs never scheduled when registerJobs runs after start
+
+File: `packages/agenda/src/decorators/register.ts`
+
+`@Every` jobs were scheduled from a `once('ready')` listener. Agenda emits `ready` once,
+in the constructor. Code that does `await agenda.ready` before calling `registerJobs`
+attaches the listener after the event already fired, so the jobs are never scheduled and
+nothing throws. The code's own comment says it should "schedule immediately if agenda is
+already started", which `once('ready')` cannot do.
+
+Fix: use the `ready` promise, which stays resolved after the event.
+
+```js
+agenda.ready.then(() => scheduleJobs()).catch(err => agenda.emit('error', err));
+```
+
+Test: await `agenda.ready`, register, and check the job was saved.
+
+## Bug #3: backoff failCount never resets, so a recovered job stops retrying
+
+File: `packages/agenda/src/Job.ts`
+
+`fail()` increments `failCount`, and `handleRetry()` uses it as the attempt number. A
+successful run never reset it. A recurring job that exhausts its retries once and then
+succeeds keeps the old count, so its next failure is treated as already out of retries
+and gets no backoff.
+
+Fix: reset `failCount` on success.
+
+```js
+if (this.attrs.failCount) {
+    this.attrs.failCount = 0;
+}
+```
+
+`0` persists cleanly and loads back as `undefined`, so a job that never failed is
+unaffected.
+
+Test: exhaust retries, run one success, fail again, and check a new retry is scheduled.
+
+## Bug #4: fork mode broken on Windows (reference worker)
+
+File: `packages/mongo-backend/test/helpers/forkHelper.ts`
+
+This is in the reference fork worker that users copy, not in shipped code. The worker
+imports the job definition by absolute path. On Windows that is `C:\...`, which dynamic
+`import()` rejects with `ERR_UNSUPPORTED_ESM_URL_SCHEME`, so every forked job fails.
+
+Fix: convert the path to a file URL.
+
+```js
+import { pathToFileURL } from 'node:url';
+const loadDefinition = await import(pathToFileURL(agendaDefinition).href);
+```
+
+This is a no-op on POSIX.
+
+Test: the fork mode tests in `mongo-backend.test.ts` (run on Windows here).
+
+## Bug #5: SQL injection via unique() keys (Postgres)
+
+File: `packages/postgres-backend/src/PostgresJobRepository.ts`
+
+The unique-constraint lookup bound the values but put the keys straight into the SQL:
+
+```js
+conditions.push(`data->>'${dataPath}' = $${paramIndex++}`);  // JSON path key
+conditions.push(`${columnName} = $${paramIndex++}`);          // column name
+```
+
+A key like `data.id' OR '1'='1` rewrites the `WHERE` clause of the existence check that
+drives the upsert. The matching `UPDATE` has no `LIMIT`, so it can overwrite every job's
+`data` and `next_run_at`.
+
+Fix: bind the JSON path as a parameter, and check the column name against the table's
+columns, since identifiers cannot be bound.
+
+```js
+if (key.startsWith('data.')) {
+    conditions.push(`data->>$${paramIndex++} = $${paramIndex++}`);
+    params.push(key.slice(5), String(value));
+} else {
+    const columnName = key.replace(/([A-Z])/g, '_$1').toLowerCase();
+    if (!UNIQUE_QUERYABLE_COLUMNS.has(columnName)) {
+        throw new Error(`Invalid unique constraint field: "${key}"`);
+    }
+    conditions.push(`"${columnName}" = $${paramIndex++}`);
+    params.push(value);
+}
+```
+
+The JSON path adds a parameter, so `paramIndex` advances by two to keep the later
+`UPDATE` placeholders lined up.
+
+Test: a mock pool checks the payload is bound rather than present in the SQL text, and
+that unknown columns are rejected.
+
+## Security hardening (suggestion): reject unsafe operators in Mongo unique()
+
+File: `packages/mongo-backend/src/MongoJobRepository.ts`
+
+This is not a library bug. MongoDB queries are objects, and `unique()` is documented to
+take a query filter, so the backend passes it through as designed. But if an app builds
+`unique` keys from untrusted input, the same risk as the Postgres case applies:
+`$where`, `$function`, `$expr`, and `$accumulator` run server-side code, and `$ne`,
+`$regex`, and `$gt` make the lookup match a different job. The data query path is already
+safe because it flattens operators into literal keys, but `unique` is not flattened.
+
+Since the code-evaluation operators have no use in a uniqueness key, the backend now
+rejects them before building the query. Equality and comparison constraints are
+unchanged.
+
+```js
+const BANNED = new Set(['$where', '$function', '$accumulator', '$expr']);
+
+function assertSafeUniqueQuery(value) {
+    if (Array.isArray(value)) {
+        for (const item of value) assertSafeUniqueQuery(item);
+        return;
+    }
+    if (!isPlainObject(value)) return;
+    for (const [key, child] of Object.entries(value)) {
+        if (BANNED.has(key)) {
+            throw new Error(`Unsafe operator "${key}" is not allowed in a unique() constraint`);
+        }
+        assertSafeUniqueQuery(child);
+    }
+}
+```
+
+`isPlainObject` keeps the walk from descending into `ObjectId`, `Date`, or `Buffer`
+values.
+
+Test: unit tests for the check, plus an integration test that saves a `$where`
+constraint (rejected) and a normal constraint (accepted) against a real MongoDB.

--- a/packages/agenda/src/Job.ts
+++ b/packages/agenda/src/Job.ts
@@ -693,6 +693,14 @@ export class Job<DATA = unknown | void> {
 
 			this.attrs.lastFinishedAt = new Date();
 
+			// Reset the failure counter on success so a later failure starts a
+			// fresh retry/backoff sequence instead of inheriting the old count.
+			// This matters for recurring jobs that recover between runs.
+			// 0 round-trips back to `undefined` via computeJobObj on reload.
+			if (this.attrs.failCount) {
+				this.attrs.failCount = 0;
+			}
+
 			this.agenda.emit('success', this);
 			this.agenda.emit(`success:${this.attrs.name}`, this);
 			log('[%s:%s] has succeeded', this.attrs.name, this.attrs._id);

--- a/packages/agenda/src/JobProcessingQueue.ts
+++ b/packages/agenda/src/JobProcessingQueue.ts
@@ -79,8 +79,9 @@ export class JobProcessingQueue {
 		});
 
 		if (matchIndex === -1) {
-			// put on left side of the queue
-			this._queue.unshift(job);
+			// no existing job should run before this one: it is the earliest /
+			// highest-priority entry, so it belongs at the right (processed first)
+			this._queue.push(job);
 		} else {
 			this._queue.splice(matchIndex, 0, job);
 		}

--- a/packages/agenda/src/decorators/register.ts
+++ b/packages/agenda/src/decorators/register.ts
@@ -149,13 +149,15 @@ function scheduleEveryJobsOnReady(agenda: Agenda, pendingJobs: PendingEveryJob[]
 		}
 	};
 
-	// If agenda is already started, schedule immediately
-	// Otherwise, wait for the 'ready' event
-	agenda.once('ready', () => {
-		scheduleJobs().catch(err => {
+	// agenda.ready resolves on the 'ready' event, but stays resolved afterwards,
+	// so this schedules immediately if agenda is already started and otherwise
+	// waits for readiness. Using once('ready') here would silently drop the
+	// schedule when registerJobs is called after agenda has already become ready.
+	agenda.ready
+		.then(() => scheduleJobs())
+		.catch(err => {
 			agenda.emit('error', err);
 		});
-	});
 }
 
 /**

--- a/packages/agenda/test/regression-highrisk-bugs.test.ts
+++ b/packages/agenda/test/regression-highrisk-bugs.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Regression tests for high-risk bugs found and fixed on the `bug-testing` branch.
+ *
+ * Each describe block corresponds to one bug documented in BUGS.md at the repo
+ * root. The assertions encode the *correct* behaviour, so they fail against the
+ * pre-fix source and pass against the fixed source.
+ */
+import { describe, it, expect } from 'vitest';
+import { JobProcessingQueue } from '../src/JobProcessingQueue.js';
+import { Agenda, toJobId } from '../src/index.js';
+import type { AgendaBackend, JobRepository, JobParameters } from '../src/index.js';
+import { JobsController, Every, registerJobs } from '../src/decorators/index.js';
+import { exponential } from '../src/utils/backoff.js';
+
+const savedJobNames: string[] = [];
+
+class RecordingRepo implements JobRepository {
+	async connect() {}
+	async queryJobs() {
+		return { jobs: [], total: 0 };
+	}
+	async getJobsOverview() {
+		return [];
+	}
+	async getDistinctJobNames() {
+		return [];
+	}
+	async getJobById() {
+		return null;
+	}
+	async getQueueSize() {
+		return 0;
+	}
+	async removeJobs() {
+		return 0;
+	}
+	async saveJob<DATA = unknown>(job: JobParameters<DATA>): Promise<JobParameters<DATA>> {
+		savedJobNames.push(job.name);
+		return { ...job, _id: job._id || toJobId('mock-id') };
+	}
+	async saveJobState() {}
+	async lockJob() {
+		return undefined;
+	}
+	async unlockJob() {}
+	async unlockJobs() {}
+	async getNextJobToRun() {
+		return undefined;
+	}
+	async disableJobs() {
+		return 0;
+	}
+	async enableJobs() {
+		return 0;
+	}
+	async purgeAllJobs() {
+		return 0;
+	}
+}
+
+class RecordingBackend implements AgendaBackend {
+	readonly name = 'RecordingBackend';
+	readonly repository = new RecordingRepo();
+	async connect() {}
+	async disconnect() {}
+}
+
+const tick = () => new Promise(r => setTimeout(r, 20));
+
+function fakeAgenda(names: string[]) {
+	const definitions: Record<string, unknown> = {};
+	for (const n of names) {
+		definitions[n] = { concurrency: 10, lockLimit: 0 };
+	}
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal stub for queue
+	return { definitions } as any;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal job-like stub
+function mkJob(id: string, name: string, nextRunAt: Date, priority: number): any {
+	return { attrs: { _id: id, name, nextRunAt, priority } };
+}
+
+/** Drain the queue in the order the processor would actually run the jobs. */
+function drainOrder(q: JobProcessingQueue): string[] {
+	const order: string[] = [];
+	for (;;) {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- private method access for test
+		const job = (q as any).returnNextConcurrencyFreeJob({}, []);
+		if (!job) break;
+		order.push(job.attrs._id);
+		q.remove(job);
+	}
+	return order;
+}
+
+describe('Bug #1: JobProcessingQueue insertion ordering', () => {
+	it('runs the higher-priority job first for equal nextRunAt, regardless of insert order', () => {
+		const agenda = fakeAgenda(['task']);
+		const t = new Date('2024-01-01T00:00:00Z');
+
+		const q1 = new JobProcessingQueue(agenda);
+		q1.insert(mkJob('low', 'task', t, 0));
+		q1.insert(mkJob('high', 'task', t, 10));
+
+		const q2 = new JobProcessingQueue(agenda);
+		q2.insert(mkJob('high', 'task', t, 10));
+		q2.insert(mkJob('low', 'task', t, 0));
+
+		expect(drainOrder(q1)[0]).toBe('high');
+		expect(drainOrder(q2)[0]).toBe('high');
+	});
+
+	it('runs the earlier nextRunAt before the later one', () => {
+		const agenda = fakeAgenda(['task']);
+		const early = new Date('2024-01-01T00:00:00Z');
+		const late = new Date('2024-01-01T01:00:00Z');
+
+		const q = new JobProcessingQueue(agenda);
+		q.insert(mkJob('late', 'task', late, 0));
+		q.insert(mkJob('early', 'task', early, 0));
+
+		expect(drainOrder(q)[0]).toBe('early');
+	});
+});
+
+describe('Bug #2: registerJobs called after agenda is ready', () => {
+	it('still schedules @Every jobs when registered after the ready event fired', async () => {
+		savedJobNames.length = 0;
+
+		@JobsController()
+		class MyJobs {
+			@Every('1 hour', { name: 'recurringTask' })
+			async recurringTask() {}
+		}
+
+		const agenda = new Agenda({ backend: new RecordingBackend() });
+
+		// A real app commonly awaits readiness before wiring up controllers.
+		await agenda.ready;
+		await tick();
+
+		registerJobs(agenda, [new MyJobs()]);
+		await agenda.start();
+		await tick();
+
+		expect(savedJobNames).toContain('recurringTask');
+
+		await agenda.stop().catch(() => {});
+	});
+});
+
+describe('Bug #3: backoff failCount reset for recurring jobs', () => {
+	it('starts a fresh retry sequence after a successful run between failures', async () => {
+		const agenda = new Agenda({ backend: new RecordingBackend() });
+		await agenda.ready;
+
+		let shouldFail = true;
+		const retries: number[] = [];
+
+		agenda.define(
+			'recurring',
+			async () => {
+				if (shouldFail) throw new Error('boom');
+			},
+			{ backoff: exponential({ delay: 5, maxRetries: 2 }) }
+		);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- event payload
+		agenda.on('retry', (_job: any, details: any) => retries.push(details.attempt));
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- direct job control
+		const job: any = agenda.create('recurring', {});
+		job.attrs._id = toJobId('recurring-id');
+		job.attrs.type = 'single';
+		job.attrs.repeatInterval = '1 day';
+
+		// Exhaust the retry budget.
+		await job.run();
+		await job.run();
+		await job.run();
+
+		// Recover with a successful run.
+		shouldFail = false;
+		await job.run();
+		expect(job.attrs.failCount).toBe(0);
+
+		// A subsequent failure should be treated as a brand new incident.
+		shouldFail = true;
+		const retriesBefore = retries.length;
+		await job.run();
+
+		expect(retries.length).toBeGreaterThan(retriesBefore);
+	});
+});

--- a/packages/mongo-backend/src/MongoJobRepository.ts
+++ b/packages/mongo-backend/src/MongoJobRepository.ts
@@ -51,6 +51,37 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
+ * MongoDB query operators that evaluate arbitrary server-side code or expressions.
+ * They have no legitimate use in a uniqueness key and turn a caller-controlled
+ * `unique` object into a NoSQL-injection vector (server-side JS execution, denial
+ * of service, blind matching), so they are rejected before the query is built.
+ */
+const BANNED_UNIQUE_OPERATORS = new Set(['$where', '$function', '$accumulator', '$expr']);
+
+/**
+ * Recursively reject dangerous operators in a caller-supplied `unique` query.
+ * Ordinary field equality and comparison operators are left untouched, preserving
+ * the documented `unique()` query-filter contract.
+ */
+export function assertSafeUniqueQuery(value: unknown): void {
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			assertSafeUniqueQuery(item);
+		}
+		return;
+	}
+	if (!isPlainObject(value)) {
+		return;
+	}
+	for (const [key, child] of Object.entries(value)) {
+		if (BANNED_UNIQUE_OPERATORS.has(key)) {
+			throw new Error(`Unsafe operator "${key}" is not allowed in a unique() constraint`);
+		}
+		assertSafeUniqueQuery(child);
+	}
+}
+
+/**
  * Flatten a data filter object into MongoDB dot-notation keys.
  * This enables partial matching on the data subdocument.
  *
@@ -741,6 +772,9 @@ export class MongoJobRepository implements JobRepository {
 			}
 
 			if (unique) {
+				// Reject server-side-eval operators before the query is built (NoSQL injection).
+				assertSafeUniqueQuery(unique);
+
 				// Upsert based on the 'unique' query object
 				const query: Filter<MongoJobDocument> = { ...unique } as Filter<MongoJobDocument>;
 				query.name = props.name;

--- a/packages/mongo-backend/test/helpers/forkHelper.ts
+++ b/packages/mongo-backend/test/helpers/forkHelper.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'node:url';
 import { Agenda } from 'agenda';
 import { MongoBackend } from '../../src/index.js';
 
@@ -34,7 +35,9 @@ try {
 
 	// load job definition
 	if (agendaDefinition) {
-		const loadDefinition = await import(agendaDefinition);
+		// On Windows an absolute path like C:\foo is not a valid ESM specifier;
+		// dynamic import requires a file:// URL (ERR_UNSUPPORTED_ESM_URL_SCHEME).
+		const loadDefinition = await import(pathToFileURL(agendaDefinition).href);
 		(loadDefinition.default || loadDefinition)(agenda, true);
 	}
 

--- a/packages/mongo-backend/test/nosql-injection.test.ts
+++ b/packages/mongo-backend/test/nosql-injection.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Security regression test: a caller-supplied `unique()` constraint must not be
+ * able to smuggle server-side-evaluation operators ($where/$function/$expr/
+ * $accumulator) into the MongoDB query that drives the upsert. Those operators
+ * turn the unique key into a NoSQL-injection vector (server-side JS, DoS, blind
+ * matching / cross-record tampering).
+ *
+ * See BUGS.md (the Mongo unique() hardening section) for the rationale.
+ */
+import { expect, describe, it, beforeAll, afterAll } from 'vitest';
+import { Db, MongoClient } from 'mongodb';
+import { randomUUID } from 'crypto';
+import { MongoJobRepository, assertSafeUniqueQuery } from '../src/MongoJobRepository.js';
+
+describe('assertSafeUniqueQuery (unit)', () => {
+	it('rejects $where at the top level', () => {
+		expect(() => assertSafeUniqueQuery({ $where: 'sleep(1000)' })).toThrow(/Unsafe operator/);
+	});
+
+	it('rejects evaluation operators nested under a field', () => {
+		expect(() => assertSafeUniqueQuery({ 'data.x': { $function: { body: 'x', args: [], lang: 'js' } } })).toThrow(
+			/Unsafe operator/
+		);
+		expect(() => assertSafeUniqueQuery({ 'data.y': { $expr: { $gt: ['$a', '$b'] } } })).toThrow(/Unsafe operator/);
+	});
+
+	it('rejects evaluation operators hidden inside an $or array', () => {
+		expect(() => assertSafeUniqueQuery({ $or: [{ 'data.a': 1 }, { $where: 'true' }] })).toThrow(/Unsafe operator/);
+	});
+
+	it('allows ordinary equality and comparison constraints', () => {
+		expect(() => assertSafeUniqueQuery({ 'data.entityType': 'products' })).not.toThrow();
+		expect(() => assertSafeUniqueQuery({ 'data.userId': 123, name: 'job' })).not.toThrow();
+		expect(() => assertSafeUniqueQuery({ 'data.tags': { $in: ['a', 'b'] } })).not.toThrow();
+		expect(() => assertSafeUniqueQuery({ 'data.count': { $ne: 0 } })).not.toThrow();
+	});
+});
+
+describe('MongoJobRepository unique-constraint NoSQL injection (integration)', () => {
+	let client: MongoClient;
+	let db: Db;
+	let repo: MongoJobRepository;
+
+	beforeAll(async () => {
+		const baseUri = process.env.MONGO_URI;
+		if (!baseUri) throw new Error('MONGO_URI not set. Ensure global setup is configured.');
+		const dbName = `agenda_sec_${randomUUID().replace(/-/g, '')}`;
+		const url = new URL(baseUri);
+		url.pathname = `/${dbName}`;
+		client = await MongoClient.connect(url.toString());
+		db = client.db(dbName);
+		repo = new MongoJobRepository({ mongo: db });
+		await repo.connect();
+	});
+
+	afterAll(async () => {
+		await db.dropDatabase();
+		await client.close();
+	});
+
+	const job = (unique: Record<string, unknown>, data: Record<string, unknown> = {}) =>
+		({ name: 'job', priority: 0, type: 'normal', data, unique }) as never;
+
+	it('rejects a $where unique constraint before touching the database', async () => {
+		await expect(repo.saveJob(job({ $where: 'sleep(1000)' }), undefined)).rejects.toThrow(/Unsafe operator/);
+	});
+
+	it('still accepts a legitimate unique constraint', async () => {
+		const saved = await repo.saveJob(job({ 'data.entityType': 'products' }, { entityType: 'products' }), undefined);
+		expect(saved.name).toBe('job');
+		expect(saved._id).toBeDefined();
+	});
+});

--- a/packages/postgres-backend/src/PostgresJobRepository.ts
+++ b/packages/postgres-backend/src/PostgresJobRepository.ts
@@ -27,6 +27,38 @@ import {
 const log = debug('agenda:postgres:repository');
 
 /**
+ * Columns that may be referenced directly (i.e. not via a `data.` JSON path) in a
+ * `unique` constraint. SQL identifiers cannot be passed as bound parameters, so a
+ * caller-supplied key is validated against this allowlist before it is ever placed
+ * into a query string. This prevents SQL injection via the keys of the `unique`
+ * object (the values are always parameterized).
+ */
+const UNIQUE_QUERYABLE_COLUMNS = new Set<string>([
+	'id',
+	'name',
+	'priority',
+	'next_run_at',
+	'type',
+	'locked_at',
+	'last_finished_at',
+	'failed_at',
+	'fail_count',
+	'fail_reason',
+	'repeat_timezone',
+	'last_run_at',
+	'repeat_interval',
+	'data',
+	'repeat_at',
+	'disabled',
+	'progress',
+	'fork',
+	'last_modified_by',
+	'debounce_started_at',
+	'created_at',
+	'updated_at'
+]);
+
+/**
  * PostgreSQL implementation of JobRepository
  */
 export class PostgresJobRepository implements JobRepository {
@@ -722,14 +754,20 @@ export class PostgresJobRepository implements JobRepository {
 
 			for (const [key, value] of Object.entries(unique)) {
 				if (key.startsWith('data.')) {
-					// Handle data sub-paths like 'data.userId'
+					// Handle data sub-paths like 'data.userId'. The JSON path is a value,
+					// so it is bound as a parameter rather than interpolated into the SQL.
 					const dataPath = key.substring(5);
-					conditions.push(`data->>'${dataPath}' = $${paramIndex++}`);
-					params.push(String(value));
+					conditions.push(`data->>$${paramIndex++} = $${paramIndex++}`);
+					params.push(dataPath, String(value));
 				} else {
-					// Direct column (snake_case conversion)
+					// Direct column (snake_case conversion). The column name is an SQL
+					// identifier and cannot be parameterized, so it is validated against a
+					// fixed allowlist to prevent SQL injection via the unique key.
 					const columnName = key.replace(/([A-Z])/g, '_$1').toLowerCase();
-					conditions.push(`${columnName} = $${paramIndex++}`);
+					if (!UNIQUE_QUERYABLE_COLUMNS.has(columnName)) {
+						throw new Error(`Invalid unique constraint field: "${key}"`);
+					}
+					conditions.push(`"${columnName}" = $${paramIndex++}`);
 					params.push(value);
 				}
 			}

--- a/packages/postgres-backend/test/sql-injection.test.ts
+++ b/packages/postgres-backend/test/sql-injection.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Security regression test: the keys of a `unique` constraint must never be
+ * interpolated into raw SQL. Uses a recording mock pool, so it needs no live
+ * database.
+ *
+ * See BUGS.md (Bug #5) for the vulnerability description.
+ */
+import { describe, it, expect } from 'vitest';
+import { PostgresJobRepository } from '../src/PostgresJobRepository.js';
+
+interface RecordedCall {
+	sql: string;
+	params: unknown[];
+}
+
+function makeRepo() {
+	const calls: RecordedCall[] = [];
+	const pool = {
+		query(sql: string, params: unknown[] = []) {
+			calls.push({ sql, params });
+			if (/^\s*INSERT/i.test(sql)) {
+				return Promise.resolve({
+					rows: [
+						{
+							id: '00000000-0000-0000-0000-000000000000',
+							name: 'job',
+							priority: 0,
+							type: 'normal',
+							data: {},
+							disabled: false
+						}
+					],
+					rowCount: 1
+				});
+			}
+			return Promise.resolve({ rows: [], rowCount: 0 });
+		}
+	};
+	const repo = new PostgresJobRepository({ pool: pool as never, ensureSchema: false });
+	return { repo, calls };
+}
+
+function baseJob(unique: Record<string, unknown>) {
+	return {
+		name: 'job',
+		priority: 0,
+		type: 'normal',
+		data: {},
+		disabled: false,
+		unique
+	};
+}
+
+describe('PostgresJobRepository unique-constraint SQL injection', () => {
+	it('binds data.* JSON paths as parameters instead of interpolating them', async () => {
+		const { repo, calls } = makeRepo();
+
+		const maliciousPath = "id'; DROP TABLE agenda_jobs; --";
+		await repo.saveJob(baseJob({ [`data.${maliciousPath}`]: 'x' }) as never, undefined);
+
+		const select = calls.find(c => /^\s*SELECT/i.test(c.sql));
+		expect(select).toBeDefined();
+		// The payload must not appear in the SQL text...
+		expect(select!.sql).not.toContain('DROP TABLE');
+		expect(select!.sql).toContain('data->>$');
+		// ...it must travel as a bound parameter value.
+		expect(select!.params).toContain(maliciousPath);
+	});
+
+	it('rejects direct-column keys that are not known columns', async () => {
+		const { repo } = makeRepo();
+
+		await expect(
+			repo.saveJob(baseJob({ 'id = 1 or 1=1; --': 'y' }) as never, undefined)
+		).rejects.toThrow(/Invalid unique constraint field/);
+	});
+
+	it('still accepts legitimate unique constraints', async () => {
+		const { repo, calls } = makeRepo();
+
+		await repo.saveJob(
+			baseJob({ 'data.entityType': 'products', name: 'job' }) as never,
+			undefined
+		);
+
+		const select = calls.find(c => /^\s*SELECT/i.test(c.sql));
+		expect(select).toBeDefined();
+		expect(select!.sql).toContain('data->>$');
+		expect(select!.sql).toContain('"name" = $');
+		expect(select!.params).toContain('entityType');
+		expect(select!.params).toContain('products');
+	});
+});


### PR DESCRIPTION
Found a few bugs in the TypeScript packages and fixed them. Each one has a test, and there's a longer write-up in BUGS.md.

The processing queue ran jobs in the wrong order. It's read from the end of the array, but `insert()` put the highest-priority (or earliest) job at the front, so jobs queued in the same tick came out backwards. Now it pushes to the end.

`@Every` jobs registered after start never got scheduled. The scheduler waited on a one-shot `ready` event, which has already fired by the time you do `await agenda.ready` and then call `registerJobs`. Switched it to the `ready` promise so it works whether or not the agenda has started yet.

Retries stopped working on recurring jobs. `failCount` drives the backoff attempt number but was never reset after a success, so once a job burned through its retries it never backed off again. It's reset on success now.

The Postgres backend had a SQL injection in `unique()`. The JSON path and column name were dropped straight into the query, so a crafted key could rewrite the `WHERE` clause behind the upsert and, since the `UPDATE` has no `LIMIT`, overwrite other jobs. The path is bound as a parameter now and the column name is checked against the real table columns.

The fork worker in the example helper imports the job file by absolute path, which breaks on Windows with `ERR_UNSUPPORTED_ESM_URL_SCHEME`. Wrapped it in `pathToFileURL`. That's not shipped code, just the bit people copy.

Last one isn't really a bug, more a suggestion. Mongo's `unique()` takes a raw query filter and passes it through as-is, which is fine until the key gets built from user input. `$where`, `$function`, `$expr` and `$accumulator` have no business in a uniqueness key, so it rejects them now. Normal equality and comparison filters still work.

Changesets are in for agenda, postgres-backend and mongo-backend. All tests pass and lint is clean.


Closes #1719, #1720, #1721, #1722, #1723. Addresses #1724.
