### PR TITLE
fix(agenda): honor maxAttempts and exponential backoff on channel reconnect

### DIFF
--- a/.changeset/notification-reconnect-maxattempts.md
+++ b/.changeset/notification-reconnect-maxattempts.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+Fix notification channel reconnect ignoring maxAttempts and never applying exponential backoff (infinite tight retry loop)

--- a/packages/agenda/src/notifications/BaseNotificationChannel.ts
+++ b/packages/agenda/src/notifications/BaseNotificationChannel.ts
@@ -55,6 +55,12 @@ export abstract class BaseNotificationChannel extends EventEmitter implements No
 	protected setState(newState: NotificationChannelState): void {
 		if (this._state !== newState) {
 			this._state = newState;
+			// Reset the reconnect budget only on a successful connection, so the
+			// maxAttempts guard and exponential backoff in scheduleReconnect() can
+			// actually progress across failed reconnect attempts.
+			if (newState === 'connected') {
+				this.reconnectAttempts = 0;
+			}
 			this.emit('stateChange', newState);
 		}
 	}
@@ -142,10 +148,13 @@ export abstract class BaseNotificationChannel extends EventEmitter implements No
 	}
 
 	protected clearReconnect(): void {
+		// Only clear the pending reconnect timer here. The attempt counter must NOT
+		// be reset on every connect() attempt, otherwise the maxAttempts guard never
+		// trips and backoff stays pinned at the initial delay. The counter is reset
+		// in setState() when a connection actually succeeds.
 		if (this.reconnectTimeout) {
 			clearTimeout(this.reconnectTimeout);
 			this.reconnectTimeout = undefined;
 		}
-		this.reconnectAttempts = 0;
 	}
 }

