### PR TITLE
fix(agenda): emit progress events locally on job.touch

### DIFF
--- a/.changeset/progress-event-local-emit.md
+++ b/.changeset/progress-event-local-emit.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+Emit `progress` and `progress:<name>` events locally when `job.touch(progress)` is called, matching the local-emit pattern used by other job lifecycle events.

--- a/packages/agenda/src/Job.ts
+++ b/packages/agenda/src/Job.ts
@@ -466,8 +466,10 @@ export class Job<DATA = unknown | void> {
 			lastModifiedBy: this.agenda.attrs.name || undefined
 		});
 
-		// Publish progress state notification if progress was provided (fire-and-forget)
+		// Emit progress events locally and publish notification if progress was provided
 		if (progress !== undefined) {
+			this.agenda.emit('progress', this);
+			this.agenda.emit(`progress:${this.attrs.name}`, this);
 			this.agenda.publishJobStateNotification(this, 'progress', {
 				progress
 			});

--- a/packages/agenda/test/unit.test.ts
+++ b/packages/agenda/test/unit.test.ts
@@ -227,6 +227,38 @@ describe('Job Unit Tests', () => {
 		});
 	});
 
+	describe('touch', () => {
+		it('emits progress events locally when progress is provided', async () => {
+			agenda.define('progressJob', () => {});
+			const job = agenda.create('progressJob', {});
+
+			const progressSpy = vi.fn();
+			const progressNamedSpy = vi.fn();
+			agenda.on('progress', progressSpy);
+			agenda.on('progress:progressJob', progressNamedSpy);
+
+			await job.touch(50);
+
+			expect(progressSpy).toHaveBeenCalledTimes(1);
+			expect(progressSpy).toHaveBeenCalledWith(job);
+			expect(progressNamedSpy).toHaveBeenCalledTimes(1);
+			expect(progressNamedSpy).toHaveBeenCalledWith(job);
+			expect(job.attrs.progress).toBe(50);
+		});
+
+		it('does not emit progress events when progress is omitted', async () => {
+			agenda.define('progressJob', () => {});
+			const job = agenda.create('progressJob', {});
+
+			const progressSpy = vi.fn();
+			agenda.on('progress', progressSpy);
+
+			await job.touch();
+
+			expect(progressSpy).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('toJson', () => {
 		it('handles null failedAt', () => {
 			const job = new Job(agenda, {


### PR DESCRIPTION
Fixes #1772

## Problem

`Job.touch(progress)` publishes a `progress` state notification but never emits the event locally, so `agenda.on('progress')` and `agenda.on('progress:<name>')` never fire in the process running the job. Every other lifecycle event (start/success/fail/complete/retry) emits locally and publishes; `progress` was missing the local emit.

## Fix

When `progress !== undefined`, also `emit('progress', this)` and `emit('progress:<name>', this)` alongside the existing publish, matching the established pattern in `Job.run()`.

## Test

Added unit tests (MockBackend) asserting both `progress` and `progress:<name>` fire locally on `job.touch(50)`, and that nothing fires when progress is omitted. The new test fails on HEAD (0 calls) and passes with the fix.