### PR TITLE
preserve startDate, endDate and skipDays in the Mongo backend

### DIFF
--- a/.changeset/mongo-preserve-date-constraints.md
+++ b/.changeset/mongo-preserve-date-constraints.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/mongo-backend': patch
+---
+
+Preserve `startDate`, `endDate`, and `skipDays` when reading jobs from MongoDB. `computeJobObj` did not map these fields, so they were lost on every read. A repeating job therefore lost its date constraints after the first run and could be rescheduled onto skipped days or outside its start/end window.

--- a/packages/mongo-backend/src/MongoJobRepository.ts
+++ b/packages/mongo-backend/src/MongoJobRepository.ts
@@ -95,7 +95,10 @@ function computeJobObj<DATA = unknown>(job: WithId<MongoJobDocument>): JobParame
 		uniqueOpts: job.uniqueOpts,
 		lastModifiedBy: job.lastModifiedBy,
 		fork: job.fork,
-		debounceStartedAt: job.debounceStartedAt
+		debounceStartedAt: job.debounceStartedAt,
+		startDate: job.startDate,
+		endDate: job.endDate,
+		skipDays: job.skipDays
 	};
 }
 

--- a/packages/mongo-backend/test/mongo-backend.test.ts
+++ b/packages/mongo-backend/test/mongo-backend.test.ts
@@ -342,6 +342,34 @@ describe('MongoBackend', () => {
 			expect(removed).toBe(1);
 		});
 
+		it('should round-trip date constraints (startDate, endDate, skipDays)', async () => {
+			const startDate = new Date('2026-01-01T00:00:00Z');
+			const endDate = new Date('2026-12-31T00:00:00Z');
+			const skipDays = [0, 6];
+
+			const saved = await backend.repository.saveJob({
+				name: 'constraints-test',
+				priority: 0,
+				nextRunAt: new Date(),
+				type: 'normal',
+				data: {},
+				repeatInterval: '1 day',
+				startDate,
+				endDate,
+				skipDays
+			}, undefined);
+
+			const byId = await backend.repository.getJobById(saved._id!.toString());
+			expect(byId?.startDate?.getTime()).toBe(startDate.getTime());
+			expect(byId?.endDate?.getTime()).toBe(endDate.getTime());
+			expect(byId?.skipDays).toEqual(skipDays);
+
+			const result = await backend.repository.queryJobs({ name: 'constraints-test' });
+			expect(result.jobs[0].startDate?.getTime()).toBe(startDate.getTime());
+			expect(result.jobs[0].endDate?.getTime()).toBe(endDate.getTime());
+			expect(result.jobs[0].skipDays).toEqual(skipDays);
+		});
+
 		it('should handle concurrent job locking with findOneAndUpdate', async () => {
 			await Promise.all([
 				backend.repository.saveJob({


### PR DESCRIPTION
`saveJob` persists `startDate`, `endDate` and `skipDays` (they ride along in the spread props), but `computeJobObj` — the single function that maps a stored Mongo document back to `JobParameters`, used by `getJobById`, `queryJobs`, `getNextJobToRun`, `lockJob`, and `saveJob`'s own return value — never copied them back. So every job read from the database came back with those constraints `undefined`.

The observable effect: when the processor picks up a repeating job and `Job.run()` recomputes `nextRunAt` via `computeFromInterval`, the constraints are gone, so the job can be scheduled onto days it was told to skip and outside its start/end window.

Fix maps the three fields in `computeJobObj`. Added a test that saves a job with all three and asserts they survive `getJobById` and `queryJobs`; it fails on the current code and passes with the change.