### PR TITLE
fix: use column inference ON CONFLICT (name) for single-job upsert

### DIFF
--- a/packages/postgres-backend/src/PostgresJobRepository.ts
+++ b/packages/postgres-backend/src/PostgresJobRepository.ts
@@ -676,7 +676,7 @@ export class PostgresJobRepository implements JobRepository {
 					name, priority, next_run_at, type, repeat_timezone,
 					repeat_interval, data, repeat_at, disabled, fork, last_modified_by
 				 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-				 ON CONFLICT ((name)) WHERE type = 'single'
+				 ON CONFLICT (name) WHERE type = 'single'
 				 DO UPDATE SET
 					priority = EXCLUDED.priority,
 					next_run_at = ${shouldProtectNextRunAt


### PR DESCRIPTION


## Description

Change the single-type job upsert in `PostgresJobRepository.saveJob` from expression inference to column inference:

```diff
- ON CONFLICT ((name)) WHERE type = 'single'
+ ON CONFLICT (name) WHERE type = 'single'
```

`packages/postgres-backend/src/PostgresJobRepository.ts:679`

Closes #1731

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [ ] Added changeset if needed (`pnpm changeset`)
- [ ] Updated documentation if needed
