### PR TITLE
fix(agenda): preserve debounce config when unique() is called without opts

### DIFF
--- a/.changeset/unique-preserves-debounce.md
+++ b/.changeset/unique-preserves-debounce.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+Fix fluent unique() discarding a previously-set debounce()/uniqueOpts when called without explicit options

--- a/packages/agenda/src/Job.ts
+++ b/packages/agenda/src/Job.ts
@@ -238,7 +238,9 @@ export class Job<DATA = unknown | void> {
 		opts?: JobParameters['uniqueOpts']
 	): this {
 		this.attrs.unique = unique;
-		this.attrs.uniqueOpts = opts;
+		// Don't clobber previously-set uniqueOpts (e.g. a debounce config applied via
+		// .debounce()) when unique() is called without explicit opts.
+		this.attrs.uniqueOpts = opts ?? this.attrs.uniqueOpts;
 		return this;
 	}
 

--- a/packages/agenda/test/unit.test.ts
+++ b/packages/agenda/test/unit.test.ts
@@ -260,6 +260,28 @@ describe('Job Unit Tests', () => {
 			const job = new Job(agenda, { name: 'demo', type: 'normal' });
 			expect(job.unique({})).toBe(job);
 		});
+
+		it('preserves a previously-set debounce config when called without opts', () => {
+			const job = new Job(agenda, { name: 'demo', type: 'normal' })
+				.debounce(2000)
+				.unique({ 'data.x': 1 });
+
+			expect(job.attrs.unique).toEqual({ 'data.x': 1 });
+			expect(job.attrs.uniqueOpts?.debounce).toEqual({
+				delay: 2000,
+				maxWait: undefined,
+				strategy: 'trailing'
+			});
+		});
+
+		it('supports unique(opts) followed by debounce()', () => {
+			const job = new Job(agenda, { name: 'demo', type: 'normal' })
+				.unique({ 'data.x': 1 }, { insertOnly: true })
+				.debounce(2000);
+
+			expect(job.attrs.uniqueOpts?.insertOnly).toBe(true);
+			expect(job.attrs.uniqueOpts?.debounce?.delay).toBe(2000);
+		});
 	});
 
 	describe('repeatEvery', () => {


### PR DESCRIPTION
Fixes #1762

## Problem

`Job.unique()` overwrites `this.attrs.uniqueOpts` with its (possibly undefined) `opts` argument. Since `debounce()` stores its config inside `uniqueOpts`, calling `.debounce(d).unique(u)` silently discards the debounce configuration.

## Fix

```ts
this.attrs.uniqueOpts = opts ?? this.attrs.uniqueOpts;
```

This preserves any previously-set opts (such as a debounce config) when `unique()` is called without explicit options, while still honoring opts when they are passed.

## Test

Added unit tests asserting that `.debounce(2000).unique({'data.x':1})` preserves `uniqueOpts.debounce`, and that `.unique(u, { insertOnly: true }).debounce(2000)` keeps both settings. Verified the first test fails on the current code and passes with the fix.