### PR TITLE
convert fork worker job path to file URL for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -2121,7 +2121,10 @@ process.on('message', message => {
 	});
   */
 	if (agendaDefinition) {
-		const loadDefinition = await import(agendaDefinition);
+		// On Windows an absolute path like C:\foo is not a valid ESM specifier;
+		// dynamic import requires a file:// URL (ERR_UNSUPPORTED_ESM_URL_SCHEME).
+		const { pathToFileURL } = await import('node:url');
+		const loadDefinition = await import(pathToFileURL(agendaDefinition).href);
 		(loadDefinition.default || loadDefinition)(agenda, true);
 	}
 

--- a/packages/mongo-backend/test/helpers/forkHelper.ts
+++ b/packages/mongo-backend/test/helpers/forkHelper.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'node:url';
 import { Agenda } from 'agenda';
 import { MongoBackend } from '../../src/index.js';
 
@@ -34,7 +35,9 @@ try {
 
 	// load job definition
 	if (agendaDefinition) {
-		const loadDefinition = await import(agendaDefinition);
+		// On Windows an absolute path like C:\foo is not a valid ESM specifier;
+		// dynamic import requires a file:// URL (ERR_UNSUPPORTED_ESM_URL_SCHEME).
+		const loadDefinition = await import(pathToFileURL(agendaDefinition).href);
 		(loadDefinition.default || loadDefinition)(agenda, true);
 	}
 

--- a/packages/postgres-backend/test/helpers/forkHelper.ts
+++ b/packages/postgres-backend/test/helpers/forkHelper.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'node:url';
 import { Agenda } from 'agenda';
 import { PostgresBackend } from '../../src/index.js';
 
@@ -34,7 +35,9 @@ try {
 
 	// load job definition
 	if (agendaDefinition) {
-		const loadDefinition = await import(agendaDefinition);
+		// On Windows an absolute path like C:\foo is not a valid ESM specifier;
+		// dynamic import requires a file:// URL (ERR_UNSUPPORTED_ESM_URL_SCHEME).
+		const loadDefinition = await import(pathToFileURL(agendaDefinition).href);
 		(loadDefinition.default || loadDefinition)(agenda, true);
 	}
 

--- a/packages/redis-backend/test/helpers/forkHelper.ts
+++ b/packages/redis-backend/test/helpers/forkHelper.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'node:url';
 import { Agenda } from 'agenda';
 import { RedisBackend } from '../../src/index.js';
 
@@ -34,7 +35,9 @@ try {
 
 	// load job definition
 	if (agendaDefinition) {
-		const loadDefinition = await import(agendaDefinition);
+		// On Windows an absolute path like C:\foo is not a valid ESM specifier;
+		// dynamic import requires a file:// URL (ERR_UNSUPPORTED_ESM_URL_SCHEME).
+		const loadDefinition = await import(pathToFileURL(agendaDefinition).href);
 		(loadDefinition.default || loadDefinition)(agenda, true);
 	}
 


### PR DESCRIPTION
Fixes #1723.

The reference fork workers (`forkHelper.ts` for the Mongo, Redis, and Postgres backends) and the fork example in the README import the job definition by absolute path:

```js
const loadDefinition = await import(agendaDefinition);
```

On Windows `agendaDefinition` is an absolute path like `C:\...`, which dynamic `import()` rejects with `ERR_UNSUPPORTED_ESM_URL_SCHEME`, so every forked job fails to load its definition.

The fix converts the path to a file URL with `pathToFileURL`. This is a no-op on POSIX.

No changeset: these are test helpers and documentation, not shipped package code.