### PR TITLE
surface async handler errors via 'error' event

### DIFF
--- a/.changeset/notification-handler-async-errors.md
+++ b/.changeset/notification-handler-async-errors.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+Surface notification handler errors consistently. A subscriber that threw synchronously emitted an `error` event, but one that returned a rejected promise was swallowed by `Promise.allSettled`. Rejected async handlers (for both job and state notifications) now emit `error` like synchronous throws.

--- a/packages/agenda/src/notifications/BaseNotificationChannel.ts
+++ b/packages/agenda/src/notifications/BaseNotificationChannel.ts
@@ -76,13 +76,18 @@ export abstract class BaseNotificationChannel extends EventEmitter implements No
 			try {
 				const result = handler(notification);
 				if (result instanceof Promise) {
-					promises.push(result);
+					// Surface rejected handlers via 'error', like the synchronous throw below.
+					promises.push(
+						result.catch(error => {
+							this.emit('error', error);
+						})
+					);
 				}
 			} catch (error) {
 				this.emit('error', error);
 			}
 		}
-		await Promise.allSettled(promises);
+		await Promise.all(promises);
 	}
 
 	/**
@@ -95,13 +100,18 @@ export abstract class BaseNotificationChannel extends EventEmitter implements No
 			try {
 				const result = handler(notification);
 				if (result instanceof Promise) {
-					promises.push(result);
+					// Surface rejected handlers via 'error', like the synchronous throw below.
+					promises.push(
+						result.catch(error => {
+							this.emit('error', error);
+						})
+					);
 				}
 			} catch (error) {
 				this.emit('error', error);
 			}
 		}
-		await Promise.allSettled(promises);
+		await Promise.all(promises);
 	}
 
 	/**

--- a/packages/agenda/test/notification-channel-errors.test.ts
+++ b/packages/agenda/test/notification-channel-errors.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { InMemoryNotificationChannel, toJobId } from '../src/index.js';
+import type { JobNotification } from '../src/index.js';
+
+const notification = (): JobNotification => ({
+	jobId: toJobId('1'),
+	jobName: 'test',
+	nextRunAt: null,
+	priority: 0
+});
+
+describe('BaseNotificationChannel handler errors', () => {
+	let channel: InMemoryNotificationChannel;
+
+	beforeEach(async () => {
+		channel = new InMemoryNotificationChannel();
+		await channel.connect();
+	});
+
+	afterEach(async () => {
+		await channel.disconnect();
+	});
+
+	it('emits error when an async handler rejects and still runs other handlers', async () => {
+		const errors: Error[] = [];
+		channel.on('error', err => errors.push(err as Error));
+
+		const ran: string[] = [];
+		channel.subscribe(async () => {
+			throw new Error('async boom');
+		});
+		channel.subscribe(() => {
+			ran.push('second');
+		});
+
+		await channel.publish(notification());
+
+		expect(errors).toHaveLength(1);
+		expect(errors[0].message).toBe('async boom');
+		expect(ran).toEqual(['second']);
+	});
+
+	it('emits error when a sync handler throws', async () => {
+		const errors: Error[] = [];
+		channel.on('error', err => errors.push(err as Error));
+
+		channel.subscribe(() => {
+			throw new Error('sync boom');
+		});
+
+		await channel.publish(notification());
+
+		expect(errors).toHaveLength(1);
+		expect(errors[0].message).toBe('sync boom');
+	});
+});


### PR DESCRIPTION
`notifyHandlers` and `notifyStateHandlers` wrap each handler call in try/catch and re-emit synchronous throws as an `error` event. But a handler that returns a rejected promise is pushed into `Promise.allSettled`, which never rejects, so the rejection is swallowed and never surfaces.

The result is inconsistent: a subscriber that throws synchronously emits `error`, but one that rejects asynchronously fails silently, which makes a broken handler hard to notice.

This catches rejected handler promises and emits `error` for them too, matching the synchronous path. Other handlers still run regardless of one failing.

Added a unit test covering both async-reject and sync-throw against `InMemoryNotificationChannel`; the async case fails on the current code and passes with the change.