### PR TITLE
fix(mongo-backend): paginate queryJobs at the database

### DIFF
--- a/.changeset/mongo-query-db-pagination.md
+++ b/.changeset/mongo-query-db-pagination.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/mongo-backend': patch
+---
+
+Push skip/limit to the database in queryJobs when no state filter is requested, instead of loading the entire matching collection into memory. Prevents out-of-memory on large collections (#1713, #1712).

--- a/packages/mongo-backend/src/MongoJobRepository.ts
+++ b/packages/mongo-backend/src/MongoJobRepository.ts
@@ -272,10 +272,41 @@ export class MongoJobRepository implements JobRepository {
 			query.disabled = { $ne: true };
 		}
 
-		// Fetch jobs
-		const allJobs = await this.collection.find(query).sort(this.toMongoSort(sort)).toArray();
+		const mongoSort = this.toMongoSort(sort);
 
-		// Compute states and filter by state if specified
+		// When there is no state filter, the state is computed purely from the
+		// stored fields and cannot exclude documents, so pagination can be pushed
+		// to the database. This avoids materializing the entire matching
+		// collection into memory (which can OOM on large collections).
+		if (!state) {
+			let cursor = this.collection.find(query).sort(mongoSort);
+			if (skip > 0) {
+				cursor = cursor.skip(skip);
+			}
+			if (limit > 0) {
+				cursor = cursor.limit(limit);
+			}
+
+			const [pageJobs, total] = await Promise.all([
+				cursor.toArray(),
+				this.collection.countDocuments(query)
+			]);
+
+			const jobs: JobWithState[] = pageJobs.map(job => {
+				const jobOb = computeJobObj(job);
+				return {
+					...jobOb,
+					state: computeJobState(jobOb, now)
+				};
+			});
+
+			return { jobs, total };
+		}
+
+		// A state filter is computed in application code, so the full result set
+		// must be fetched, filtered, then paginated.
+		const allJobs = await this.collection.find(query).sort(mongoSort).toArray();
+
 		// Special handling for 'paused' state which is based on disabled field
 		let jobsWithState: JobWithState[] = allJobs
 			.map(job => {
@@ -286,7 +317,6 @@ export class MongoJobRepository implements JobRepository {
 				};
 			})
 			.filter(job => {
-				if (!state) return true;
 				if (state === 'paused') return job.disabled === true;
 				return job.state === state;
 			});

--- a/packages/mongo-backend/test/mongo-backend.test.ts
+++ b/packages/mongo-backend/test/mongo-backend.test.ts
@@ -549,16 +549,20 @@ describe('MongoBackend', () => {
 				type: 'normal',
 				data: { i }
 			}));
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- raw docs for insertMany
 			await db.collection(TEST_COLLECTION).insertMany(docs as any);
 
 			// Wrap find() on the repository's own collection to capture how many
 			// documents the returned cursor materializes via toArray().
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- access internal collection
 			const collection = (backend.repository as any).collection as ReturnType<Db['collection']>;
 			const originalFind = collection.find.bind(collection);
 			let materialized = -1;
 			const findSpy = vi
 				.spyOn(collection, 'find')
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- pass-through spy
 				.mockImplementation((...args: any[]) => {
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- pass-through spy
 					const cursor = (originalFind as any)(...args);
 					const originalToArray = cursor.toArray.bind(cursor);
 					cursor.toArray = async () => {

--- a/packages/mongo-backend/test/mongo-backend.test.ts
+++ b/packages/mongo-backend/test/mongo-backend.test.ts
@@ -1,4 +1,4 @@
-import { expect, describe, it, beforeAll, afterAll, beforeEach, afterEach, assert } from 'vitest';
+import { expect, describe, it, beforeAll, afterAll, beforeEach, afterEach, assert, vi } from 'vitest';
 import { Db, DbOptions, MongoClient, ObjectId } from 'mongodb';
 import { randomUUID } from 'crypto';
 import { InMemoryNotificationChannel } from 'agenda';
@@ -536,6 +536,52 @@ describe('MongoBackend', () => {
 			expect(next.startDate).toEqual(startDate);
 			expect(next.endDate).toEqual(endDate);
 			expect(next.skipDays).toEqual(skipDays);
+		});
+	});
+
+	describe('queryJobs pagination', () => {
+		it('should push skip/limit to the database when no state filter is set', async () => {
+			const total = 200;
+			const docs = Array.from({ length: total }, (_, i) => ({
+				name: 'pagination-test',
+				priority: 0,
+				nextRunAt: new Date(),
+				type: 'normal',
+				data: { i }
+			}));
+			await db.collection(TEST_COLLECTION).insertMany(docs as any);
+
+			// Wrap find() on the repository's own collection to capture how many
+			// documents the returned cursor materializes via toArray().
+			const collection = (backend.repository as any).collection as ReturnType<Db['collection']>;
+			const originalFind = collection.find.bind(collection);
+			let materialized = -1;
+			const findSpy = vi
+				.spyOn(collection, 'find')
+				.mockImplementation((...args: any[]) => {
+					const cursor = (originalFind as any)(...args);
+					const originalToArray = cursor.toArray.bind(cursor);
+					cursor.toArray = async () => {
+						const result = await originalToArray();
+						materialized = result.length;
+						return result;
+					};
+					return cursor;
+				});
+
+			try {
+				const result = await backend.repository.queryJobs({
+					name: 'pagination-test',
+					limit: 10
+				});
+
+				expect(result.jobs).toHaveLength(10);
+				expect(result.total).toBe(total);
+				// The cursor must only materialize the page, not the whole collection.
+				expect(materialized).toBe(10);
+			} finally {
+				findSpy.mockRestore();
+			}
 		});
 	});
 


### PR DESCRIPTION
Fixes #1713 (also addresses #1712)

## Problem

`MongoJobRepository.queryJobs` fetched the entire matching collection with `find(query).sort(...).toArray()` and then paginated in JavaScript. Because job `state` is computed in application code, everything was pulled into memory even for a simple paginated query. On large collections this causes out-of-memory errors.

## Fix

When no `state` filter is requested, the state is derived purely from stored fields and cannot exclude documents, so pagination can be pushed to the database:

- `cursor.skip(skip).limit(limit)` for the page
- `collection.countDocuments(query)` for the total (run in parallel)

When a `state` filter IS present, the previous fetch-filter-slice behavior is preserved, since state cannot be expressed as a Mongo query. The `limit: 0` ("no limit") default is also preserved.

## Tests

Added a mongo-backend test that inserts 200 jobs and spies on the repository cursor's `toArray`, asserting that a state-free `queryJobs({ name, limit: 10 })` materializes only 10 documents while `total` reflects the full count. The test fails on the previous implementation (materializes all 200) and passes with the fix.
