### PR TITLE
fix(agenda): guard isExpired() against undefined job definition

### DIFF
--- a/.changeset/isexpired-undefined-definition.md
+++ b/.changeset/isexpired-undefined-definition.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+Fix isExpired()/isDead() throwing a TypeError when the job's definition is not registered in the calling process

--- a/packages/agenda/src/Job.ts
+++ b/packages/agenda/src/Job.ts
@@ -441,7 +441,12 @@ export class Job<DATA = unknown | void> {
 
 		const definition = this.agenda.definitions[this.attrs.name];
 
-		const lockDeadline = new Date(Date.now() - definition.lockLifetime);
+		// In a distributed setup the job's handler may not be registered in this
+		// process (e.g. an API/scheduler process), so `definition` can be undefined.
+		// Fall back to the agenda-wide default lock lifetime instead of dereferencing.
+		const lockLifetime = definition?.lockLifetime ?? this.agenda.attrs.defaultLockLifetime;
+
+		const lockDeadline = new Date(Date.now() - lockLifetime);
 
 		// This means a job has "expired", as in it has not been "touched" within the lockoutTime
 		// Remove from local lock

--- a/packages/agenda/test/unit.test.ts
+++ b/packages/agenda/test/unit.test.ts
@@ -484,6 +484,25 @@ describe('Job Unit Tests', () => {
 			expect(job.disable()).toBe(job);
 		});
 	});
+
+	describe('isExpired / isDead without a registered definition', () => {
+		it('does not throw when the job definition is not registered in this process', async () => {
+			// In a distributed setup, the handler for 'undefinedJob' is registered in
+			// the worker process but not here. Construct the job as the processor would
+			// (byJobProcessor=true) so it uses the in-memory definition lookup, which is
+			// undefined here. It must fall back to the default lock lifetime, not throw.
+			const job = new Job(
+				agenda,
+				{ name: 'undefinedJob', type: 'normal', lockedAt: new Date(Date.now() - 60_000) },
+				true
+			);
+
+			expect(agenda.definitions.undefinedJob).toBeUndefined();
+
+			await expect(job.isExpired()).resolves.toEqual(expect.any(Boolean));
+			await expect(job.isDead()).resolves.toEqual(expect.any(Boolean));
+		});
+	});
 });
 
 /**


### PR DESCRIPTION
Fixes #1760

## Problem

`Job.isExpired()` dereferences the job definition without a guard:

```ts
const definition = this.agenda.definitions[this.attrs.name];
const lockDeadline = new Date(Date.now() - definition.lockLifetime);
```

In a distributed scheduler/API process the handler is not registered, so `definition` is undefined and this throws a TypeError. `isDead()` delegates to `isExpired()`, so it is affected too.

## Fix

Fall back to the agenda-wide default lock lifetime when the definition is missing:

```ts
const lockLifetime = definition?.lockLifetime ?? this.agenda.attrs.defaultLockLifetime;
const lockDeadline = new Date(Date.now() - lockLifetime);
```

## Test

Added a unit test that constructs a Job for a name with no registered definition and a stale `lockedAt`, then asserts `isExpired()` and `isDead()` resolve to a boolean instead of throwing. Verified it fails on the current code and passes with the fix.