### PR TITLE
fix(agenda): prevent concurrent start() from leaking a second JobProcessor

### DIFF
--- a/.changeset/start-double-start-race.md
+++ b/.changeset/start-double-start-race.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+Fix start() race where concurrent calls leaked a second JobProcessor and connected the notification channel twice

--- a/packages/agenda/src/index.ts
+++ b/packages/agenda/src/index.ts
@@ -238,6 +238,8 @@ export class Agenda extends EventEmitter {
 
 	private jobProcessor?: JobProcessor;
 
+	private startPromise?: Promise<void>;
+
 	readonly ready: Promise<void>;
 
 	isActiveJobProcessor(): boolean {
@@ -1091,29 +1093,47 @@ export class Agenda extends EventEmitter {
 			'Agenda.start called, waiting for agenda to be initialized (db connection)',
 			this.attrs.processEvery
 		);
-		await this.ready;
+
 		if (this.jobProcessor) {
 			log('Agenda.start was already called, ignoring');
 			return;
 		}
 
-		// Connect notification channel if configured
-		if (this.notificationChannel) {
-			log('Agenda.start connecting notification channel');
-			await this.notificationChannel.connect();
-
-			// Subscribe to state notifications for cross-process event propagation
-			this.stateSubscriptionUnsubscribe = this.subscribeToStateNotifications();
+		// Guard against concurrent start() calls: the awaits below (ready, channel
+		// connect) yield to the event loop, so two callers could otherwise both pass
+		// the jobProcessor guard and create duplicate JobProcessors (leaked intervals,
+		// double channel connect). Cache the in-flight promise and reuse it.
+		if (this.startPromise) {
+			log('Agenda.start already in progress, awaiting existing start');
+			return this.startPromise;
 		}
 
-		this.jobProcessor = new JobProcessor(
-			this,
-			this.attrs.maxConcurrency,
-			this.attrs.lockLimit,
-			this.attrs.processEvery,
-			this.notificationChannel
-		);
+		this.startPromise = (async () => {
+			await this.ready;
 
+			// Connect notification channel if configured
+			if (this.notificationChannel) {
+				log('Agenda.start connecting notification channel');
+				await this.notificationChannel.connect();
+
+				// Subscribe to state notifications for cross-process event propagation
+				this.stateSubscriptionUnsubscribe = this.subscribeToStateNotifications();
+			}
+
+			this.jobProcessor = new JobProcessor(
+				this,
+				this.attrs.maxConcurrency,
+				this.attrs.lockLimit,
+				this.attrs.processEvery,
+				this.notificationChannel
+			);
+		})();
+
+		try {
+			await this.startPromise;
+		} finally {
+			this.startPromise = undefined;
+		}
 	}
 
 	/**

--- a/packages/agenda/test/unit.test.ts
+++ b/packages/agenda/test/unit.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { Agenda, Job, toJobId } from '../src/index.js';
+import { Agenda, Job, toJobId, InMemoryNotificationChannel } from '../src/index.js';
 import type { AgendaBackend, JobRepository, JobParameters, JobLogger, JobLogEntry, JobLogQuery, JobLogQueryResult } from '../src/index.js';
 import { computeJobState } from '../src/types/JobQuery.js';
 
@@ -854,5 +854,40 @@ describe('computeJobState', () => {
 	it('should return "completed" for a job with no dates set', () => {
 		const job = makeJob();
 		expect(computeJobState(job, now)).toBe('completed');
+	});
+});
+
+describe('start() concurrency', () => {
+	/** Backend whose connect resolves after a short delay, opening a race window. */
+	class DeferredBackend extends MockBackend {
+		async connect(): Promise<void> {
+			await new Promise(resolve => setTimeout(resolve, 30));
+		}
+	}
+
+	/** In-memory channel that counts how many times connect() was invoked. */
+	class CountingChannel extends InMemoryNotificationChannel {
+		public connectCount = 0;
+
+		async connect(): Promise<void> {
+			this.connectCount += 1;
+			await super.connect();
+		}
+	}
+
+	it('two concurrent start() calls create exactly one processor and connect once', async () => {
+		const channel = new CountingChannel();
+		const agenda = new Agenda({ backend: new DeferredBackend(), notificationChannel: channel });
+
+		await Promise.all([agenda.start(), agenda.start()]);
+
+		// Only one channel connect and one live processor despite two concurrent starts
+		expect(channel.connectCount).toBe(1);
+		expect(agenda.isActiveJobProcessor()).toBe(true);
+
+		// After stop, everything is torn down (the single processor, no leaks)
+		await agenda.stop();
+		expect(agenda.isActiveJobProcessor()).toBe(false);
+		expect(channel.state).toBe('disconnected');
 	});
 });


### PR DESCRIPTION
Fixes #1758

## Problem

`Agenda.start()` checks `if (this.jobProcessor) return;` only after `await this.ready` and `await this.notificationChannel.connect()`. Two concurrent `start()` calls both clear the guard before either assigns `this.jobProcessor`, creating two JobProcessors. This leaks the first processor's `setInterval` (since `stop()` only tears down one), causes duplicate job execution, and connects the notification channel twice.

## Fix

Cache the in-flight start promise in a private `startPromise` field. Re-entrant calls await the existing promise instead of starting again, so exactly one JobProcessor is created and the channel connects once.

## Test

Added a unit test (`test/unit.test.ts`) with a deferred-connect backend and a connect-counting channel: `await Promise.all([agenda.start(), agenda.start()])` results in exactly one channel connect and one live processor; after `stop()` the processor is gone and the channel is disconnected. Verified the test fails on the current code (connectCount === 2) and passes with the fix.