### PR TITLE
fix(redis-backend): apply jobName filter in logger getLogs with jobId

### DIFF
--- a/.changeset/redis-logger-jobname-filter.md
+++ b/.changeset/redis-logger-jobname-filter.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/redis-backend': patch
+---
+
+Fix RedisJobLogger.getLogs to apply the jobName filter when jobId is also supplied, matching the AND semantics of the Mongo/Postgres loggers.

--- a/packages/redis-backend/src/RedisJobLogger.ts
+++ b/packages/redis-backend/src/RedisJobLogger.ts
@@ -171,6 +171,13 @@ export class RedisJobLogger implements JobLogger {
 					const events = Array.isArray(query.event) ? query.event : [query.event];
 					if (!events.includes(entry.event)) continue;
 				}
+				// Apply jobName filter as a secondary in-memory filter. When both
+				// jobId and jobName are supplied, the sorted set queried is the
+				// jobId index, so jobName must still be matched here (AND semantics,
+				// matching the Mongo/Postgres loggers).
+				if (query?.jobId && query?.jobName && entry.jobName !== query.jobName) {
+					continue;
+				}
 
 				entries.push(entry);
 			}

--- a/packages/redis-backend/test/redis-backend.test.ts
+++ b/packages/redis-backend/test/redis-backend.test.ts
@@ -312,3 +312,39 @@ jobLoggerTestSuite({
 		await logger.clearLogs();
 	}
 });
+
+describe('RedisJobLogger getLogs filtering', () => {
+	let logger: RedisJobLogger;
+
+	beforeEach(async () => {
+		logger = new RedisJobLogger({ redis: sharedRedis, keyPrefix: TEST_LOG_PREFIX });
+		await logger.clearLogs();
+	});
+
+	afterEach(async () => {
+		await logger.clearLogs();
+	});
+
+	it('applies jobName as an AND filter when jobId is also supplied', async () => {
+		await logger.log({
+			timestamp: new Date(),
+			level: 'info',
+			event: 'start',
+			jobId: 'shared-id',
+			jobName: 'jobA',
+			message: 'a'
+		});
+		await logger.log({
+			timestamp: new Date(),
+			level: 'info',
+			event: 'start',
+			jobId: 'shared-id',
+			jobName: 'jobB',
+			message: 'b'
+		});
+
+		const { entries } = await logger.getLogs({ jobId: 'shared-id', jobName: 'jobA' });
+		expect(entries).toHaveLength(1);
+		expect(entries[0].jobName).toBe('jobA');
+	});
+});


### PR DESCRIPTION
Fixes #1756

## Problem

`RedisJobLogger.getLogs` picks the sorted set to scan by preferring `jobId` over `jobName`, and the in-memory post-filter only handles `level` and `event`. As a result, when both `jobId` and `jobName` are supplied, `jobName` is silently ignored and entries with a matching `jobId` but a different `jobName` are returned. The Mongo and Postgres loggers apply both as AND conditions.

## Fix

Apply `jobName` as a secondary in-memory filter when both `jobId` and `jobName` are present, giving AND semantics consistent with the other backends.

## Tests

Added a regression test that logs two entries sharing a `jobId` but with different `jobName` values and asserts `getLogs({ jobId, jobName })` returns only the matching one. Fails on the previous code (returns both), passes with the fix.
