### PR TITLE
preserve progress on a bare touch() keep-alive

### DIFF
--- a/.changeset/fix-touch-preserve-progress.md
+++ b/.changeset/fix-touch-preserve-progress.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+Fix `job.touch()` wiping a job's `progress`. A bare `touch()` keep-alive call set `progress` to `undefined`, discarding a previously reported value. It now only updates `progress` when a value is passed.

--- a/packages/agenda/src/Job.ts
+++ b/packages/agenda/src/Job.ts
@@ -460,7 +460,11 @@ export class Job<DATA = unknown | void> {
 			throw new Error(`job ${this.attrs.name} got canceled already: ${this.canceled}!`);
 		}
 		this.attrs.lockedAt = new Date();
-		this.attrs.progress = progress;
+		// Only update progress when a value is supplied; bare touch() (keep-alive)
+		// must not wipe a previously reported progress value.
+		if (progress !== undefined) {
+			this.attrs.progress = progress;
+		}
 
 		await this.agenda.db.saveJobState(this.attrs, {
 			lastModifiedBy: this.agenda.attrs.name || undefined

--- a/packages/agenda/test/unit.test.ts
+++ b/packages/agenda/test/unit.test.ts
@@ -177,6 +177,21 @@ describe('Agenda Unit Tests', () => {
 		});
 	});
 
+	describe('touch', () => {
+		it('preserves progress when touch() is called without an argument', async () => {
+			agenda.define('touch-job', async () => {});
+			const job = agenda.create('touch-job', {});
+			job.attrs._id = toJobId('touch-id');
+
+			await job.touch(50);
+			expect(job.attrs.progress).toBe(50);
+
+			// touch() with no arg (keep-alive) must not wipe progress
+			await job.touch();
+			expect(job.attrs.progress).toBe(50);
+		});
+	});
+
 	describe('job creation with create()', () => {
 		it('creates a job instance', () => {
 			agenda.define('test job', () => {});


### PR DESCRIPTION
`Job.touch(progress)` assigns `this.attrs.progress = progress` unconditionally. So calling `touch()` with no argument, the documented keep-alive use for long-running jobs, sets `progress` to `undefined` and discards a value reported by an earlier `touch(n)`.

Fix only updates `progress` when a value is supplied. Added a unit test: `touch(50)` then bare `touch()` keeps progress at 50; it fails on the current code and passes with the change.