### PR TITLE
schedule @Every jobs registered after agenda is ready

### DIFF
--- a/.changeset/fix-every-after-ready.md
+++ b/.changeset/fix-every-after-ready.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+Fix `@Every` jobs registered after the agenda was already ready never being scheduled. The scheduler relied on a one-shot `ready` event that had already fired, so it now uses the `ready` promise, which stays resolved.

--- a/packages/agenda/src/decorators/register.ts
+++ b/packages/agenda/src/decorators/register.ts
@@ -149,13 +149,15 @@ function scheduleEveryJobsOnReady(agenda: Agenda, pendingJobs: PendingEveryJob[]
 		}
 	};
 
-	// If agenda is already started, schedule immediately
-	// Otherwise, wait for the 'ready' event
-	agenda.once('ready', () => {
-		scheduleJobs().catch(err => {
+	// agenda.ready resolves on the 'ready' event, but stays resolved afterwards,
+	// so this schedules immediately if agenda is already started and otherwise
+	// waits for readiness. Using once('ready') here would silently drop the
+	// schedule when registerJobs is called after agenda has already become ready.
+	agenda.ready
+		.then(() => scheduleJobs())
+		.catch(err => {
 			agenda.emit('error', err);
 		});
-	});
 }
 
 /**

--- a/packages/agenda/test/every-after-ready.test.ts
+++ b/packages/agenda/test/every-after-ready.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { Agenda, toJobId } from '../src/index.js';
+import type { AgendaBackend, JobRepository, JobParameters } from '../src/index.js';
+import { JobsController, Every, registerJobs } from '../src/decorators/index.js';
+
+const savedJobNames: string[] = [];
+
+class RecordingRepo implements JobRepository {
+	async connect() {}
+	async queryJobs() {
+		return { jobs: [], total: 0 };
+	}
+	async getJobsOverview() {
+		return [];
+	}
+	async getDistinctJobNames() {
+		return [];
+	}
+	async getJobById() {
+		return null;
+	}
+	async getQueueSize() {
+		return 0;
+	}
+	async removeJobs() {
+		return 0;
+	}
+	async saveJob<DATA = unknown>(job: JobParameters<DATA>): Promise<JobParameters<DATA>> {
+		savedJobNames.push(job.name);
+		return { ...job, _id: job._id || toJobId('mock-id') };
+	}
+	async saveJobState() {}
+	async lockJob() {
+		return undefined;
+	}
+	async unlockJob() {}
+	async unlockJobs() {}
+	async getNextJobToRun() {
+		return undefined;
+	}
+	async disableJobs() {
+		return 0;
+	}
+	async enableJobs() {
+		return 0;
+	}
+	async purgeAllJobs() {
+		return 0;
+	}
+}
+
+class RecordingBackend implements AgendaBackend {
+	readonly name = 'RecordingBackend';
+	readonly repository = new RecordingRepo();
+	async connect() {}
+	async disconnect() {}
+}
+
+const tick = () => new Promise(r => setTimeout(r, 20));
+
+describe('registerJobs called after agenda is ready', () => {
+	it('still schedules @Every jobs when registered after the ready event fired', async () => {
+		savedJobNames.length = 0;
+
+		@JobsController()
+		class MyJobs {
+			@Every('1 hour', { name: 'recurringTask' })
+			async recurringTask() {}
+		}
+
+		const agenda = new Agenda({ backend: new RecordingBackend() });
+
+		// A real app commonly awaits readiness before wiring up controllers.
+		await agenda.ready;
+		await tick();
+
+		registerJobs(agenda, [new MyJobs()]);
+		await agenda.start();
+		await tick();
+
+		expect(savedJobNames).toContain('recurringTask');
+
+		await agenda.stop().catch(() => {});
+	});
+});


### PR DESCRIPTION
Fixes #1720.

`@Every` jobs were scheduled from a `once('ready')` listener. Agenda emits `ready` once, in the constructor. Code that does `await agenda.ready` before calling `registerJobs` attaches the listener after the event already fired, so the jobs are never scheduled and nothing throws. The code's own comment says it should schedule immediately if agenda is already started, which `once('ready')` cannot do.

The fix uses the `ready` promise, which stays resolved after the event.

Test awaits `agenda.ready`, registers a controller with an `@Every` job, and checks it was saved.