### PR TITLE
fix(agenda): correct processing queue insertion order

### DIFF
--- a/.changeset/fix-queue-order.md
+++ b/.changeset/fix-queue-order.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+Fix processing queue order. `JobProcessingQueue.insert` placed the highest-priority (or earliest `nextRunAt`) job in the slot that runs last, because the queue is read from the end. Jobs queued in the same tick now run in the correct priority order.

--- a/packages/agenda/src/JobProcessingQueue.ts
+++ b/packages/agenda/src/JobProcessingQueue.ts
@@ -79,8 +79,9 @@ export class JobProcessingQueue {
 		});
 
 		if (matchIndex === -1) {
-			// put on left side of the queue
-			this._queue.unshift(job);
+			// no existing job should run before this one: it is the earliest /
+			// highest-priority entry, so it belongs at the right (processed first)
+			this._queue.push(job);
 		} else {
 			this._queue.splice(matchIndex, 0, job);
 		}

--- a/packages/agenda/test/queue-order.test.ts
+++ b/packages/agenda/test/queue-order.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { JobProcessingQueue } from '../src/JobProcessingQueue.js';
+
+function fakeAgenda(names: string[]) {
+	const definitions: Record<string, unknown> = {};
+	for (const n of names) {
+		definitions[n] = { concurrency: 10, lockLimit: 0 };
+	}
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal stub for queue
+	return { definitions } as any;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal job-like stub
+function mkJob(id: string, name: string, nextRunAt: Date, priority: number): any {
+	return { attrs: { _id: id, name, nextRunAt, priority } };
+}
+
+/** Drain the queue in the order the processor would actually run the jobs. */
+function drainOrder(q: JobProcessingQueue): string[] {
+	const order: string[] = [];
+	for (;;) {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- private method access for test
+		const job = (q as any).returnNextConcurrencyFreeJob({}, []);
+		if (!job) break;
+		order.push(job.attrs._id);
+		q.remove(job);
+	}
+	return order;
+}
+
+describe('JobProcessingQueue insertion ordering', () => {
+	it('runs the higher-priority job first for equal nextRunAt, regardless of insert order', () => {
+		const agenda = fakeAgenda(['task']);
+		const t = new Date('2024-01-01T00:00:00Z');
+
+		const q1 = new JobProcessingQueue(agenda);
+		q1.insert(mkJob('low', 'task', t, 0));
+		q1.insert(mkJob('high', 'task', t, 10));
+
+		const q2 = new JobProcessingQueue(agenda);
+		q2.insert(mkJob('high', 'task', t, 10));
+		q2.insert(mkJob('low', 'task', t, 0));
+
+		expect(drainOrder(q1)[0]).toBe('high');
+		expect(drainOrder(q2)[0]).toBe('high');
+	});
+
+	it('runs the earlier nextRunAt before the later one', () => {
+		const agenda = fakeAgenda(['task']);
+		const early = new Date('2024-01-01T00:00:00Z');
+		const late = new Date('2024-01-01T01:00:00Z');
+
+		const q = new JobProcessingQueue(agenda);
+		q.insert(mkJob('late', 'task', late, 0));
+		q.insert(mkJob('early', 'task', early, 0));
+
+		expect(drainOrder(q)[0]).toBe('early');
+	});
+});


### PR DESCRIPTION
Fixes #1719.

`JobProcessingQueue.insert` placed the highest-priority (or earliest `nextRunAt`) job at the front of the array with `unshift`. The queue is read from the end (`returnNextConcurrencyFreeJob` scans in reverse), so that job ran last. Jobs queued in the same tick came out in reverse priority order.

The fix pushes the no-earlier-match job to the end instead.

Test inserts jobs in both orders and asserts the higher-priority and earlier `nextRunAt` job runs first. It fails on the previous code and passes with the fix.