### PR TITLE
fix(postgres-backend): persist fail fields on job insert

### DIFF
--- a/.changeset/postgres-insert-fail-fields.md
+++ b/.changeset/postgres-insert-fail-fields.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/postgres-backend': patch
+---
+
+Persist `failReason`, `failCount`, and `failedAt` when a job is inserted with failure state. Previously these columns were only written on the UPDATE path, so a brand-new job saved with failure state lost it.

--- a/packages/postgres-backend/src/PostgresJobRepository.ts
+++ b/packages/postgres-backend/src/PostgresJobRepository.ts
@@ -674,8 +674,9 @@ export class PostgresJobRepository implements JobRepository {
 			const result = await this.pool.query<PostgresJobRow>(
 				`INSERT INTO "${this.tableName}" (
 					name, priority, next_run_at, type, repeat_timezone,
-					repeat_interval, data, repeat_at, disabled, fork, last_modified_by
-				 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+					repeat_interval, data, repeat_at, disabled, fork, last_modified_by,
+					fail_reason, fail_count, failed_at
+				 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 				 ON CONFLICT ((name)) WHERE type = 'single'
 				 DO UPDATE SET
 					priority = EXCLUDED.priority,
@@ -701,7 +702,10 @@ export class PostgresJobRepository implements JobRepository {
 					props.repeatAt || null,
 					props.disabled || false,
 					props.fork || false,
-					options?.lastModifiedBy || null
+					options?.lastModifiedBy || null,
+					props.failReason ?? null,
+					props.failCount ?? null,
+					props.failedAt || null
 				]
 			);
 
@@ -830,8 +834,9 @@ export class PostgresJobRepository implements JobRepository {
 				const result = await this.pool.query<PostgresJobRow>(
 					`INSERT INTO "${this.tableName}" (
 						name, priority, next_run_at, type, repeat_timezone,
-						repeat_interval, data, repeat_at, disabled, fork, last_modified_by, debounce_started_at
-					 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+						repeat_interval, data, repeat_at, disabled, fork, last_modified_by, debounce_started_at,
+						fail_reason, fail_count, failed_at
+					 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 					 RETURNING *`,
 					[
 						props.name,
@@ -845,7 +850,10 @@ export class PostgresJobRepository implements JobRepository {
 						props.disabled || false,
 						props.fork || false,
 						options?.lastModifiedBy || null,
-						debounceStartedAt
+						debounceStartedAt,
+						props.failReason ?? null,
+						props.failCount ?? null,
+						props.failedAt || null
 					]
 				);
 
@@ -858,8 +866,9 @@ export class PostgresJobRepository implements JobRepository {
 		const result = await this.pool.query<PostgresJobRow>(
 			`INSERT INTO "${this.tableName}" (
 				name, priority, next_run_at, type, repeat_timezone,
-				repeat_interval, data, repeat_at, disabled, fork, last_modified_by
-			 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+				repeat_interval, data, repeat_at, disabled, fork, last_modified_by,
+				fail_reason, fail_count, failed_at
+			 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 			 RETURNING *`,
 			[
 				props.name,
@@ -872,7 +881,10 @@ export class PostgresJobRepository implements JobRepository {
 				props.repeatAt || null,
 				props.disabled || false,
 				props.fork || false,
-				options?.lastModifiedBy || null
+				options?.lastModifiedBy || null,
+				props.failReason ?? null,
+				props.failCount ?? null,
+				props.failedAt || null
 			]
 		);
 

--- a/packages/postgres-backend/test/postgres-backend.test.ts
+++ b/packages/postgres-backend/test/postgres-backend.test.ts
@@ -175,6 +175,69 @@ describe('PostgresBackend', () => {
 		});
 	});
 
+	describe('failure fields on fresh insert', () => {
+		const failedAt = new Date('2025-01-01T00:00:00.000Z');
+
+		it('persists fail fields on a normal insert', async () => {
+			const saved = await backend.repository.saveJob({
+				name: 'fail-normal',
+				priority: 0,
+				nextRunAt: new Date(),
+				type: 'normal',
+				data: {},
+				failReason: 'boom',
+				failCount: 3,
+				failedAt
+			}, undefined);
+
+			const fetched = await backend.repository.getJobById(saved._id!);
+			expect(fetched).not.toBeNull();
+			expect(fetched!.failReason).toBe('boom');
+			expect(fetched!.failCount).toBe(3);
+			expect(fetched!.failedAt?.getTime()).toBe(failedAt.getTime());
+		});
+
+		it('persists fail fields on a single-type insert', async () => {
+			const saved = await backend.repository.saveJob({
+				name: 'fail-single',
+				priority: 0,
+				nextRunAt: new Date(),
+				type: 'single',
+				data: {},
+				failReason: 'single-boom',
+				failCount: 2,
+				failedAt
+			}, undefined);
+
+			const fetched = await backend.repository.getJobById(saved._id!);
+			expect(fetched).not.toBeNull();
+			expect(fetched!.failReason).toBe('single-boom');
+			expect(fetched!.failCount).toBe(2);
+			expect(fetched!.failedAt?.getTime()).toBe(failedAt.getTime());
+		});
+
+		it('persists fail fields on a unique (debounce) insert', async () => {
+			const saved = await backend.repository.saveJob({
+				name: 'fail-unique',
+				priority: 0,
+				nextRunAt: new Date(),
+				type: 'normal',
+				data: { entity: 'a' },
+				unique: { 'data.entity': 'a' },
+				uniqueOpts: { debounce: { delay: 1000 } },
+				failReason: 'unique-boom',
+				failCount: 1,
+				failedAt
+			}, undefined);
+
+			const fetched = await backend.repository.getJobById(saved._id!);
+			expect(fetched).not.toBeNull();
+			expect(fetched!.failReason).toBe('unique-boom');
+			expect(fetched!.failCount).toBe(1);
+			expect(fetched!.failedAt?.getTime()).toBe(failedAt.getTime());
+		});
+	});
+
 	describe('PostgreSQL-specific features', () => {
 		it('should support JSONB queries for job data', async () => {
 			await backend.repository.saveJob({


### PR DESCRIPTION
Fixes #1774

## Problem

The three `saveJob` INSERT statements in `PostgresJobRepository` (plain insert, single-type upsert insert, unique/debounce insert) omit the `fail_reason`, `fail_count`, and `failed_at` columns, so a brand-new job saved with failure state loses it. The UPDATE path already writes these columns, and the Mongo backend persists them on insert.

## Fix

Add `fail_reason`, `fail_count`, `failed_at` to each INSERT's column list and VALUES (`failReason ?? null`, `failCount ?? null`, `failedAt || null`), renumbering placeholders.

## Test

Added a `failure fields on fresh insert` describe block that saves a fresh job (no `_id`) with `failReason`/`failCount`/`failedAt` for all three insert paths (normal, single, unique-debounce) and asserts `getJobById` returns them. All three fail on HEAD (undefined) and pass with the fix. Verified against a postgres:16 container.