### PR TITLE
fix(redis-backend): use value containment for data filters

### DIFF
--- a/.changeset/redis-data-filter-containment.md
+++ b/.changeset/redis-data-filter-containment.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/redis-backend': patch
+---
+
+Fix data filter to use recursive value containment instead of a JSON-substring match, preventing false matches (and wrong-job deletion) for prefix-colliding values and reordered multi-key filters.

--- a/packages/redis-backend/src/RedisJobRepository.ts
+++ b/packages/redis-backend/src/RedisJobRepository.ts
@@ -20,6 +20,35 @@ import type { RedisBackendConfig, RedisJobData } from './types.js';
 const log = debug('agenda:redis:repository');
 
 /**
+ * Recursively check whether `stored` contains every key/value of `filter`.
+ *
+ * Mirrors the containment semantics of the Mongo (dot-notation) and Postgres
+ * (jsonb `@>`) backends: plain objects are matched key-by-key (allowing extra
+ * keys in `stored`), and leaf values must be strictly equal. This avoids the
+ * false positives/negatives of the previous JSON-substring approach (e.g.
+ * `{ x: 1 }` no longer matches stored `{ x: 11 }`, and `{ b: 2, a: 1 }` matches
+ * stored `{ a: 1, b: 2 }` regardless of key order).
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function matchesContainment(stored: unknown, filter: unknown): boolean {
+	if (isPlainObject(filter)) {
+		if (!isPlainObject(stored)) return false;
+		for (const key of Object.keys(filter)) {
+			if (!matchesContainment(stored[key], filter[key])) return false;
+		}
+		return true;
+	}
+	if (Array.isArray(filter)) {
+		if (!Array.isArray(stored) || stored.length !== filter.length) return false;
+		return filter.every((value, index) => matchesContainment(stored[index], value));
+	}
+	return stored === filter;
+}
+
+/**
  * Redis implementation of JobRepository
  *
  * Data structure:
@@ -240,9 +269,7 @@ export class RedisJobRepository implements JobRepository {
 			if (!includeDisabled && job.disabled) continue;
 			if (search && !job.name.toLowerCase().includes(search.toLowerCase())) continue;
 			if (data !== undefined) {
-				const jobDataStr = JSON.stringify(job.data);
-				const searchDataStr = JSON.stringify(data);
-				if (!jobDataStr.includes(searchDataStr.slice(1, -1))) continue;
+				if (!matchesContainment(job.data, data)) continue;
 			}
 
 			const jobState = computeJobState(job, now);
@@ -426,14 +453,22 @@ export class RedisJobRepository implements JobRepository {
 
 	/**
 	 * Filter job IDs by matching against their stored data field.
-	 * Uses a substring match on the JSON-serialized data.
+	 * Uses recursive value containment (matching Mongo/Postgres semantics)
+	 * rather than a JSON-substring match, which avoids false positives such as
+	 * `{ id: 1 }` matching stored `{ id: 11 }`.
 	 */
 	private async filterJobIdsByData(jobIds: string[], dataFilter: unknown): Promise<string[]> {
-		const searchDataStr = JSON.stringify(dataFilter);
 		const matching: string[] = [];
 		for (const jobId of jobIds) {
 			const jobData = await this.redis.hget(this.key(`job:${jobId}`), 'data');
-			if (jobData && jobData.includes(searchDataStr.slice(1, -1))) {
+			if (jobData === null || jobData === undefined) continue;
+			let stored: unknown;
+			try {
+				stored = JSON.parse(jobData || '{}');
+			} catch {
+				continue;
+			}
+			if (matchesContainment(stored, dataFilter)) {
 				matching.push(jobId);
 			}
 		}

--- a/packages/redis-backend/test/redis-backend.test.ts
+++ b/packages/redis-backend/test/redis-backend.test.ts
@@ -274,6 +274,57 @@ describe('RedisBackend', () => {
 			expect(members.length).toBe(1);
 		});
 	});
+
+	describe('data filter containment', () => {
+		const baseJob = (data: Record<string, unknown>) => ({
+			name: 'data-filter',
+			priority: 0,
+			nextRunAt: new Date(),
+			type: 'normal' as const,
+			data
+		});
+
+		it('queryJobs must not match a numeric prefix collision', async () => {
+			await backend.repository.saveJob(baseJob({ x: 11 }));
+
+			const { jobs } = await backend.repository.queryJobs({ data: { x: 1 } });
+			expect(jobs).toHaveLength(0);
+
+			const exact = await backend.repository.queryJobs({ data: { x: 11 } });
+			expect(exact.jobs).toHaveLength(1);
+		});
+
+		it('queryJobs must not match a string prefix collision', async () => {
+			await backend.repository.saveJob(baseJob({ code: 'abcdef' }));
+
+			const { jobs } = await backend.repository.queryJobs({ data: { code: 'abc' } });
+			expect(jobs).toHaveLength(0);
+		});
+
+		it('queryJobs must match multi-key filters regardless of key order', async () => {
+			await backend.repository.saveJob(baseJob({ a: 1, b: 2 }));
+
+			const { jobs } = await backend.repository.queryJobs({ data: { b: 2, a: 1 } });
+			expect(jobs).toHaveLength(1);
+		});
+
+		it('removeJobs must not delete a job with a prefix-colliding value', async () => {
+			await backend.repository.saveJob(baseJob({ otherId: 11 }));
+
+			const removed = await backend.repository.removeJobs({ data: { otherId: 1 } });
+			expect(removed).toBe(0);
+
+			const { total } = await backend.repository.queryJobs({ data: { otherId: 11 } });
+			expect(total).toBe(1);
+		});
+
+		it('removeJobs must delete a job matched by a reordered multi-key filter', async () => {
+			await backend.repository.saveJob(baseJob({ a: 1, b: 2 }));
+
+			const removed = await backend.repository.removeJobs({ data: { b: 2, a: 1 } });
+			expect(removed).toBe(1);
+		});
+	});
 });
 
 // ============================================================================


### PR DESCRIPTION
Fixes #1751

## Problem

The Redis backend matched the `data` filter via a substring check on the JSON-serialized job data, in both `queryJobs` and `filterJobIdsByData` (used by `removeJobs`/`disableJobs`/`enableJobs`):

```ts
if (!jobDataStr.includes(searchDataStr.slice(1, -1))) continue;
```

This is not value equality:

- `{ id: 1 }` falsely matches stored `{ id: 11 }` (numeric prefix)
- `{ code: abc }` falsely matches stored `{ code: abcdef }` (string prefix)
- `{ b: 2, a: 1 }` fails to match stored `{ a: 1, b: 2 }` (key order)

Because `removeJobs` routes through this, `removeJobs({ data: { id: 1 } })` could delete a job with `{ id: 11 }`.

## Fix

Introduce a recursive `matchesContainment` helper that mirrors the Mongo (dot-notation) and Postgres (`jsonb @>`) containment semantics: plain objects match key-by-key allowing extra keys in the stored doc, arrays match element-wise, and leaf values compare with strict equality. Both `queryJobs` and `filterJobIdsByData` now use it (parsing the stored JSON).

## Tests

Added regression tests covering numeric prefix collision, string prefix collision, and reordered multi-key filters for both `queryJobs` and `removeJobs`. They fail on the previous substring implementation and pass with the fix.