### PR TITLE
fix(backends): re-fire leading-strategy debounce after the window elapses

### DIFF
--- a/.changeset/leading-debounce-refire.md
+++ b/.changeset/leading-debounce-refire.md
@@ -1,0 +1,7 @@
+---
+'@agendajs/mongo-backend': patch
+'@agendajs/postgres-backend': patch
+'@agendajs/redis-backend': patch
+---
+
+Fix leading-strategy debounce never re-firing after its window elapsed (the debounce window was never reset once the job ran)

--- a/packages/agenda/test/shared/debounce-test-suite.ts
+++ b/packages/agenda/test/shared/debounce-test-suite.ts
@@ -209,6 +209,42 @@ export function debounceTestSuite(config: DebounceTestConfig): void {
 				// Data should be updated even though nextRunAt isn't
 				expect(job2.attrs.data).toEqual({ key: 'lead3', value: 'second' });
 			});
+
+			it('should re-fire after the debounce window has elapsed', async () => {
+				agenda.define('debounceLeadingRefire', async () => {});
+
+				// First save: leading edge fires immediately.
+				const job1 = await agenda
+					.create('debounceLeadingRefire', { key: 'lead4', value: 1 })
+					.unique({ 'data.key': 'lead4' })
+					.debounce(300, { strategy: 'leading' })
+					.save();
+
+				const firstNextRunAt = job1.attrs.nextRunAt!.getTime();
+
+				// Simulate the job having run: clear nextRunAt as the processor would.
+				// (Leading-edge jobs run on their first nextRunAt; afterwards nextRunAt is null.)
+				job1.attrs.nextRunAt = null;
+				await agenda.db.saveJobState(job1.attrs, undefined);
+
+				// Wait for the leading window to elapse.
+				await new Promise(resolve => setTimeout(resolve, 350));
+
+				// Next save after the window must start a fresh leading edge and re-fire.
+				const job2 = await agenda
+					.create('debounceLeadingRefire', { key: 'lead4', value: 2 })
+					.unique({ 'data.key': 'lead4' })
+					.debounce(300, { strategy: 'leading' })
+					.save();
+
+				expect(job2.attrs.nextRunAt).not.toBeNull();
+				expect(job2.attrs.nextRunAt).toBeDefined();
+				// Fresh leading edge ~now (not the stale first nextRunAt, not null).
+				const secondNextRunAt = job2.attrs.nextRunAt!.getTime();
+				expect(secondNextRunAt).toBeGreaterThan(firstNextRunAt);
+				expect(secondNextRunAt).toBeGreaterThanOrEqual(Date.now() - 200);
+				expect(secondNextRunAt).toBeLessThanOrEqual(Date.now() + 200);
+			});
 		});
 
 		describe('maxWait', () => {

--- a/packages/mongo-backend/src/MongoJobRepository.ts
+++ b/packages/mongo-backend/src/MongoJobRepository.ts
@@ -764,14 +764,22 @@ export class MongoJobRepository implements JobRepository {
 						const timeSinceStart = now.getTime() - debounceStartedAt.getTime();
 
 						if (debounce.strategy === 'leading') {
-							// Leading: keep original nextRunAt, just update data
-							// Don't change nextRunAt - the job runs on its original schedule
-							log('leading debounce: keeping original nextRunAt, updating data only');
+							// Leading: while still within the debounce window, ignore the call
+							// (keep the original nextRunAt, just update data). Once the window
+							// has elapsed, start a fresh leading edge so the job fires again.
+							const windowElapsed = timeSinceStart >= debounce.delay;
+							const leadingNextRunAt = windowElapsed ? now : existingJob.nextRunAt;
+							const leadingStartedAt = windowElapsed ? now : debounceStartedAt;
+							log(
+								windowElapsed
+									? 'leading debounce: window elapsed, starting fresh leading edge'
+									: 'leading debounce: within window, keeping original nextRunAt, updating data only'
+							);
 							const leadingUpdate: UpdateFilter<MongoJobDocument> = {
 								$set: {
 									...propsWithModifier,
-									nextRunAt: existingJob.nextRunAt, // Preserve original
-									debounceStartedAt: debounceStartedAt
+									nextRunAt: leadingNextRunAt,
+									debounceStartedAt: leadingStartedAt
 								}
 							};
 							const result = await this.collection.findOneAndUpdate(query, leadingUpdate, {

--- a/packages/postgres-backend/src/PostgresJobRepository.ts
+++ b/packages/postgres-backend/src/PostgresJobRepository.ts
@@ -760,10 +760,18 @@ export class PostgresJobRepository implements JobRepository {
 					const timeSinceStart = now.getTime() - existingDebounceStartedAt.getTime();
 
 					if (debounce.strategy === 'leading') {
-						// Leading: keep original nextRunAt, just update data
-						log('leading debounce: keeping original nextRunAt, updating data only');
-						nextRunAt = existingRow.next_run_at;
-						debounceStartedAt = existingDebounceStartedAt;
+						// Leading: while still within the debounce window, ignore the call
+						// (keep the original nextRunAt). Once the window has elapsed, start a
+						// fresh leading edge so the job fires again.
+						if (timeSinceStart >= debounce.delay) {
+							log('leading debounce: window elapsed, starting fresh leading edge');
+							nextRunAt = now;
+							debounceStartedAt = now;
+						} else {
+							log('leading debounce: within window, keeping original nextRunAt, updating data only');
+							nextRunAt = existingRow.next_run_at;
+							debounceStartedAt = existingDebounceStartedAt;
+						}
 					} else {
 						// Trailing (default): push nextRunAt forward
 						if (debounce.maxWait && timeSinceStart >= debounce.maxWait) {

--- a/packages/redis-backend/src/RedisJobRepository.ts
+++ b/packages/redis-backend/src/RedisJobRepository.ts
@@ -999,10 +999,18 @@ export class RedisJobRepository implements JobRepository {
 						const timeSinceStart = now.getTime() - existingDebounceStartedAt.getTime();
 
 						if (debounce.strategy === 'leading') {
-							// Leading: keep original nextRunAt, just update data
-							log('leading debounce: keeping original nextRunAt, updating data only');
-							nextRunAt = jobData.nextRunAt || 'null';
-							debounceStartedAt = existingDebounceStartedAt.toISOString();
+							// Leading: while still within the debounce window, ignore the call
+							// (keep the original nextRunAt). Once the window has elapsed, start a
+							// fresh leading edge so the job fires again.
+							if (timeSinceStart >= debounce.delay) {
+								log('leading debounce: window elapsed, starting fresh leading edge');
+								nextRunAt = nowIso;
+								debounceStartedAt = now.toISOString();
+							} else {
+								log('leading debounce: within window, keeping original nextRunAt, updating data only');
+								nextRunAt = jobData.nextRunAt || 'null';
+								debounceStartedAt = existingDebounceStartedAt.toISOString();
+							}
 						} else {
 							// Trailing (default): push nextRunAt forward
 							if (debounce.maxWait && timeSinceStart >= debounce.maxWait) {


### PR DESCRIPTION
Fixes #1766

## Problem

For leading-strategy debounce, the Mongo, Postgres, and Redis repositories always preserved the existing `nextRunAt` and the original `debounceStartedAt` on subsequent saves, with no expiry check. After the leading-edge job runs (`nextRunAt` becomes null), every later leading save just rewrites null and keeps the stale `debounceStartedAt`, so the job never fires again.

## Fix

In each backend's leading branch, when the debounce window has elapsed (`timeSinceStart >= debounce.delay`), start a fresh leading edge: `nextRunAt = now`, `debounceStartedAt = now`. The original schedule is only preserved while still within the window (the existing intended behavior).

## Test

Added a shared `should re-fire after the debounce window has elapsed` case to `packages/agenda/test/shared/debounce-test-suite.ts`, so it runs against all backends. It saves a leading-debounced job, simulates the run by clearing `nextRunAt`, waits past the window, then saves again and asserts the job gets a fresh non-null `nextRunAt` (~now). Verified the test fails on the current code and passes with the fix for MongoDB (mongodb-memory-server), PostgreSQL, and Redis.