--- a/packages/agenda/test/notification-reconnect.test.ts
+++ b/packages/agenda/test/notification-reconnect.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for BaseNotificationChannel reconnect/backoff behavior.
+ *
+ * These verify that reconnection honors `maxAttempts`, uses exponential backoff,
+ * gives up with an error, and restores the full retry budget after a successful
+ * reconnect.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { BaseNotificationChannel } from '../src/notifications/BaseNotificationChannel.js';
+import type { JobNotification } from '../src/index.js';
+
+/**
+ * Test channel that fails to connect a configurable number of times, then succeeds.
+ * Mirrors the real subclass wiring: clearReconnect() at the top of connect(),
+ * scheduleReconnect() on failure.
+ */
+class FlakyChannel extends BaseNotificationChannel {
+	public connectCalls = 0;
+
+	/** Number of leading connect() calls that should fail. Infinity = always fail. */
+	public failUntilCall = Infinity;
+
+	async connect(): Promise<void> {
+		this.connectCalls += 1;
+		this.clearReconnect();
+		try {
+			if (this.connectCalls <= this.failUntilCall) {
+				throw new Error('connect failed');
+			}
+			this.setState('connected');
+		} catch (error) {
+			this.scheduleReconnect();
+			throw error;
+		}
+	}
+
+	async disconnect(): Promise<void> {
+		this.clearReconnect();
+		this.setState('disconnected');
+	}
+
+	async publish(_notification: JobNotification): Promise<void> {}
+
+	get reconnectAttemptsForTest(): number {
+		return this.reconnectAttempts;
+	}
+}
+
+describe('BaseNotificationChannel reconnect', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('stops after maxAttempts, reaches error state, emits give-up error, and backs off', async () => {
+		const channel = new FlakyChannel({
+			reconnect: { enabled: true, maxAttempts: 3, initialDelayMs: 100, maxDelayMs: 30000 }
+		});
+
+		const errors: Error[] = [];
+		channel.on('error', err => errors.push(err));
+
+		// Initial connect fails and schedules the first reconnect.
+		await expect(channel.connect()).rejects.toThrow('connect failed');
+		expect(channel.connectCalls).toBe(1);
+
+		// Drain all scheduled reconnect timers.
+		await vi.runAllTimersAsync();
+
+		// connect() is called at most maxAttempts + 1 times (initial + maxAttempts retries).
+		expect(channel.connectCalls).toBeLessThanOrEqual(4);
+		// It should actually exhaust the budget (not give up early, not loop forever).
+		expect(channel.connectCalls).toBe(4);
+
+		// Final state is 'error' and the give-up error was emitted.
+		expect(channel.state).toBe('error');
+		expect(errors.some(e => /Max reconnection attempts reached/i.test(e.message))).toBe(true);
+	});
+
+	it('uses exponential backoff between attempts', async () => {
+		const channel = new FlakyChannel({
+			reconnect: { enabled: true, maxAttempts: 4, initialDelayMs: 100, maxDelayMs: 30000 }
+		});
+		channel.on('error', () => {});
+
+		const delays: number[] = [];
+		const realSetTimeout = globalThis.setTimeout;
+		const spy = vi
+			.spyOn(globalThis, 'setTimeout')
+			.mockImplementation(((fn: (...args: unknown[]) => void, ms?: number, ...rest: unknown[]) => {
+				if (typeof ms === 'number') {
+					delays.push(ms);
+				}
+				return (realSetTimeout as typeof globalThis.setTimeout)(fn, ms, ...rest);
+			}) as typeof globalThis.setTimeout);
+
+		await expect(channel.connect()).rejects.toThrow();
+		await vi.runAllTimersAsync();
+
+		spy.mockRestore();
+
+		// First few backoff delays should grow: 100, 200, 400, ...
+		expect(delays.slice(0, 3)).toEqual([100, 200, 400]);
+	});
+
+	it('restores the full retry budget after a successful reconnect', async () => {
+		const channel = new FlakyChannel({
+			reconnect: { enabled: true, maxAttempts: 3, initialDelayMs: 100, maxDelayMs: 30000 }
+		});
+		channel.on('error', () => {});
+
+		// Fail twice, then succeed on the 3rd connect() call.
+		channel.failUntilCall = 2;
+
+		await expect(channel.connect()).rejects.toThrow();
+		await vi.runAllTimersAsync();
+
+		expect(channel.state).toBe('connected');
+		// Budget reset on success: a later failure run can again use the full budget.
+		expect(channel.reconnectAttemptsForTest).toBe(0);
+
+		// Now make it always fail again and confirm we get a fresh full budget.
+		channel.failUntilCall = Infinity;
+		channel.connectCalls = 0;
+		await expect(channel.connect()).rejects.toThrow();
+		await vi.runAllTimersAsync();
+
+		expect(channel.connectCalls).toBe(4); // initial + 3 retries again
+		expect(channel.state).toBe('error');
+	});
+});


### PR DESCRIPTION
Fixes #1764

## Problem

`BaseNotificationChannel.clearReconnect()` resets `reconnectAttempts = 0`, and every subclass `connect()` calls `clearReconnect()` at the top. Because each scheduled reconnect re-invokes `connect()`, the attempt counter is zeroed before the next failure is counted. As a result:

- the `reconnectAttempts >= maxAttempts` guard never trips, so reconnection retries forever and the give-up error is never emitted;
- the backoff `initialDelayMs * Math.pow(2, reconnectAttempts)` is always `2^0`, pinning the delay at `initialDelayMs`.

This affects the Postgres notification channel reconnect path (and any subclass following the same pattern).

## Fix

- `clearReconnect()` now only clears the pending reconnect timer.
- The attempt counter is reset to 0 only on a successful connection, inside `setState()` when transitioning to `'connected'`.

## Test

Added `test/notification-reconnect.test.ts` with an always-failing channel and vitest fake timers, asserting: connect is called at most `maxAttempts + 1` times, the state reaches `'error'`, the give-up error is emitted, backoff grows (100, 200, 400, ...), and a later successful reconnect restores the full retry budget. Verified the tests fail on the current code and pass with the fix.