### PR TITLE
preserve startDate, endDate and skipDays in the Postgres backend

### DIFF
--- a/.changeset/postgres-preserve-date-constraints.md
+++ b/.changeset/postgres-preserve-date-constraints.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/postgres-backend': patch
+---
+
+Persist and restore `startDate`, `endDate` and `skipDays` in the Postgres backend. These were not columns in the schema, were not written by `saveJob`, and were not read by `rowToJob`, so a job saved with date constraints lost them entirely, silently disabling its start/end window and skipped days. Adds the columns and wires them through every save path and the row mapping.

--- a/packages/postgres-backend/src/PostgresJobRepository.ts
+++ b/packages/postgres-backend/src/PostgresJobRepository.ts
@@ -157,7 +157,10 @@ export class PostgresJobRepository implements JobRepository {
 			progress: row.progress ?? undefined,
 			fork: row.fork ?? undefined,
 			lastModifiedBy: row.last_modified_by ?? undefined,
-			debounceStartedAt: row.debounce_started_at ?? undefined
+			debounceStartedAt: row.debounce_started_at ?? undefined,
+			startDate: row.start_date ?? undefined,
+			endDate: row.end_date ?? undefined,
+			skipDays: row.skip_days ?? undefined
 		};
 	}
 
@@ -632,7 +635,10 @@ export class PostgresJobRepository implements JobRepository {
 					 fail_reason = $12,
 					 fail_count = $13,
 					 failed_at = $14,
-					 last_modified_by = $15
+					 last_modified_by = $15,
+					 start_date = $16,
+					 end_date = $17,
+					 skip_days = $18
 				 WHERE id = $1 AND name = $2
 				 RETURNING *`,
 				[
@@ -650,7 +656,10 @@ export class PostgresJobRepository implements JobRepository {
 					props.failReason ?? null,
 					props.failCount ?? null,
 					props.failedAt || null,
-					options?.lastModifiedBy || null
+					options?.lastModifiedBy || null,
+					props.startDate || null,
+					props.endDate || null,
+					props.skipDays || null
 				]
 			);
 
@@ -674,8 +683,9 @@ export class PostgresJobRepository implements JobRepository {
 			const result = await this.pool.query<PostgresJobRow>(
 				`INSERT INTO "${this.tableName}" (
 					name, priority, next_run_at, type, repeat_timezone,
-					repeat_interval, data, repeat_at, disabled, fork, last_modified_by
-				 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+					repeat_interval, data, repeat_at, disabled, fork, last_modified_by,
+					start_date, end_date, skip_days
+				 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 				 ON CONFLICT ((name)) WHERE type = 'single'
 				 DO UPDATE SET
 					priority = EXCLUDED.priority,
@@ -688,7 +698,10 @@ export class PostgresJobRepository implements JobRepository {
 					repeat_at = EXCLUDED.repeat_at,
 					disabled = EXCLUDED.disabled,
 					fork = EXCLUDED.fork,
-					last_modified_by = EXCLUDED.last_modified_by
+					last_modified_by = EXCLUDED.last_modified_by,
+					start_date = EXCLUDED.start_date,
+					end_date = EXCLUDED.end_date,
+					skip_days = EXCLUDED.skip_days
 				 RETURNING *`,
 				[
 					props.name,
@@ -701,7 +714,10 @@ export class PostgresJobRepository implements JobRepository {
 					props.repeatAt || null,
 					props.disabled || false,
 					props.fork || false,
-					options?.lastModifiedBy || null
+					options?.lastModifiedBy || null,
+					props.startDate || null,
+					props.endDate || null,
+					props.skipDays || null
 				]
 			);
 
@@ -791,7 +807,10 @@ export class PostgresJobRepository implements JobRepository {
 						 disabled = $${paramIndex + 7},
 						 fork = $${paramIndex + 8},
 						 last_modified_by = $${paramIndex + 9},
-						 debounce_started_at = $${paramIndex + 10}
+						 debounce_started_at = $${paramIndex + 10},
+						 start_date = $${paramIndex + 11},
+						 end_date = $${paramIndex + 12},
+						 skip_days = $${paramIndex + 13}
 					 WHERE ${conditions.join(' AND ')}
 					 RETURNING *`,
 					[
@@ -806,7 +825,10 @@ export class PostgresJobRepository implements JobRepository {
 						props.disabled || false,
 						props.fork || false,
 						options?.lastModifiedBy || null,
-						debounceStartedAt
+						debounceStartedAt,
+						props.startDate || null,
+						props.endDate || null,
+						props.skipDays || null
 					]
 				);
 
@@ -830,8 +852,9 @@ export class PostgresJobRepository implements JobRepository {
 				const result = await this.pool.query<PostgresJobRow>(
 					`INSERT INTO "${this.tableName}" (
 						name, priority, next_run_at, type, repeat_timezone,
-						repeat_interval, data, repeat_at, disabled, fork, last_modified_by, debounce_started_at
-					 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+						repeat_interval, data, repeat_at, disabled, fork, last_modified_by, debounce_started_at,
+						start_date, end_date, skip_days
+					 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 					 RETURNING *`,
 					[
 						props.name,
@@ -845,7 +868,10 @@ export class PostgresJobRepository implements JobRepository {
 						props.disabled || false,
 						props.fork || false,
 						options?.lastModifiedBy || null,
-						debounceStartedAt
+						debounceStartedAt,
+						props.startDate || null,
+						props.endDate || null,
+						props.skipDays || null
 					]
 				);
 
@@ -858,8 +884,9 @@ export class PostgresJobRepository implements JobRepository {
 		const result = await this.pool.query<PostgresJobRow>(
 			`INSERT INTO "${this.tableName}" (
 				name, priority, next_run_at, type, repeat_timezone,
-				repeat_interval, data, repeat_at, disabled, fork, last_modified_by
-			 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+				repeat_interval, data, repeat_at, disabled, fork, last_modified_by,
+				start_date, end_date, skip_days
+			 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 			 RETURNING *`,
 			[
 				props.name,
@@ -872,7 +899,10 @@ export class PostgresJobRepository implements JobRepository {
 				props.repeatAt || null,
 				props.disabled || false,
 				props.fork || false,
-				options?.lastModifiedBy || null
+				options?.lastModifiedBy || null,
+				props.startDate || null,
+				props.endDate || null,
+				props.skipDays || null
 			]
 		);
 

--- a/packages/postgres-backend/src/schema.ts
+++ b/packages/postgres-backend/src/schema.ts
@@ -25,6 +25,9 @@ export function getCreateTableSQL(tableName: string): string {
 			fork BOOLEAN DEFAULT FALSE,
 			last_modified_by VARCHAR(255),
 			debounce_started_at TIMESTAMPTZ,
+			start_date TIMESTAMPTZ,
+			end_date TIMESTAMPTZ,
+			skip_days INTEGER[],
 			created_at TIMESTAMPTZ DEFAULT NOW(),
 			updated_at TIMESTAMPTZ DEFAULT NOW()
 		);

--- a/packages/postgres-backend/src/types.ts
+++ b/packages/postgres-backend/src/types.ts
@@ -60,6 +60,9 @@ export interface PostgresJobRow {
 	fork: boolean;
 	last_modified_by: string | null;
 	debounce_started_at: Date | null;
+	start_date: Date | null;
+	end_date: Date | null;
+	skip_days: number[] | null;
 	created_at: Date;
 	updated_at: Date;
 }

--- a/packages/postgres-backend/test/date-constraints.test.ts
+++ b/packages/postgres-backend/test/date-constraints.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Date constraints (startDate, endDate, skipDays) must survive a save/read
+ * round-trip. Uses a recording mock pool, so it needs no live database.
+ */
+import { describe, it, expect } from 'vitest';
+import { PostgresJobRepository } from '../src/PostgresJobRepository.js';
+
+const startDate = new Date('2026-01-01T00:00:00.000Z');
+const endDate = new Date('2026-12-31T00:00:00.000Z');
+const skipDays = [0, 6];
+
+interface RecordedCall {
+	sql: string;
+	params: unknown[];
+}
+
+function makeRepo() {
+	const calls: RecordedCall[] = [];
+	const pool = {
+		query(sql: string, params: unknown[] = []) {
+			calls.push({ sql, params });
+			if (/^\s*INSERT/i.test(sql)) {
+				return Promise.resolve({
+					rows: [
+						{
+							id: '00000000-0000-0000-0000-000000000000',
+							name: 'job',
+							priority: 0,
+							next_run_at: null,
+							type: 'normal',
+							data: {},
+							disabled: false,
+							start_date: startDate,
+							end_date: endDate,
+							skip_days: skipDays
+						}
+					],
+					rowCount: 1
+				});
+			}
+			return Promise.resolve({ rows: [], rowCount: 0 });
+		}
+	};
+	const repo = new PostgresJobRepository({ pool: pool as never, ensureSchema: false });
+	return { repo, calls };
+}
+
+function baseJob(extra: Record<string, unknown>) {
+	return {
+		name: 'job',
+		priority: 0,
+		nextRunAt: new Date(),
+		type: 'normal',
+		data: {},
+		startDate,
+		endDate,
+		skipDays,
+		...extra
+	};
+}
+
+describe('PostgresJobRepository date constraints round-trip', () => {
+	it('writes startDate, endDate and skipDays on insert and reads them back', async () => {
+		const { repo, calls } = makeRepo();
+
+		const saved = await repo.saveJob(baseJob({}) as never, undefined);
+
+		const insert = calls.find(c => /^\s*INSERT/i.test(c.sql));
+		expect(insert).toBeDefined();
+		expect(insert!.sql).toContain('start_date');
+		expect(insert!.sql).toContain('end_date');
+		expect(insert!.sql).toContain('skip_days');
+		expect(insert!.params).toContainEqual(startDate);
+		expect(insert!.params).toContainEqual(endDate);
+		expect(insert!.params).toContainEqual(skipDays);
+
+		expect(saved.startDate).toEqual(startDate);
+		expect(saved.endDate).toEqual(endDate);
+		expect(saved.skipDays).toEqual(skipDays);
+	});
+
+	it('writes the constraints on the single-type upsert', async () => {
+		const { repo, calls } = makeRepo();
+
+		await repo.saveJob(baseJob({ type: 'single' }) as never, undefined);
+
+		const upsert = calls.find(c => /ON CONFLICT/i.test(c.sql));
+		expect(upsert).toBeDefined();
+		expect(upsert!.sql).toContain('start_date = EXCLUDED.start_date');
+		expect(upsert!.params).toContainEqual(startDate);
+		expect(upsert!.params).toContainEqual(skipDays);
+	});
+});


### PR DESCRIPTION
The Postgres backend never persists or reads back a job's `startDate`, `endDate` or `skipDays`. They are not columns in `schema.ts`, not written by any `saveJob` path, and not read by `rowToJob`, so a job saved with these date constraints loses them entirely. The scheduler uses these fields (`utils/dateConstraints.ts`, `utils/nextRunAt.ts`) to gate when a job runs, so the constraints are silently disabled.

This adds `start_date`, `end_date` and `skip_days` columns to the schema and `PostgresJobRow`, writes them in every save path (default insert, single-type upsert including its `ON CONFLICT DO UPDATE`, debounce insert/update, and the by-id update), and maps them in `rowToJob`.

Added a mock-pool test asserting the constraints are written on both the default insert and the single-type upsert and read back via `rowToJob`; it fails on the current code and passes with the change.