### PR TITLE
reset backoff failCount on success

### DIFF
--- a/.changeset/fix-backoff-failcount-reset.md
+++ b/.changeset/fix-backoff-failcount-reset.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+Reset a job's backoff retry counter after a successful run. A recurring job that exhausted its retries earlier in its lifetime kept the old `failCount`, so a later failure was treated as already out of retries and stopped retrying.

--- a/packages/agenda/src/Job.ts
+++ b/packages/agenda/src/Job.ts
@@ -693,6 +693,14 @@ export class Job<DATA = unknown | void> {
 
 			this.attrs.lastFinishedAt = new Date();
 
+			// Reset the failure counter on success so a later failure starts a
+			// fresh retry/backoff sequence instead of inheriting the old count.
+			// This matters for recurring jobs that recover between runs.
+			// 0 round-trips back to `undefined` via computeJobObj on reload.
+			if (this.attrs.failCount) {
+				this.attrs.failCount = 0;
+			}
+
 			this.agenda.emit('success', this);
 			this.agenda.emit(`success:${this.attrs.name}`, this);
 			log('[%s:%s] has succeeded', this.attrs.name, this.attrs._id);

--- a/packages/agenda/src/Job.ts
+++ b/packages/agenda/src/Job.ts
@@ -696,7 +696,8 @@ export class Job<DATA = unknown | void> {
 			// Reset the failure counter on success so a later failure starts a
 			// fresh retry/backoff sequence instead of inheriting the old count.
 			// This matters for recurring jobs that recover between runs.
-			// 0 round-trips back to `undefined` via computeJobObj on reload.
+			// All consumers coerce falsy failCount (attempt: failCount || 1), so
+			// a persisted 0 behaves identically to an absent value.
 			if (this.attrs.failCount) {
 				this.attrs.failCount = 0;
 			}

--- a/packages/agenda/test/backoff-failcount-reset.test.ts
+++ b/packages/agenda/test/backoff-failcount-reset.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { Agenda, toJobId } from '../src/index.js';
+import type { AgendaBackend, JobRepository, JobParameters } from '../src/index.js';
+import { exponential } from '../src/utils/backoff.js';
+
+class RecordingRepo implements JobRepository {
+	async connect() {}
+	async queryJobs() {
+		return { jobs: [], total: 0 };
+	}
+	async getJobsOverview() {
+		return [];
+	}
+	async getDistinctJobNames() {
+		return [];
+	}
+	async getJobById() {
+		return null;
+	}
+	async getQueueSize() {
+		return 0;
+	}
+	async removeJobs() {
+		return 0;
+	}
+	async saveJob<DATA = unknown>(job: JobParameters<DATA>): Promise<JobParameters<DATA>> {
+		return { ...job, _id: job._id || toJobId('mock-id') };
+	}
+	async saveJobState() {}
+	async lockJob() {
+		return undefined;
+	}
+	async unlockJob() {}
+	async unlockJobs() {}
+	async getNextJobToRun() {
+		return undefined;
+	}
+	async disableJobs() {
+		return 0;
+	}
+	async enableJobs() {
+		return 0;
+	}
+	async purgeAllJobs() {
+		return 0;
+	}
+}
+
+class RecordingBackend implements AgendaBackend {
+	readonly name = 'RecordingBackend';
+	readonly repository = new RecordingRepo();
+	async connect() {}
+	async disconnect() {}
+}
+
+describe('backoff failCount reset for recurring jobs', () => {
+	it('starts a fresh retry sequence after a successful run between failures', async () => {
+		const agenda = new Agenda({ backend: new RecordingBackend() });
+		await agenda.ready;
+
+		let shouldFail = true;
+		const retries: number[] = [];
+
+		agenda.define(
+			'recurring',
+			async () => {
+				if (shouldFail) throw new Error('boom');
+			},
+			{ backoff: exponential({ delay: 5, maxRetries: 2 }) }
+		);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- event payload
+		agenda.on('retry', (_job: any, details: any) => retries.push(details.attempt));
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- direct job control
+		const job: any = agenda.create('recurring', {});
+		job.attrs._id = toJobId('recurring-id');
+		job.attrs.type = 'single';
+		job.attrs.repeatInterval = '1 day';
+
+		// Exhaust the retry budget.
+		await job.run();
+		await job.run();
+		await job.run();
+
+		// Recover with a successful run.
+		shouldFail = false;
+		await job.run();
+		expect(job.attrs.failCount).toBe(0);
+
+		// A subsequent failure should be treated as a brand new incident.
+		shouldFail = true;
+		const retriesBefore = retries.length;
+		await job.run();
+
+		expect(retries.length).toBeGreaterThan(retriesBefore);
+	});
+});


### PR DESCRIPTION
Fixes #1721.

`fail()` increments `failCount`, and `handleRetry()` uses it as the attempt number. A successful run never reset it. A recurring job that exhausts its retries once and then succeeds keeps the old count, so its next failure is treated as already out of retries and gets no backoff.

The fix resets `failCount` on success. `0` persists cleanly and loads back as `undefined`, so a job that never failed is unaffected.

Test exhausts the retry budget, runs one success, fails again, and checks a new retry is scheduled.