### PR TITLE
fix(test): send fork child error message over IPC instead of empty object

### DIFF
--- a/packages/agenda/test/shared/agenda-test-suite.ts
+++ b/packages/agenda/test/shared/agenda-test-suite.ts
@@ -1954,6 +1954,13 @@ export function agendaTestSuite(config: AgendaTestConfig): void {
 					const jobDataFinished = await backend.repository.getJobById(job.attrs._id!);
 					expect(jobDataFinished?.lastFinishedAt).toBeDefined();
 					expect(jobDataFinished?.failReason).not.toBeUndefined();
+					// failReason must be the real error message string, not a serialized
+					// Error object. JSON.stringify(error) yields "{}", which would be
+					// persisted as an empty object (losing the message and violating the
+					// `failReason: string` type). The fork helper sends `err.message`.
+					expect(typeof jobDataFinished?.failReason).toBe('string');
+					expect((jobDataFinished?.failReason as string).length).toBeGreaterThan(0);
+					expect(jobDataFinished?.failReason).not.toBe('{}');
 					expect(jobDataFinished?.failCount).toBe(1);
 
 					await agendaFork.stop();

--- a/packages/mongo-backend/test/helpers/forkHelper.ts
+++ b/packages/mongo-backend/test/helpers/forkHelper.ts
@@ -48,7 +48,7 @@ try {
 } catch (err) {
 	console.error('err', err);
 	if (process.send) {
-		process.send(JSON.stringify(err));
+		process.send(err instanceof Error ? err.message : JSON.stringify(err));
 	}
 	process.exit(1);
 }

--- a/packages/postgres-backend/test/helpers/forkHelper.ts
+++ b/packages/postgres-backend/test/helpers/forkHelper.ts
@@ -46,7 +46,7 @@ try {
 } catch (err) {
 	console.error('err', err);
 	if (process.send) {
-		process.send(JSON.stringify(err));
+		process.send(err instanceof Error ? err.message : JSON.stringify(err));
 	}
 	process.exit(1);
 }

--- a/packages/redis-backend/test/helpers/forkHelper.ts
+++ b/packages/redis-backend/test/helpers/forkHelper.ts
@@ -46,7 +46,7 @@ try {
 } catch (err) {
 	console.error('err', err);
 	if (process.send) {
-		process.send(JSON.stringify(err));
+		process.send(err instanceof Error ? err.message : JSON.stringify(err));
 	}
 	process.exit(1);
 }


### PR DESCRIPTION
Fixes #1776

## Problem

The reference fork helpers (`packages/{mongo,postgres,redis}-backend/test/helpers/forkHelper.ts`) send a child error to the parent with `process.send(JSON.stringify(err))`. `JSON.stringify(Error)` is `"{}"`, so the real `message` is lost and the parent persists `failReason` as an empty object (violating the `failReason: string` type).

## Fix

`process.send(err instanceof Error ? err.message : JSON.stringify(err))` in all three helpers.

## Test

Strengthened the shared `should handle job failure in fork mode` test to assert `failReason` is a non-empty string (not the `'{}'` artifact). Verified with a real forked run on mongodb-memory-server:
- HEAD (old helper): `typeof failReason === 'object'` -> test fails.
- With fix: `typeof failReason === 'string'` -> test passes.

Note: the fork happy-path import currently hits a separate, already-known Windows `file://` URL issue in this environment, so the specific thrown message (`intended error :-)`) cannot surface locally on Windows. The error-serialization fix is nonetheless verified end-to-end: the surfaced error message is now a real string rather than `{}`. The assertions are intentionally message-agnostic so they hold across environments.

No changeset: these are test/reference helpers, not part of a published package.