### PR TITLE
fix(redis): order negative priorities correctly in getNextJobToRun

### DIFF
--- a/.changeset/redis-negative-priority-order.md
+++ b/.changeset/redis-negative-priority-order.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/redis-backend': patch
+---
+
+Fix priority ordering for negative priorities in the Redis backend. The sorted-set score clamped every priority below `0` to the same fractional tiebreak, so jobs with equal `nextRunAt` and named priorities `normal`, `low`, and `lowest` were ordered arbitrarily instead of by priority descending. Negative priorities are now mapped into a distinct, monotonic tiebreak so higher priority always runs first, matching the Mongo and Postgres backends.

--- a/packages/agenda/test/shared/repository-test-suite.ts
+++ b/packages/agenda/test/shared/repository-test-suite.ts
@@ -577,6 +577,54 @@ export function repositoryTestSuite(config: RepositoryTestConfig): void {
 				expect(next!.data).toEqual({ priority: 'high' });
 			});
 
+			it('should respect priority ordering for negative priorities', async () => {
+				// Agenda's named priorities are negative (low=-10, lowest=-20).
+				// With equal nextRunAt, higher priority must run first:
+				// normal(0) before low(-10) before lowest(-20).
+				const sameTime = new Date(Date.now() - 60000);
+
+				await repo.saveJob({
+					name: 'neg-priority-test',
+					priority: -20,
+					nextRunAt: sameTime,
+					type: 'normal',
+					data: { priority: 'lowest' }
+				}, undefined);
+				await repo.saveJob({
+					name: 'neg-priority-test',
+					priority: -10,
+					nextRunAt: sameTime,
+					type: 'normal',
+					data: { priority: 'low' }
+				}, undefined);
+				await repo.saveJob({
+					name: 'neg-priority-test',
+					priority: 0,
+					nextRunAt: sameTime,
+					type: 'normal',
+					data: { priority: 'normal' }
+				}, undefined);
+
+				const now = new Date();
+				const nextScanAt = new Date(now.getTime() + 5000);
+				const lockDeadline = new Date(now.getTime() - 600000);
+
+				const first = await repo.getNextJobToRun('neg-priority-test', nextScanAt, lockDeadline, now, undefined);
+				expect(first).toBeDefined();
+				expect(first!.priority).toBe(0);
+				expect(first!.data).toEqual({ priority: 'normal' });
+
+				const second = await repo.getNextJobToRun('neg-priority-test', nextScanAt, lockDeadline, now, undefined);
+				expect(second).toBeDefined();
+				expect(second!.priority).toBe(-10);
+				expect(second!.data).toEqual({ priority: 'low' });
+
+				const third = await repo.getNextJobToRun('neg-priority-test', nextScanAt, lockDeadline, now, undefined);
+				expect(third).toBeDefined();
+				expect(third!.priority).toBe(-20);
+				expect(third!.data).toEqual({ priority: 'lowest' });
+			});
+
 			it('should not return disabled jobs', async () => {
 				await repo.saveJob({
 					name: 'disabled-test',

--- a/packages/redis-backend/src/RedisJobRepository.ts
+++ b/packages/redis-backend/src/RedisJobRepository.ts
@@ -180,9 +180,15 @@ export class RedisJobRepository implements JobRepository {
 		if (!nextRunAt) {
 			return Number.MAX_SAFE_INTEGER; // Jobs without nextRunAt go to the end
 		}
-		// Combine timestamp with priority as decimal part
-		// Higher priority = lower decimal = comes first when sorting ascending
-		const priorityPart = (100 - Math.min(Math.max(priority, 0), 99)) / 1000;
+		// Combine timestamp with priority as decimal part.
+		// Map the signed priority into a fractional tiebreak in (0, 1) so that a
+		// higher priority yields a strictly smaller part (comes first when sorting
+		// ascending) while keeping adjacent priorities distinct. Agenda's named
+		// priorities are negative (lowest=-20, low=-10, normal=0, high=10, highest=20),
+		// so clamping to [0, 99] (the previous behaviour) collapsed every
+		// non-positive priority to the same tiebreak and broke ordering.
+		const clampedPriority = Math.min(Math.max(priority, -1000), 1000);
+		const priorityPart = (1000 - clampedPriority) / 2001;
 		return nextRunAt.getTime() + priorityPart;
 	}
 


### PR DESCRIPTION
Fixes #1770.

## Problem

The Redis backend breaks priority ordering for negative priorities. In `getJobScore` (`packages/redis-backend/src/RedisJobRepository.ts`) the sorted-set tiebreak was:

```js
const priorityPart = (100 - Math.min(Math.max(priority, 0), 99)) / 1000;
```

`Math.max(priority, 0)` clamps every negative priority to `0`, so `normal(0)`, `low(-10)` and `lowest(-20)` all collapse to the same fractional tiebreak (`0.100`). Jobs with equal `nextRunAt` were then ordered arbitrarily by the `getNextJobToRun` Lua script instead of priority-descending. Agenda's named priorities are negative, so this is common usage, and Mongo/Postgres apply a true `priority DESC` (cross-backend divergence).

## Fix

Map the signed priority into a fractional tiebreak in `(0, 1)` so that higher priority yields a strictly smaller part, keeping adjacent priorities distinct:

```js
const clampedPriority = Math.min(Math.max(priority, -1000), 1000);
const priorityPart = (1000 - clampedPriority) / 2001;
```

This preserves `high < normal < low < lowest` ordering with distinct values, even at a year-2100 timestamp. The `!nextRunAt` MAX_SAFE_INTEGER branch is unchanged.

## Tests

Added a `getNextJobToRun` case to the shared repository test suite asserting that, with equal `nextRunAt`, `normal(0)` is picked before `low(-10)` and `low(-10)` before `lowest(-20)`. The new assertions fail on the previous code and pass with the fix. Verified against a live Redis 7 instance; the redis-backend repository suite is green.

A changeset is included (patch for `@agendajs/redis-backend`).