### PR TITLE
refactor(JobProcessor): improve job unlocking logic to preserve running job locks

### DIFF
--- a/.changeset/stop-preserves-running-locks.md
+++ b/.changeset/stop-preserves-running-locks.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+`stop()` no longer unlocks jobs that are still running, preventing duplicate concurrent execution of the same job occurrence on another instance during rolling restarts. Only jobs that are locked locally but have not started running are unlocked; running jobs keep their database lock until they complete (or `lockLifetime` expires if the process dies).

--- a/packages/agenda/src/JobProcessor.ts
+++ b/packages/agenda/src/JobProcessor.ts
@@ -133,10 +133,11 @@ export class JobProcessor {
 			this.notificationUnsubscribe = undefined;
 		}
 
-		// Return both locked and running jobs so they can all be unlocked
-		// Running jobs are also "locked" in the database (they have lockedAt set),
-		// they just moved from lockedJobs to runningJobs when processing started
-		return [...this.lockedJobs, ...this.runningJobs];
+		const runningJobIds = new Set(this.runningJobs.map(job => job.attrs._id.toString()));
+
+		// Only unlock jobs that are held locally but have not started running.
+		// Running jobs keep their database locks until they complete or the lock expires.
+		return this.lockedJobs.filter(job => !runningJobIds.has(job.attrs._id.toString()));
 	}
 
 	/**

--- a/packages/agenda/test/shared/agenda-test-suite.ts
+++ b/packages/agenda/test/shared/agenda-test-suite.ts
@@ -414,7 +414,7 @@ export function agendaTestSuite(config: AgendaTestConfig): void {
 				expect(lockedDuringProcessing).toBe(true);
 			});
 
-			it('should clear locks on stop', async () => {
+			it('should preserve locks for running jobs on stop', async () => {
 				agenda.define('clear-lock-test', async () => {
 					await new Promise(resolve => setTimeout(resolve, 5000));
 				});
@@ -425,7 +425,45 @@ export function agendaTestSuite(config: AgendaTestConfig): void {
 				await agenda.stop();
 
 				const result = await agenda.queryJobs({ name: 'clear-lock-test' });
-				expect(result.jobs[0].lockedAt).toBeFalsy();
+				expect(result.jobs[0].lockedAt).toBeTruthy();
+			});
+
+			it('should clear locks for queued jobs on stop', async () => {
+				agenda.define(
+					'queued-lock-test',
+					async () => {
+						await delay(5000);
+					},
+					{ concurrency: 1 }
+				);
+
+				await agenda.start();
+				await Promise.all([agenda.now('queued-lock-test'), agenda.now('queued-lock-test')]);
+
+				let lockedJobs = 0;
+				let runningJobs = 0;
+				const deadline = Date.now() + 5000;
+
+				do {
+					const stats = await agenda.getRunningStats();
+					lockedJobs = stats.lockedJobs as number;
+					runningJobs = stats.runningJobs as number;
+
+					if (lockedJobs >= 2 && runningJobs === 1) {
+						break;
+					}
+
+					await delay(25);
+				} while (Date.now() < deadline);
+
+				expect(lockedJobs).toBeGreaterThanOrEqual(2);
+				expect(runningJobs).toBe(1);
+
+				await agenda.stop();
+
+				const result = await agenda.queryJobs({ name: 'queued-lock-test' });
+				const lockedAfterStop = result.jobs.filter(job => job.lockedAt).length;
+				expect(lockedAfterStop).toBe(1);
 			});
 		});
 

--- a/packages/agenda/test/shared/agenda-test-suite.ts
+++ b/packages/agenda/test/shared/agenda-test-suite.ts
@@ -465,6 +465,103 @@ export function agendaTestSuite(config: AgendaTestConfig): void {
 				const lockedAfterStop = result.jobs.filter(job => job.lockedAt).length;
 				expect(lockedAfterStop).toBe(1);
 			});
+
+			it('should clear locks for scheduled jobs waiting in the local queue on stop', async () => {
+				agenda.processEvery(1000);
+				agenda.define('scheduled-queued-lock-test', async () => {
+					await delay(5000);
+				});
+
+				await agenda.schedule(new Date(Date.now() + 300), 'scheduled-queued-lock-test');
+				await agenda.start();
+
+				let lockedJobs = 0;
+				let runningJobs = 0;
+				const deadline = Date.now() + 5000;
+
+				do {
+					const stats = await agenda.getRunningStats();
+					lockedJobs = stats.lockedJobs as number;
+					runningJobs = stats.runningJobs as number;
+
+					if (lockedJobs === 1 && runningJobs === 0) {
+						break;
+					}
+
+					await delay(25);
+				} while (Date.now() < deadline);
+
+				expect(lockedJobs).toBe(1);
+				expect(runningJobs).toBe(0);
+
+				await agenda.stop();
+
+				const result = await agenda.queryJobs({ name: 'scheduled-queued-lock-test' });
+				expect(result.jobs[0].lockedAt).toBeFalsy();
+			});
+
+			it('should preserve locks for running scheduled jobs on stop', async () => {
+				agenda.define('scheduled-running-lock-test', async () => {
+					await delay(5000);
+				});
+
+				await agenda.start();
+				const startPromise = waitForEvent(agenda, 'start:scheduled-running-lock-test');
+				await agenda.schedule(new Date(Date.now() + 25), 'scheduled-running-lock-test');
+				await startPromise;
+
+				await agenda.stop();
+
+				const result = await agenda.queryJobs({ name: 'scheduled-running-lock-test' });
+				expect(result.jobs[0].lockedAt).toBeTruthy();
+			});
+
+			it('should preserve locks for running repeat jobs on stop', async () => {
+				agenda.define('repeat-running-lock-test', async () => {
+					await delay(5000);
+				});
+
+				const startPromise = waitForEvent(agenda, 'start:repeat-running-lock-test');
+				await agenda.every('1 second', 'repeat-running-lock-test');
+				await agenda.start();
+				await startPromise;
+
+				await agenda.stop();
+
+				const result = await agenda.queryJobs({ name: 'repeat-running-lock-test' });
+				expect(result.jobs[0].repeatInterval).toBe('1 second');
+				expect(result.jobs[0].lockedAt).toBeTruthy();
+			});
+
+			it('should preserve locks for running retry jobs on stop', async () => {
+				let attempts = 0;
+
+				agenda.define(
+					'retry-running-lock-test',
+					async () => {
+						attempts++;
+						if (attempts === 1) {
+							throw new Error('first attempt fails');
+						}
+						await delay(5000);
+					},
+					{
+						backoff: () => 50
+					}
+				);
+
+				const retryStartPromise = waitForEvents(agenda, 'start:retry-running-lock-test', 2);
+				await agenda.start();
+				await agenda.now('retry-running-lock-test');
+				await retryStartPromise;
+
+				await agenda.stop();
+
+				const result = await agenda.queryJobs({ name: 'retry-running-lock-test' });
+				expect(attempts).toBe(2);
+				expect(result.jobs[0].failCount).toBe(1);
+				expect(result.jobs[0].lockedAt).toBeTruthy();
+			});
 		});
 
 		describe('concurrency', () => {


### PR DESCRIPTION


## Description 
#1778

- Updated the job unlocking mechanism to only unlock jobs that are held locally and not currently running.
- Enhanced test cases to verify that locks are preserved for running jobs during the stop process and that queued jobs maintain their locks as expected.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Added changeset if needed (`pnpm changeset`)
- [x] Updated documentation if needed
