### PR TITLE
clamp backoff jitter to maxDelay

### DIFF
--- a/.changeset/fix-backoff-jitter-maxdelay.md
+++ b/.changeset/fix-backoff-jitter-maxdelay.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+Keep backoff jitter within `maxDelay`. `applyJitter` could add up to `jitter * delay` on top of the already-capped delay, so a jittered retry delay could exceed the documented `maxDelay` hard cap. The jittered result is now clamped to `[0, maxDelay]`.

--- a/packages/agenda/src/utils/backoff.ts
+++ b/packages/agenda/src/utils/backoff.ts
@@ -54,15 +54,17 @@ export interface LinearBackoffOptions extends BackoffOptions {
 
 /**
  * Apply jitter to a delay value
- * @param delay - Base delay in milliseconds
+ * @param delay - Base delay in milliseconds (already capped to maxDelay)
  * @param jitter - Jitter factor (0-1), where 0 means no jitter and 1 means up to ±100%
- * @returns Delay with jitter applied
+ * @param maxDelay - Upper bound the jittered result must not exceed
+ * @returns Delay with jitter applied, clamped to [0, maxDelay]
  */
-function applyJitter(delay: number, jitter: number): number {
+function applyJitter(delay: number, jitter: number, maxDelay: number): number {
 	if (jitter <= 0) return delay;
 	// Random value between -jitter and +jitter
 	const jitterAmount = delay * jitter * (Math.random() * 2 - 1);
-	return Math.max(0, Math.round(delay + jitterAmount));
+	// keep within [0, maxDelay] so maxDelay stays the documented hard cap
+	return Math.min(maxDelay, Math.max(0, Math.round(delay + jitterAmount)));
 }
 
 /**
@@ -84,7 +86,7 @@ export function constant(options: BackoffOptions = {}): BackoffStrategy {
 			return null;
 		}
 		const baseDelay = Math.min(delay, maxDelay);
-		return applyJitter(baseDelay, jitter);
+		return applyJitter(baseDelay, jitter, maxDelay);
 	};
 }
 
@@ -114,7 +116,7 @@ export function linear(options: LinearBackoffOptions = {}): BackoffStrategy {
 		}
 		const baseDelay = delay + increment * (context.attempt - 1);
 		const cappedDelay = Math.min(baseDelay, maxDelay);
-		return applyJitter(cappedDelay, jitter);
+		return applyJitter(cappedDelay, jitter, maxDelay);
 	};
 }
 
@@ -143,7 +145,7 @@ export function exponential(options: ExponentialBackoffOptions = {}): BackoffStr
 		}
 		const baseDelay = delay * Math.pow(factor, context.attempt - 1);
 		const cappedDelay = Math.min(baseDelay, maxDelay);
-		return applyJitter(cappedDelay, jitter);
+		return applyJitter(cappedDelay, jitter, maxDelay);
 	};
 }
 

--- a/packages/agenda/test/shared/backoff-test-suite.ts
+++ b/packages/agenda/test/shared/backoff-test-suite.ts
@@ -145,6 +145,21 @@ export function backoffTestSuite(config: BackoffTestConfig): void {
 					expect(delay).toBeLessThanOrEqual(1500);
 				}
 			});
+
+			it('should never exceed maxDelay even with jitter', () => {
+				// maxDelay is the documented hard cap; jitter must not push past it
+				const maxDelay = 500;
+				const strategy = exponential({ delay: 100, factor: 2, maxDelay, maxRetries: 10, jitter: 0.5 });
+				for (let i = 0; i < 500; i++) {
+					for (let attempt = 1; attempt <= 10; attempt++) {
+						const delay = strategy({ attempt, error: new Error('test'), jobName: 'test', jobData: {} });
+						if (delay !== null) {
+							expect(delay).toBeGreaterThanOrEqual(0);
+							expect(delay).toBeLessThanOrEqual(maxDelay);
+						}
+					}
+				}
+			});
 		});
 
 		describe('combine strategy', () => {


### PR DESCRIPTION
`applyJitter` adds a random amount of up to `jitter * delay` on top of the already-capped delay:

```js
const jitterAmount = delay * jitter * (Math.random() * 2 - 1);
return Math.max(0, Math.round(delay + jitterAmount));
```

So a jittered retry delay can exceed `maxDelay`, which the options document as the hard cap (e.g. `exponential({ delay: 100, factor: 2, maxDelay: 500, jitter: 0.5 })` can return up to 750). Fix clamps the jittered result to `[0, maxDelay]`.

Added a case to the backoff suite that runs many jittered delays and asserts none exceed `maxDelay`; it fails on the current code and passes with the change.