### PR TITLE
fix(agenda): unlock future-dated job freed by the processor

### DIFF
--- a/.changeset/fix-jobprocessor-stale-lock-future-job.md
+++ b/.changeset/fix-jobprocessor-stale-lock-future-job.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+Release the database lock when the processor frees a job whose `nextRunAt` is too far in the future. Previously such a job, when picked up via the expired-lock recovery path (for example a recurring job left locked by a crashed worker), was removed from the local locked list but never unlocked in the database, so it was re-locked on every scan and never reached its run time.

--- a/packages/agenda/src/JobProcessor.ts
+++ b/packages/agenda/src/JobProcessor.ts
@@ -516,6 +516,11 @@ export class JobProcessor {
 
 						this.lockedJobs.splice(lockedJobIndex, 1);
 						this.updateStatus(job.attrs.name, 'locked', -1);
+						// Release the database lock as well. Otherwise a job that was
+						// locked via the expired-lock recovery path while its nextRunAt
+						// is still in the future gets re-locked on every scan and never
+						// reaches its run time.
+						this.agenda.db.unlockJob(job.attrs);
 					} else {
 						log.extend('jobProcessing')(
 							'[%s:%s] nextRunAt is in the future, calling setTimeout(%d)',

--- a/packages/agenda/test/jobprocessor-stale-lock.test.ts
+++ b/packages/agenda/test/jobprocessor-stale-lock.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import { Agenda } from '../src/index.js';
+import type { AgendaBackend } from '../src/index.js';
+import type { JobRepository, RemoveJobsOptions } from '../src/types/JobRepository.js';
+import type { JobParameters } from '../src/types/JobParameters.js';
+
+const delay = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+/**
+ * Minimal in-memory repository that mirrors the locking semantics the backends
+ * implement: getNextJobToRun returns a job that is either free and due, or whose
+ * lock has expired (regardless of nextRunAt). This is enough to exercise the
+ * processor's lock handling without a database.
+ */
+class InMemoryRepository implements JobRepository {
+	private store = new Map<string, JobParameters>();
+
+	private nextId = 1;
+
+	async connect(): Promise<void> {}
+
+	async queryJobs(options?: { id?: unknown; name?: string }) {
+		let jobs = [...this.store.values()];
+		if (options?.id) {
+			jobs = jobs.filter(j => j._id?.toString() === options.id?.toString());
+		}
+		if (options?.name) {
+			jobs = jobs.filter(j => j.name === options.name);
+		}
+		return { jobs: jobs.map(j => ({ ...j })), total: jobs.length } as never;
+	}
+
+	async getJobsOverview() {
+		return [];
+	}
+
+	async getDistinctJobNames() {
+		return [...new Set([...this.store.values()].map(j => j.name))];
+	}
+
+	async getJobById(id: string) {
+		const job = this.store.get(id);
+		return job ? { ...job } : null;
+	}
+
+	async getQueueSize() {
+		const now = new Date();
+		return [...this.store.values()].filter(j => j.nextRunAt && j.nextRunAt <= now).length;
+	}
+
+	async removeJobs(options: RemoveJobsOptions) {
+		let removed = 0;
+		for (const [key, job] of [...this.store.entries()]) {
+			const matchesId = options.id !== undefined && job._id?.toString() === options.id.toString();
+			const matchesName = options.name !== undefined && job.name === options.name;
+			if (matchesId || matchesName) {
+				this.store.delete(key);
+				removed += 1;
+			}
+		}
+		return removed;
+	}
+
+	async saveJob<DATA = unknown>(job: JobParameters<DATA>): Promise<JobParameters<DATA>> {
+		const copy = { ...job } as JobParameters<DATA>;
+		if (!copy._id) {
+			copy._id = String(this.nextId++) as never;
+		}
+		this.store.set(copy._id.toString(), copy as never);
+		return { ...copy };
+	}
+
+	async saveJobState(job: JobParameters) {
+		if (!job._id) {
+			return;
+		}
+		const existing = this.store.get(job._id.toString());
+		if (!existing) {
+			return;
+		}
+		existing.lockedAt = job.lockedAt;
+		existing.lastRunAt = job.lastRunAt;
+		existing.lastFinishedAt = job.lastFinishedAt;
+		existing.nextRunAt = job.nextRunAt;
+		existing.progress = job.progress;
+		existing.failCount = job.failCount;
+	}
+
+	async lockJob(job: JobParameters) {
+		if (!job._id) {
+			return undefined;
+		}
+		const existing = this.store.get(job._id.toString());
+		if (!existing || existing.lockedAt != null || existing.disabled) {
+			return undefined;
+		}
+		existing.lockedAt = new Date();
+		return { ...existing };
+	}
+
+	async unlockJob(job: JobParameters) {
+		if (!job._id) {
+			return;
+		}
+		const existing = this.store.get(job._id.toString());
+		if (existing && existing.nextRunAt != null) {
+			existing.lockedAt = undefined;
+		}
+	}
+
+	async unlockJobs(ids: unknown[]) {
+		for (const id of ids) {
+			const existing = this.store.get(String(id));
+			if (existing) {
+				existing.lockedAt = undefined;
+			}
+		}
+	}
+
+	async getNextJobToRun(name: string, nextScanAt: Date, lockDeadline: Date, now?: Date) {
+		const lockedAt = now ?? new Date();
+		const candidates = [...this.store.values()].filter(j => {
+			if (j.name !== name || j.disabled) {
+				return false;
+			}
+			const freeAndDue = j.lockedAt == null && j.nextRunAt != null && j.nextRunAt <= nextScanAt;
+			const lockExpired = j.lockedAt != null && j.lockedAt <= lockDeadline;
+			return freeAndDue || lockExpired;
+		});
+		if (!candidates.length) {
+			return undefined;
+		}
+		candidates.sort((a, b) => {
+			const an = a.nextRunAt ? a.nextRunAt.getTime() : Infinity;
+			const bn = b.nextRunAt ? b.nextRunAt.getTime() : Infinity;
+			return an !== bn ? an - bn : (b.priority || 0) - (a.priority || 0);
+		});
+		const chosen = this.store.get(candidates[0]._id!.toString())!;
+		chosen.lockedAt = lockedAt;
+		return { ...chosen };
+	}
+
+	async disableJobs() {
+		return 0;
+	}
+
+	async enableJobs() {
+		return 0;
+	}
+
+	async purgeAllJobs() {
+		const size = this.store.size;
+		this.store.clear();
+		return size;
+	}
+
+	// test helper
+	seed(job: JobParameters): void {
+		this.store.set(job._id!.toString(), job);
+	}
+}
+
+class InMemoryBackend implements AgendaBackend {
+	readonly name = 'InMemory';
+
+	readonly repository = new InMemoryRepository();
+
+	readonly ownsConnection = false;
+
+	async connect(): Promise<void> {}
+
+	async disconnect(): Promise<void> {}
+}
+
+describe('JobProcessor stale lock on a future-dated job', () => {
+	it('runs a job that was locked while its nextRunAt is still in the future', async () => {
+		const backend = new InMemoryBackend();
+		const repo = backend.repository;
+		const agenda = new Agenda({ backend, processEvery: 100, maxConcurrency: 10, defaultConcurrency: 10 });
+		agenda.on('error', () => {});
+
+		let ranAt = 0;
+		agenda.define(
+			'recurring',
+			async () => {
+				ranAt = Date.now();
+			},
+			{ lockLifetime: 10000 }
+		);
+		await agenda.start();
+
+		// A recurring job left locked by a crashed worker: nextRunAt is in the
+		// future, but lockedAt is old enough to be considered expired.
+		const start = Date.now();
+		const dueIn = 800;
+		repo.seed({
+			_id: '900',
+			name: 'recurring',
+			priority: 0,
+			type: 'normal',
+			nextRunAt: new Date(start + dueIn),
+			lockedAt: new Date(start - 100000)
+		} as never);
+
+		await delay(3000);
+		await agenda.stop();
+
+		expect(ranAt).toBeGreaterThan(0);
+		expect(ranAt - (start + dueIn)).toBeLessThan(1000);
+	}, 20000);
+});


### PR DESCRIPTION
Fixes #1749.

When `findAndLockNextJob` locked a job via the expired-lock recovery path while its `nextRunAt` was still in the future, the "too far away" branch removed it from the local locked list but never released the database lock. The job was re-locked on every scan, refreshing `lockedAt` so the lock never expired, and it never reached its run time. This is the state of a recurring job left locked by a crashed or restarted worker.

The branch now calls `this.agenda.db.unlockJob(job.attrs)`, matching what `jobQueueFilling` already does when it frees a job.

Added a regression test using a minimal in-memory backend that seeds a future-dated job with a stale lock and asserts it runs near its `nextRunAt`. It fails on the previous code (the job never runs) and passes with the fix. Lint and the existing agenda tests pass.