### PR TITLE
cap trailing debounce nextRunAt at the maxWait deadline

### DIFF
--- a/.changeset/debounce-maxwait-cap.md
+++ b/.changeset/debounce-maxwait-cap.md
@@ -1,0 +1,7 @@
+---
+'@agendajs/mongo-backend': patch
+'@agendajs/postgres-backend': patch
+'@agendajs/redis-backend': patch
+---
+
+Cap the trailing debounce `nextRunAt` at the `maxWait` deadline. Each save rescheduled the job to `now + delay` without bounding it by `debounceStartedAt + maxWait`, so a save shortly before the deadline pushed execution past `maxWait`, breaking the documented guarantee that the job runs within `maxWait`.

--- a/packages/agenda/test/shared/debounce-test-suite.ts
+++ b/packages/agenda/test/shared/debounce-test-suite.ts
@@ -273,6 +273,31 @@ export function debounceTestSuite(config: DebounceTestConfig): void {
 				// Should still be delayed by ~500ms from now
 				expect(secondNextRunAt).toBeGreaterThanOrEqual(Date.now() + 400);
 			});
+
+			it('should not reschedule past the maxWait deadline', async () => {
+				agenda.define('debounceMaxWait', async () => {});
+
+				const job1 = await agenda
+					.create('debounceMaxWait', { key: 'max3' })
+					.unique({ 'data.key': 'max3' })
+					.debounce(2000, { maxWait: 2000 })
+					.save();
+
+				const deadline = job1.attrs.debounceStartedAt!.getTime() + 2000;
+
+				// Save again before maxWait elapses. A plain delay would push nextRunAt
+				// to now + 2000, which is past the deadline.
+				await new Promise(resolve => setTimeout(resolve, 500));
+
+				const job2 = await agenda
+					.create('debounceMaxWait', { key: 'max3', updated: true })
+					.unique({ 'data.key': 'max3' })
+					.debounce(2000, { maxWait: 2000 })
+					.save();
+
+				expect(job2.attrs.nextRunAt!.getTime()).toBeLessThanOrEqual(deadline + 50);
+				expect(job2.attrs.nextRunAt!.getTime()).toBeGreaterThan(Date.now());
+			});
 		});
 
 		describe('debounce with different unique keys', () => {

--- a/packages/mongo-backend/src/MongoJobRepository.ts
+++ b/packages/mongo-backend/src/MongoJobRepository.ts
@@ -791,8 +791,15 @@ export class MongoJobRepository implements JobRepository {
 							// Reset debounceStartedAt for the next cycle
 							(propsWithModifier as Partial<MongoJobDocument>).debounceStartedAt = undefined;
 						} else {
-							// Normal debounce: schedule for delay ms from now
+							// Normal debounce: schedule for delay ms from now, but never past the
+							// maxWait deadline so the job still runs within maxWait if saves stop.
 							newNextRunAt = new Date(now.getTime() + debounce.delay);
+							if (debounce.maxWait) {
+								const deadline = debounceStartedAt.getTime() + debounce.maxWait;
+								if (newNextRunAt.getTime() > deadline) {
+									newNextRunAt = new Date(deadline);
+								}
+							}
 							(propsWithModifier as Partial<MongoJobDocument>).debounceStartedAt = debounceStartedAt;
 							log('trailing debounce: rescheduling to %s', newNextRunAt.toISOString());
 						}

--- a/packages/postgres-backend/src/PostgresJobRepository.ts
+++ b/packages/postgres-backend/src/PostgresJobRepository.ts
@@ -771,7 +771,15 @@ export class PostgresJobRepository implements JobRepository {
 							nextRunAt = now;
 							debounceStartedAt = null; // Reset for next cycle
 						} else {
+							// Schedule for delay ms from now, but never past the maxWait deadline
+							// so the job still runs within maxWait if saves stop.
 							nextRunAt = new Date(now.getTime() + debounce.delay);
+							if (debounce.maxWait) {
+								const deadline = existingDebounceStartedAt.getTime() + debounce.maxWait;
+								if (nextRunAt.getTime() > deadline) {
+									nextRunAt = new Date(deadline);
+								}
+							}
 							debounceStartedAt = existingDebounceStartedAt;
 							log('trailing debounce: rescheduling to %s', nextRunAt.toISOString());
 						}

--- a/packages/redis-backend/src/RedisJobRepository.ts
+++ b/packages/redis-backend/src/RedisJobRepository.ts
@@ -1010,7 +1010,15 @@ export class RedisJobRepository implements JobRepository {
 								nextRunAt = nowIso;
 								debounceStartedAt = 'null'; // Reset for next cycle
 							} else {
+								// Schedule for delay ms from now, but never past the maxWait deadline
+								// so the job still runs within maxWait if saves stop.
 								const newNextRunAt = new Date(now.getTime() + debounce.delay);
+								if (debounce.maxWait) {
+									const deadline = existingDebounceStartedAt.getTime() + debounce.maxWait;
+									if (newNextRunAt.getTime() > deadline) {
+										newNextRunAt.setTime(deadline);
+									}
+								}
 								nextRunAt = newNextRunAt.toISOString();
 								debounceStartedAt = existingDebounceStartedAt.toISOString();
 								log('trailing debounce: rescheduling to %s', nextRunAt);


### PR DESCRIPTION
`maxWait` is documented to guarantee a trailing-debounced job runs within `maxWait` even if saves keep coming. Each save reschedules `nextRunAt` to `now + delay` without bounding it by `debounceStartedAt + maxWait`. So a save shortly before the deadline pushes `nextRunAt` past the deadline, and if saves then stop, the job runs late (up to `delay` after `maxWait`).

Example: `delay = 2000`, `maxWait = 2000`. First save at T0 schedules T2000. A second save at T500 reschedules to T2500, which is past the T2000 deadline.

Fix caps `nextRunAt` at `debounceStartedAt + maxWait` in all three backends (Mongo, Postgres, Redis). The existing maxWait-exceeded branch (force immediate) is unchanged.

Added `should not reschedule past the maxWait deadline` to the shared debounce suite, so it runs against all backends. It fails on the current code and passes with the change. Verified the full maxWait suite on Mongo (memory-server), Postgres, and Redis.