### PR TITLE
fix(backends): count disabled jobs only as paused in getJobsOverview

### DIFF
--- a/.changeset/jobsoverview-paused-doublecount.md
+++ b/.changeset/jobsoverview-paused-doublecount.md
@@ -1,0 +1,7 @@
+---
+'@agendajs/mongo-backend': patch
+'@agendajs/postgres-backend': patch
+'@agendajs/redis-backend': patch
+---
+
+Fix `getJobsOverview` double-counting disabled jobs. A disabled job was counted in both its computed state bucket and the `paused` bucket, so the per-state buckets summed to `total + (number of disabled jobs)`. Disabled jobs are now counted only as `paused`, consistent with the list view.

--- a/packages/agenda/test/shared/repository-test-suite.ts
+++ b/packages/agenda/test/shared/repository-test-suite.ts
@@ -703,6 +703,36 @@ export function repositoryTestSuite(config: RepositoryTestConfig): void {
 				expect(overviewJob).toBeDefined();
 				expect(overviewJob!.total).toBe(2);
 			});
+
+			it('should not double-count disabled (paused) jobs', async () => {
+				await repo.saveJob({
+					name: 'paused-overview-job',
+					priority: 0,
+					nextRunAt: new Date(Date.now() + 60000), // future run, but disabled
+					type: 'normal',
+					data: {},
+					disabled: true
+				}, undefined);
+
+				const overview = await repo.getJobsOverview();
+				const job = overview.find(o => o.name === 'paused-overview-job');
+				expect(job).toBeDefined();
+
+				// A disabled job must be counted only as paused, never also as scheduled.
+				expect(job!.paused).toBe(1);
+				expect(job!.scheduled).toBe(0);
+
+				// Per-state buckets must sum to exactly total (no double-counting).
+				const sum =
+					job!.running +
+					job!.scheduled +
+					job!.queued +
+					job!.completed +
+					job!.failed +
+					job!.repeating +
+					job!.paused;
+				expect(sum).toBe(job!.total);
+			});
 		});
 	});
 }

--- a/packages/mongo-backend/src/MongoJobRepository.ts
+++ b/packages/mongo-backend/src/MongoJobRepository.ts
@@ -292,10 +292,11 @@ export class MongoJobRepository implements JobRepository {
 				};
 
 				for (const job of jobs) {
-					const state = computeJobState(job as unknown as JobParameters, now);
-					overview[state]++;
 					if (job.disabled === true) {
 						overview.paused++;
+					} else {
+						const state = computeJobState(job as unknown as JobParameters, now);
+						overview[state]++;
 					}
 				}
 

--- a/packages/postgres-backend/src/PostgresJobRepository.ts
+++ b/packages/postgres-backend/src/PostgresJobRepository.ts
@@ -326,10 +326,11 @@ export class PostgresJobRepository implements JobRepository {
 
 				for (const row of result.rows) {
 					const job = this.rowToJob(row);
-					const state = computeJobState(job, now);
-					overview[state as keyof typeof overview]++;
 					if (job.disabled === true) {
 						overview.paused++;
+					} else {
+						const state = computeJobState(job, now);
+						overview[state as keyof typeof overview]++;
 					}
 				}
 

--- a/packages/redis-backend/src/RedisJobRepository.ts
+++ b/packages/redis-backend/src/RedisJobRepository.ts
@@ -342,10 +342,11 @@ export class RedisJobRepository implements JobRepository {
 					if (!jobData || Object.keys(jobData).length === 0) continue;
 
 					const job = this.hashToJob(jobData);
-					const state = computeJobState(job, now);
-					overview[state as keyof typeof overview]++;
 					if (job.disabled === true) {
 						overview.paused++;
+					} else {
+						const state = computeJobState(job, now);
+						overview[state as keyof typeof overview]++;
 					}
 				}
 


### PR DESCRIPTION
Fixes #1768.

## Problem

`getJobsOverview()` double-counts disabled (paused) jobs. `computeJobState()` never returns `'paused'`, so each backend counted a disabled job once in its computed-state bucket (e.g. `scheduled`) and again in `paused`. As a result the per-state buckets summed to `total + (number of disabled jobs)` rather than `total`, and the overview disagreed with the list view (`queryJobs` treats `paused` as a mutually exclusive state). Dashboards that sum these buckets show wrong totals.

## Fix

Count disabled jobs exclusively as `paused` in all three backends:

```js
if (job.disabled === true) {
  overview.paused++;
} else {
  const state = computeJobState(job, now);
  overview[state]++;
}
```

Applied to:
- `packages/mongo-backend/src/MongoJobRepository.ts`
- `packages/postgres-backend/src/PostgresJobRepository.ts`
- `packages/redis-backend/src/RedisJobRepository.ts`

## Tests

Added a regression case to the shared repository test suite (`packages/agenda/test/shared/repository-test-suite.ts`) that saves a disabled job with a future `nextRunAt` and asserts the per-state buckets sum to `total` (and that `paused === 1`, `scheduled === 0`). Verified it fails on `main` and passes with the fix, against all three backends (mongo via mongodb-memory-server, redis, postgres).

Changeset entries added (patch) for `@agendajs/mongo-backend`, `@agendajs/postgres-backend`, and `@agendajs/redis-backend`.
