### PR TITLE
reject unsafe operators in unique() constraints

### DIFF
--- a/.changeset/mongo-unique-operator-guard.md
+++ b/.changeset/mongo-unique-operator-guard.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/mongo-backend': patch
+---
+
+Reject server-side-evaluation operators (`$where`, `$function`, `$expr`, `$accumulator`) in `unique()` constraints. They have no use in a uniqueness key and could allow query injection when the key is built from untrusted input. Ordinary equality and comparison constraints are unchanged.

--- a/packages/mongo-backend/src/MongoJobRepository.ts
+++ b/packages/mongo-backend/src/MongoJobRepository.ts
@@ -51,6 +51,37 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
+ * MongoDB query operators that evaluate arbitrary server-side code or expressions.
+ * They have no legitimate use in a uniqueness key and turn a caller-controlled
+ * `unique` object into a NoSQL-injection vector (server-side JS execution, denial
+ * of service, blind matching), so they are rejected before the query is built.
+ */
+const BANNED_UNIQUE_OPERATORS = new Set(['$where', '$function', '$accumulator', '$expr']);
+
+/**
+ * Recursively reject dangerous operators in a caller-supplied `unique` query.
+ * Ordinary field equality and comparison operators are left untouched, preserving
+ * the documented `unique()` query-filter contract.
+ */
+export function assertSafeUniqueQuery(value: unknown): void {
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			assertSafeUniqueQuery(item);
+		}
+		return;
+	}
+	if (!isPlainObject(value)) {
+		return;
+	}
+	for (const [key, child] of Object.entries(value)) {
+		if (BANNED_UNIQUE_OPERATORS.has(key)) {
+			throw new Error(`Unsafe operator "${key}" is not allowed in a unique() constraint`);
+		}
+		assertSafeUniqueQuery(child);
+	}
+}
+
+/**
  * Flatten a data filter object into MongoDB dot-notation keys.
  * This enables partial matching on the data subdocument.
  *
@@ -771,6 +802,9 @@ export class MongoJobRepository implements JobRepository {
 			}
 
 			if (unique) {
+				// Reject server-side-eval operators before the query is built (NoSQL injection).
+				assertSafeUniqueQuery(unique);
+
 				// Upsert based on the 'unique' query object
 				const query: Filter<MongoJobDocument> = { ...unique } as Filter<MongoJobDocument>;
 				query.name = props.name;

--- a/packages/mongo-backend/test/nosql-injection.test.ts
+++ b/packages/mongo-backend/test/nosql-injection.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Security regression test: a caller-supplied `unique()` constraint must not be
+ * able to smuggle server-side-evaluation operators ($where/$function/$expr/
+ * $accumulator) into the MongoDB query that drives the upsert. Those operators
+ * turn the unique key into a NoSQL-injection vector (server-side JS, DoS, blind
+ * matching / cross-record tampering).
+ */
+import { expect, describe, it, beforeAll, afterAll } from 'vitest';
+import { Db, MongoClient } from 'mongodb';
+import { randomUUID } from 'crypto';
+import { MongoJobRepository, assertSafeUniqueQuery } from '../src/MongoJobRepository.js';
+
+describe('assertSafeUniqueQuery (unit)', () => {
+	it('rejects $where at the top level', () => {
+		expect(() => assertSafeUniqueQuery({ $where: 'sleep(1000)' })).toThrow(/Unsafe operator/);
+	});
+
+	it('rejects evaluation operators nested under a field', () => {
+		expect(() => assertSafeUniqueQuery({ 'data.x': { $function: { body: 'x', args: [], lang: 'js' } } })).toThrow(
+			/Unsafe operator/
+		);
+		expect(() => assertSafeUniqueQuery({ 'data.y': { $expr: { $gt: ['$a', '$b'] } } })).toThrow(/Unsafe operator/);
+	});
+
+	it('rejects evaluation operators hidden inside an $or array', () => {
+		expect(() => assertSafeUniqueQuery({ $or: [{ 'data.a': 1 }, { $where: 'true' }] })).toThrow(/Unsafe operator/);
+	});
+
+	it('allows ordinary equality and comparison constraints', () => {
+		expect(() => assertSafeUniqueQuery({ 'data.entityType': 'products' })).not.toThrow();
+		expect(() => assertSafeUniqueQuery({ 'data.userId': 123, name: 'job' })).not.toThrow();
+		expect(() => assertSafeUniqueQuery({ 'data.tags': { $in: ['a', 'b'] } })).not.toThrow();
+		expect(() => assertSafeUniqueQuery({ 'data.count': { $ne: 0 } })).not.toThrow();
+	});
+});
+
+describe('MongoJobRepository unique-constraint NoSQL injection (integration)', () => {
+	let client: MongoClient;
+	let db: Db;
+	let repo: MongoJobRepository;
+
+	beforeAll(async () => {
+		const baseUri = process.env.MONGO_URI;
+		if (!baseUri) throw new Error('MONGO_URI not set. Ensure global setup is configured.');
+		const dbName = `agenda_sec_${randomUUID().replace(/-/g, '')}`;
+		const url = new URL(baseUri);
+		url.pathname = `/${dbName}`;
+		client = await MongoClient.connect(url.toString());
+		db = client.db(dbName);
+		repo = new MongoJobRepository({ mongo: db });
+		await repo.connect();
+	});
+
+	afterAll(async () => {
+		await db.dropDatabase();
+		await client.close();
+	});
+
+	const job = (unique: Record<string, unknown>, data: Record<string, unknown> = {}) =>
+		({ name: 'job', priority: 0, type: 'normal', data, unique }) as never;
+
+	it('rejects a $where unique constraint before touching the database', async () => {
+		await expect(repo.saveJob(job({ $where: 'sleep(1000)' }), undefined)).rejects.toThrow(/Unsafe operator/);
+	});
+
+	it('still accepts a legitimate unique constraint', async () => {
+		const saved = await repo.saveJob(job({ 'data.entityType': 'products' }, { entityType: 'products' }), undefined);
+		expect(saved.name).toBe('job');
+		expect(saved._id).toBeDefined();
+	});
+});


### PR DESCRIPTION
Fixes #1724.

This is a hardening suggestion rather than a library bug. MongoDB queries are objects, and `unique()` is documented to take a query filter, so the backend passes it through as designed. But if an app builds `unique` keys from untrusted input, `$where`, `$function`, `$expr`, and `$accumulator` run server-side code. The data query path is already safe because it flattens operators into literal keys, but `unique` is not flattened.

Since the code-evaluation operators have no use in a uniqueness key, the backend now rejects them before building the query. Ordinary equality and comparison constraints (`$ne`, `$in`, `$gt`, ...) are unchanged.

Tests cover the check directly (including operators nested under a field and inside an `$or` array) plus an integration test that saves a `$where` constraint (rejected) and a normal constraint (accepted) against a real MongoDB.