### PR TITLE
preserve startDate, endDate and skipDays in the Redis backend

### DIFF
--- a/.changeset/redis-preserve-date-constraints.md
+++ b/.changeset/redis-preserve-date-constraints.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/redis-backend': patch
+---
+
+Persist and restore `startDate`, `endDate` and `skipDays` in the Redis backend. These fields were never written by `jobToHash` nor read by `hashToJob`, so a job saved with date constraints lost them on every reload, silently disabling its start/end window and skipped days.

--- a/packages/redis-backend/src/RedisJobRepository.ts
+++ b/packages/redis-backend/src/RedisJobRepository.ts
@@ -133,6 +133,13 @@ export class RedisJobRepository implements JobRepository {
 			debounceStartedAt:
 				data.debounceStartedAt && data.debounceStartedAt !== 'null'
 					? new Date(data.debounceStartedAt)
+					: undefined,
+			startDate:
+				data.startDate && data.startDate !== 'null' ? new Date(data.startDate) : undefined,
+			endDate: data.endDate && data.endDate !== 'null' ? new Date(data.endDate) : undefined,
+			skipDays:
+				data.skipDays && data.skipDays !== 'null'
+					? (JSON.parse(data.skipDays) as number[])
 					: undefined
 		};
 	}
@@ -167,6 +174,9 @@ export class RedisJobRepository implements JobRepository {
 			fork: String(job.fork ?? false),
 			lastModifiedBy: lastModifiedBy ?? 'null',
 			debounceStartedAt: job.debounceStartedAt?.toISOString() || 'null',
+			startDate: job.startDate?.toISOString() || 'null',
+			endDate: job.endDate?.toISOString() || 'null',
+			skipDays: job.skipDays ? JSON.stringify(job.skipDays) : 'null',
 			createdAt: now,
 			updatedAt: now
 		};

--- a/packages/redis-backend/src/types.ts
+++ b/packages/redis-backend/src/types.ts
@@ -53,6 +53,9 @@ export interface RedisJobData {
 	fork: string;
 	lastModifiedBy: string | null;
 	debounceStartedAt: string | null;
+	startDate: string | null;
+	endDate: string | null;
+	skipDays: string | null;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/packages/redis-backend/test/redis-backend.test.ts
+++ b/packages/redis-backend/test/redis-backend.test.ts
@@ -273,6 +273,29 @@ describe('RedisBackend', () => {
 			const members = await redis.smembers(`${TEST_KEY_PREFIX}jobs:by_name:set-test`);
 			expect(members.length).toBe(1);
 		});
+
+		it('should round-trip date constraints (startDate, endDate, skipDays)', async () => {
+			const startDate = new Date('2026-01-01T00:00:00.000Z');
+			const endDate = new Date('2026-12-31T00:00:00.000Z');
+			const skipDays = [0, 6];
+
+			const saved = await backend.repository.saveJob({
+				name: 'constraints-test',
+				priority: 0,
+				nextRunAt: new Date(),
+				type: 'normal',
+				data: {},
+				repeatInterval: '1 day',
+				startDate,
+				endDate,
+				skipDays
+			});
+
+			const byId = await backend.repository.getJobById(saved._id!.toString());
+			expect(byId?.startDate?.getTime()).toBe(startDate.getTime());
+			expect(byId?.endDate?.getTime()).toBe(endDate.getTime());
+			expect(byId?.skipDays).toEqual(skipDays);
+		});
 	});
 });
 


### PR DESCRIPTION
The Redis backend never persists or reads back a job's `startDate`, `endDate` or `skipDays`. `jobToHash` does not write them, the `RedisJobData` hash type has no slots for them, and `hashToJob` does not read them. So a job saved with these date constraints loses them on every reload (`getJobById`, `getNextJobToRun`, re-fetch after restart), silently disabling its start/end window and skipped days.

`JobParameters` defines these fields (`packages/agenda/src/types/JobParameters.ts`) and the scheduler uses them in `utils/dateConstraints.ts` and `utils/nextRunAt.ts`.

Fix serializes the three fields in `jobToHash` and deserializes them in `hashToJob` (dates via ISO strings, `skipDays` via JSON), and adds the slots to `RedisJobData`. Added a round-trip test to the Redis-specific suite; it fails on the current code and passes with the change.