### PR TITLE
fix(agenda): honor repeatTimezone when resolving repeatAt

### DIFF
--- a/.changeset/repeatat-timezone.md
+++ b/.changeset/repeatat-timezone.md
@@ -1,0 +1,9 @@
+---
+'agenda': patch
+---
+
+Honor `repeatTimezone` when computing `nextRunAt` from `repeatAt`. Previously the
+`repeatAt` time-of-day was resolved only in the server's local timezone, so a job
+with `repeatAt: '3:30pm'` and `repeatTimezone: 'Asia/Tokyo'` would fire at the
+wrong wall-clock time on a non-Tokyo server. The parsed time is now reinterpreted
+in the configured timezone, matching the cron interval path.

--- a/packages/agenda/src/utils/nextRunAt.ts
+++ b/packages/agenda/src/utils/nextRunAt.ts
@@ -120,6 +120,16 @@ export function computeFromRepeatAt(attrs: JobParameters<unknown>): Date | null 
 		nextRunAt = date(repeatAt);
 	}
 
+	// `date.js` resolves `repeatAt` against the server's local timezone only. When a
+	// `repeatTimezone` is configured, reinterpret the parsed wall-clock time as if it
+	// occurred in that zone so the job fires at the intended local time regardless of
+	// where the process runs (mirrors the `tz` option used by the cron interval path).
+	if (attrs.repeatTimezone) {
+		nextRunAt = DateTime.fromJSDate(nextRunAt)
+			.setZone(attrs.repeatTimezone, { keepLocalTime: true })
+			.toJSDate();
+	}
+
 	// Apply date constraints (startDate, endDate, skipDays)
 	if (attrs.startDate || attrs.endDate || attrs.skipDays) {
 		const constrainedDate = applyAllDateConstraints(nextRunAt, {

--- a/packages/agenda/test/unit.test.ts
+++ b/packages/agenda/test/unit.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Agenda, Job, toJobId } from '../src/index.js';
 import type { AgendaBackend, JobRepository, JobParameters, JobLogger, JobLogEntry, JobLogQuery, JobLogQueryResult } from '../src/index.js';
 import { computeJobState } from '../src/types/JobQuery.js';
+import { computeFromRepeatAt } from '../src/utils/nextRunAt.js';
 
 /**
  * Minimal mock repository that satisfies the interface without real storage.
@@ -425,6 +426,42 @@ describe('Job Unit Tests', () => {
 		});
 
 		// Note: skipImmediate is tested in the repeatEvery describe block
+	});
+
+	describe('computeFromRepeatAt timezone', () => {
+		const attrsFor = (repeatTimezone?: string): JobParameters<unknown> =>
+			({
+				name: 'demo',
+				type: 'normal',
+				repeatAt: '3:30pm',
+				// Past lastRunAt so the "tomorrow at" branch is not taken and the
+				// parsed repeatAt time-of-day is used directly.
+				lastRunAt: new Date('2000-01-01T00:00:00Z'),
+				...(repeatTimezone ? { repeatTimezone } : {})
+			} as JobParameters<unknown>);
+
+		it('resolves repeatAt in the configured repeatTimezone', () => {
+			const tokyo = computeFromRepeatAt(attrsFor('Asia/Tokyo'));
+			const newYork = computeFromRepeatAt(attrsFor('America/New_York'));
+
+			expect(tokyo).toBeTruthy();
+			expect(newYork).toBeTruthy();
+
+			// 3:30pm in Tokyo and 3:30pm in New York are different instants. The
+			// offset between the two zones is ~13-14h depending on DST; assert the
+			// gap is at least 12h so the timezone is clearly honored (and not
+			// collapsing to the same instant as before the fix).
+			const diffMs = Math.abs(newYork!.getTime() - tokyo!.getTime());
+			expect(diffMs).toBeGreaterThan(12 * 60 * 60 * 1000);
+		});
+
+		it('leaves behavior unchanged when repeatTimezone is unset', () => {
+			const withoutTz = computeFromRepeatAt(attrsFor());
+			// Without a timezone the result matches a plain local parse of the time.
+			const expected = new Date();
+			expected.setHours(15, 30, 0, 0);
+			expect(Math.abs(withoutTz!.getTime() - expected.getTime())).toBeLessThan(2000);
+		});
 	});
 
 	describe('fail', () => {


### PR DESCRIPTION
Fixes #1779

## Problem

`computeFromRepeatAt` (`packages/agenda/src/utils/nextRunAt.ts`) parses the `repeatAt` time-of-day with `date.js`, which resolves only against the server's local timezone. `attrs.repeatTimezone` was ignored, so a job with `repeatAt: '3:30pm'` and `repeatTimezone: 'Asia/Tokyo'` fired at 3:30pm in the server's zone rather than in Tokyo.

The cron interval path (`computeFromInterval`) already passes `tz: attrs.repeatTimezone` to cron-parser, so this was a cross-path inconsistency.

## Fix

When `repeatTimezone` is set, reinterpret the parsed wall-clock time in the target zone using Luxon (already imported):

```ts
nextRunAt = DateTime.fromJSDate(nextRunAt)
  .setZone(attrs.repeatTimezone, { keepLocalTime: true })
  .toJSDate();
```

Applied to both the main and "tomorrow at ..." branches, before the date-constraint logic. Behavior is unchanged when `repeatTimezone` is unset.

## Tests

Added unit tests in `packages/agenda/test/unit.test.ts`:
- `repeatAt: '3:30pm'` with `Asia/Tokyo` vs `America/New_York` must differ by more than 12h (the zone offset). Fails on current HEAD (both collapse to the same instant), passes with the fix.
- With no `repeatTimezone`, the result still matches a plain local parse.

`npx eslint` passes on the changed files; the full `unit.test.ts` suite passes.