### PR TITLE
do not skip a cron occurrence when nextRunAt is ahead of the next tick

### DIFF
--- a/.changeset/fix-cron-skip-occurrence.md
+++ b/.changeset/fix-cron-skip-occurrence.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+Fix recurring cron jobs skipping a valid occurrence. `computeFromInterval` compared the next cron tick against the stored `nextRunAt`, so when `nextRunAt` was further in the future than the next tick after `lastRunAt`, it bumped past and skipped the legitimate occurrence. It now only re-rolls when the tick is not strictly after `lastRunAt`.

--- a/packages/agenda/src/utils/nextRunAt.ts
+++ b/packages/agenda/src/utils/nextRunAt.ts
@@ -21,7 +21,6 @@ export function isValidHumanInterval(value: unknown): value is string {
  * Internal method that computes the interval
  */
 export const computeFromInterval = (attrs: JobParameters<unknown>): Date | null => {
-	const previousNextRunAt = attrs.nextRunAt || new Date();
 	log('[%s:%s] computing next run via interval [%s]', attrs.name, attrs._id, attrs.repeatInterval);
 
 	const lastRun = dateForTimezone(attrs.lastRunAt || new Date(), attrs.repeatTimezone);
@@ -38,11 +37,9 @@ export const computeFromInterval = (attrs: JobParameters<unknown>): Date | null 
 		try {
 			let cronTime = CronExpressionParser.parse(attrs.repeatInterval, cronOptions);
 			let nextDate = cronTime.next().toDate();
-			if (
-				nextDate.valueOf() === lastRun.valueOf() ||
-				nextDate.valueOf() <= previousNextRunAt.valueOf()
-			) {
-				// Handle cronTime giving back the same date for the next run time
+			if (nextDate.valueOf() <= lastRun.valueOf()) {
+				// cron-parser returned the same (or earlier) instant as lastRun, so nudge past it.
+				// Comparing against the stored nextRunAt instead would skip a valid occurrence.
 				cronOptions.currentDate = new Date(lastRun.valueOf() + 1000);
 				cronTime = CronExpressionParser.parse(attrs.repeatInterval, cronOptions);
 				nextDate = cronTime.next().toDate();

--- a/packages/agenda/test/unit.test.ts
+++ b/packages/agenda/test/unit.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Agenda, Job, toJobId } from '../src/index.js';
 import type { AgendaBackend, JobRepository, JobParameters, JobLogger, JobLogEntry, JobLogQuery, JobLogQueryResult } from '../src/index.js';
 import { computeJobState } from '../src/types/JobQuery.js';
+import { computeFromInterval } from '../src/utils/nextRunAt.js';
 
 /**
  * Minimal mock repository that satisfies the interface without real storage.
@@ -425,6 +426,27 @@ describe('Job Unit Tests', () => {
 		});
 
 		// Note: skipImmediate is tested in the repeatEvery describe block
+	});
+
+	describe('computeFromInterval cron guard', () => {
+		// Regression: when the stored nextRunAt is further in the future than the
+		// next cron tick after lastRunAt, the guard must NOT skip that tick.
+		it('does not skip a cron occurrence when nextRunAt is ahead of the next tick', () => {
+			const lastRunAt = new Date('2024-01-23T20:12:59.083Z');
+			const attrs = {
+				name: 'demo',
+				repeatInterval: '*/13 * * * *', // every 13 minutes
+				repeatTimezone: 'UTC',
+				lastRunAt,
+				// stored nextRunAt is ~1h40m ahead, well past the next tick (20:13)
+				nextRunAt: new Date('2024-01-23T21:52:49.522Z')
+			} as unknown as JobParameters;
+
+			const next = computeFromInterval(attrs);
+			expect(next).not.toBeNull();
+			// the next 13-minute tick after lastRunAt is 20:13:00, not 20:26:00
+			expect(next!.toISOString()).toBe('2024-01-23T20:13:00.000Z');
+		});
 	});
 
 	describe('fail', () => {


### PR DESCRIPTION
`computeFromInterval` re-rolls the computed cron tick when `nextDate <= previousNextRunAt` (the stored `attrs.nextRunAt`). But `lastRunAt` and the stored `nextRunAt` are unrelated quantities: `nextRunAt` is the scheduled-but-not-yet-fired time. When it is further in the future than the true next tick after `lastRunAt`, the guard bumps `currentDate` forward and recomputes, skipping the legitimate occurrence.

Example: interval `*/13 * * * *`, `lastRunAt = 2024-01-23T20:12:59Z`, `nextRunAt = 2024-01-23T21:52:49Z`. The next tick should be `20:13:00`, but the code returns `20:26:00`.

The guard's documented intent is only to handle cron-parser returning the same instant as the last run, so it now re-rolls only when the tick is not strictly after `lastRunAt`. Added a regression test; it fails on the current code and passes with the change. Full `unit.test.ts` (88) passes.