### PR TITLE
prevent SQL injection via unique() constraint keys

### DIFF
--- a/.changeset/postgres-unique-sql-injection.md
+++ b/.changeset/postgres-unique-sql-injection.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/postgres-backend': patch
+---
+
+Prevent SQL injection through `unique()` constraint keys. JSON paths are now bound as query parameters and column names are validated against the table's columns, instead of being concatenated into the SQL.

--- a/packages/postgres-backend/src/PostgresJobRepository.ts
+++ b/packages/postgres-backend/src/PostgresJobRepository.ts
@@ -54,6 +54,9 @@ const UNIQUE_QUERYABLE_COLUMNS = new Set<string>([
 	'fork',
 	'last_modified_by',
 	'debounce_started_at',
+	'start_date',
+	'end_date',
+	'skip_days',
 	'created_at',
 	'updated_at'
 ]);

--- a/packages/postgres-backend/src/PostgresJobRepository.ts
+++ b/packages/postgres-backend/src/PostgresJobRepository.ts
@@ -27,6 +27,38 @@ import {
 const log = debug('agenda:postgres:repository');
 
 /**
+ * Columns that may be referenced directly (i.e. not via a `data.` JSON path) in a
+ * `unique` constraint. SQL identifiers cannot be passed as bound parameters, so a
+ * caller-supplied key is validated against this allowlist before it is ever placed
+ * into a query string. This prevents SQL injection via the keys of the `unique`
+ * object (the values are always parameterized).
+ */
+const UNIQUE_QUERYABLE_COLUMNS = new Set<string>([
+	'id',
+	'name',
+	'priority',
+	'next_run_at',
+	'type',
+	'locked_at',
+	'last_finished_at',
+	'failed_at',
+	'fail_count',
+	'fail_reason',
+	'repeat_timezone',
+	'last_run_at',
+	'repeat_interval',
+	'data',
+	'repeat_at',
+	'disabled',
+	'progress',
+	'fork',
+	'last_modified_by',
+	'debounce_started_at',
+	'created_at',
+	'updated_at'
+]);
+
+/**
  * PostgreSQL implementation of JobRepository
  */
 export class PostgresJobRepository implements JobRepository {
@@ -722,14 +754,20 @@ export class PostgresJobRepository implements JobRepository {
 
 			for (const [key, value] of Object.entries(unique)) {
 				if (key.startsWith('data.')) {
-					// Handle data sub-paths like 'data.userId'
+					// Handle data sub-paths like 'data.userId'. The JSON path is a value,
+					// so it is bound as a parameter rather than interpolated into the SQL.
 					const dataPath = key.substring(5);
-					conditions.push(`data->>'${dataPath}' = $${paramIndex++}`);
-					params.push(String(value));
+					conditions.push(`data->>$${paramIndex++} = $${paramIndex++}`);
+					params.push(dataPath, String(value));
 				} else {
-					// Direct column (snake_case conversion)
+					// Direct column (snake_case conversion). The column name is an SQL
+					// identifier and cannot be parameterized, so it is validated against a
+					// fixed allowlist to prevent SQL injection via the unique key.
 					const columnName = key.replace(/([A-Z])/g, '_$1').toLowerCase();
-					conditions.push(`${columnName} = $${paramIndex++}`);
+					if (!UNIQUE_QUERYABLE_COLUMNS.has(columnName)) {
+						throw new Error(`Invalid unique constraint field: "${key}"`);
+					}
+					conditions.push(`"${columnName}" = $${paramIndex++}`);
 					params.push(value);
 				}
 			}

--- a/packages/postgres-backend/test/sql-injection.test.ts
+++ b/packages/postgres-backend/test/sql-injection.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Security regression test: the keys of a `unique` constraint must never be
+ * interpolated into raw SQL. Uses a recording mock pool, so it needs no live
+ * database.
+ */
+import { describe, it, expect } from 'vitest';
+import { PostgresJobRepository } from '../src/PostgresJobRepository.js';
+
+interface RecordedCall {
+	sql: string;
+	params: unknown[];
+}
+
+function makeRepo() {
+	const calls: RecordedCall[] = [];
+	const pool = {
+		query(sql: string, params: unknown[] = []) {
+			calls.push({ sql, params });
+			if (/^\s*INSERT/i.test(sql)) {
+				return Promise.resolve({
+					rows: [
+						{
+							id: '00000000-0000-0000-0000-000000000000',
+							name: 'job',
+							priority: 0,
+							type: 'normal',
+							data: {},
+							disabled: false
+						}
+					],
+					rowCount: 1
+				});
+			}
+			return Promise.resolve({ rows: [], rowCount: 0 });
+		}
+	};
+	const repo = new PostgresJobRepository({ pool: pool as never, ensureSchema: false });
+	return { repo, calls };
+}
+
+function baseJob(unique: Record<string, unknown>) {
+	return {
+		name: 'job',
+		priority: 0,
+		type: 'normal',
+		data: {},
+		disabled: false,
+		unique
+	};
+}
+
+describe('PostgresJobRepository unique-constraint SQL injection', () => {
+	it('binds data.* JSON paths as parameters instead of interpolating them', async () => {
+		const { repo, calls } = makeRepo();
+
+		const maliciousPath = "id'; DROP TABLE agenda_jobs; --";
+		await repo.saveJob(baseJob({ [`data.${maliciousPath}`]: 'x' }) as never, undefined);
+
+		const select = calls.find(c => /^\s*SELECT/i.test(c.sql));
+		expect(select).toBeDefined();
+		// The payload must not appear in the SQL text...
+		expect(select!.sql).not.toContain('DROP TABLE');
+		expect(select!.sql).toContain('data->>$');
+		// ...it must travel as a bound parameter value.
+		expect(select!.params).toContain(maliciousPath);
+	});
+
+	it('rejects direct-column keys that are not known columns', async () => {
+		const { repo } = makeRepo();
+
+		await expect(
+			repo.saveJob(baseJob({ 'id = 1 or 1=1; --': 'y' }) as never, undefined)
+		).rejects.toThrow(/Invalid unique constraint field/);
+	});
+
+	it('still accepts legitimate unique constraints', async () => {
+		const { repo, calls } = makeRepo();
+
+		await repo.saveJob(
+			baseJob({ 'data.entityType': 'products', name: 'job' }) as never,
+			undefined
+		);
+
+		const select = calls.find(c => /^\s*SELECT/i.test(c.sql));
+		expect(select).toBeDefined();
+		expect(select!.sql).toContain('data->>$');
+		expect(select!.sql).toContain('"name" = $');
+		expect(select!.params).toContain('entityType');
+		expect(select!.params).toContain('products');
+	});
+});


### PR DESCRIPTION
Fixes #1722.

The unique-constraint lookup bound the values but put the keys straight into the SQL:

```js
conditions.push(`data->>'${dataPath}' = $${paramIndex++}`);  // JSON path key
conditions.push(`${columnName} = $${paramIndex++}`);         // column name
```

A key like `data.id' OR '1'='1` rewrites the WHERE clause of the existence check that drives the upsert. The matching UPDATE has no LIMIT, so it can overwrite every job's `data` and `next_run_at`, and force them to run immediately.

The fix binds the JSON path as a parameter, and validates the column name against the table's columns since identifiers cannot be bound.

Test uses a recording mock pool: it checks the payload is bound rather than present in the SQL text, that unknown columns are rejected, and that legitimate constraints still work.