### PR TITLE
fix(agenda): treat numeric repeatInterval as milliseconds

### DIFF
--- a/.changeset/numeric-ms-repeat-interval.md
+++ b/.changeset/numeric-ms-repeat-interval.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+Treat a numeric (or purely-numeric string) repeatInterval as milliseconds in computeFromInterval, so recurring jobs scheduled with `agenda.every(5000, 'job')` keep running on backends that persist the interval as a string.

--- a/packages/agenda/src/utils/nextRunAt.ts
+++ b/packages/agenda/src/utils/nextRunAt.ts
@@ -33,7 +33,25 @@ export const computeFromInterval = (attrs: JobParameters<unknown>): Date | null 
 	let nextRunAt: Date | null = null;
 
 	let error;
-	if (typeof attrs.repeatInterval === 'string') {
+
+	// A numeric repeatInterval (or a string that is purely numeric) is treated as
+	// milliseconds. The public API allows `agenda.every(5000, 'job')`, and some
+	// backends persist the interval as a string (e.g. "5000"), which is neither a
+	// valid cron expression nor a human interval and would otherwise throw.
+	const numericInterval =
+		typeof attrs.repeatInterval === 'number'
+			? attrs.repeatInterval
+			: typeof attrs.repeatInterval === 'string' &&
+				  attrs.repeatInterval.trim() !== '' &&
+				  Number.isFinite(Number(attrs.repeatInterval))
+				? Number(attrs.repeatInterval)
+				: undefined;
+
+	if (numericInterval !== undefined) {
+		nextRunAt = attrs.lastRunAt
+			? new Date(lastRun.valueOf() + numericInterval)
+			: new Date(lastRun.valueOf());
+	} else if (typeof attrs.repeatInterval === 'string') {
 		try {
 			let cronTime = CronExpressionParser.parse(attrs.repeatInterval, cronOptions);
 			let nextDate = cronTime.next().toDate();

--- a/packages/agenda/test/nextRunAt.test.ts
+++ b/packages/agenda/test/nextRunAt.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for computeFromInterval (pure logic, no backend).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeFromInterval } from '../src/utils/nextRunAt.js';
+import type { JobParameters } from '../src/index.js';
+
+function baseAttrs(overrides: Partial<JobParameters<unknown>>): JobParameters<unknown> {
+	return {
+		name: 'test',
+		priority: 0,
+		type: 'normal',
+		nextRunAt: null,
+		data: {},
+		...overrides
+	} as JobParameters<unknown>;
+}
+
+describe('computeFromInterval - numeric millisecond repeatInterval', () => {
+	it('treats a numeric repeatInterval as milliseconds', () => {
+		const lastRunAt = new Date('2026-01-01T00:00:00.000Z');
+		const result = computeFromInterval(
+			baseAttrs({ repeatInterval: 5000, lastRunAt, nextRunAt: lastRunAt })
+		);
+		expect(result?.getTime()).toBe(lastRunAt.getTime() + 5000);
+	});
+
+	it('treats a purely-numeric string repeatInterval as milliseconds', () => {
+		const lastRunAt = new Date('2026-01-01T00:00:00.000Z');
+		const result = computeFromInterval(
+			baseAttrs({ repeatInterval: '5000', lastRunAt, nextRunAt: lastRunAt })
+		);
+		expect(result?.getTime()).toBe(lastRunAt.getTime() + 5000);
+	});
+
+	it('uses lastRunAt as-is for the first numeric run when lastRunAt is absent', () => {
+		const result = computeFromInterval(baseAttrs({ repeatInterval: 5000 }));
+		expect(result).toBeInstanceOf(Date);
+	});
+
+	it('still parses cron expressions', () => {
+		const lastRunAt = new Date('2026-01-01T00:00:00.000Z');
+		const result = computeFromInterval(
+			baseAttrs({ repeatInterval: '0 * * * *', lastRunAt, nextRunAt: lastRunAt })
+		);
+		expect(result).toBeInstanceOf(Date);
+		expect(result!.getTime()).toBeGreaterThan(lastRunAt.getTime());
+	});
+
+	it('still parses human intervals', () => {
+		const lastRunAt = new Date('2026-01-01T00:00:00.000Z');
+		const result = computeFromInterval(
+			baseAttrs({ repeatInterval: '5 minutes', lastRunAt, nextRunAt: lastRunAt })
+		);
+		expect(result?.getTime()).toBe(lastRunAt.getTime() + 5 * 60 * 1000);
+	});
+});


### PR DESCRIPTION
Fixes #1753

## Problem

`agenda.every(5000, 'job')` accepts a numeric millisecond interval. Mongo preserves the number, but the Redis and Postgres backends persist `repeatInterval` as a string, so it is read back as `5000`. In `computeFromInterval`, a numeric string is neither a valid cron expression nor a valid human interval, so the function throws, `nextRunAt` becomes `null`, and the recurring job silently stops after one run.

## Fix

In `computeFromInterval`, before the cron/human-interval branches, treat a numeric `repeatInterval` (or a string that is purely numeric) as milliseconds:

```ts
nextRunAt = attrs.lastRunAt
  ? new Date(lastRun.valueOf() + numericInterval)
  : new Date(lastRun.valueOf());
```

The existing date-constraint logic still applies. This is centralized so all backends benefit.

## Tests

Added `test/nextRunAt.test.ts` covering numeric-number and numeric-string intervals (the string case fails on the previous code with the thrown `invalid repeat interval` error), plus regression coverage that cron and human intervals still work.