### PR TITLE
fix(mongo-backend): explicit set null values and avoid relying on the ignoreUndefined flag

### DIFF
--- a/.changeset/stale-rules-matter.md
+++ b/.changeset/stale-rules-matter.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/mongo-backend': patch
+---
+
+Extended the saved Job type to have explicit null values instead of undefined and stopped relying on the MongoDb driver "ignoreUndefined" flag to set them

--- a/packages/mongo-backend/src/MongoJobRepository.ts
+++ b/packages/mongo-backend/src/MongoJobRepository.ts
@@ -80,22 +80,22 @@ function computeJobObj<DATA = unknown>(job: WithId<MongoJobDocument>): JobParame
 		nextRunAt: job.nextRunAt,
 		type: job.type,
 		data: job.data as DATA,
-		lockedAt: job.lockedAt || undefined,
-		lastFinishedAt: job.lastFinishedAt || undefined,
-		failedAt: job.failedAt || undefined,
-		failCount: job.failCount || undefined,
-		failReason: job.failReason || undefined,
-		repeatTimezone: job.repeatTimezone || undefined,
-		lastRunAt: job.lastRunAt || undefined,
-		repeatInterval: job.repeatInterval || undefined,
-		repeatAt: job.repeatAt || undefined,
-		disabled: job.disabled || undefined,
-		progress: job.progress || undefined,
-		unique: job.unique || undefined,
-		uniqueOpts: job.uniqueOpts || undefined,
-		lastModifiedBy: job.lastModifiedBy || undefined,
-		fork: job.fork || undefined,
-		debounceStartedAt: job.debounceStartedAt || undefined
+		lockedAt: job.lockedAt ?? undefined,
+		lastFinishedAt: job.lastFinishedAt ?? undefined,
+		failedAt: job.failedAt ?? undefined,
+		failCount: job.failCount ?? undefined,
+		failReason: job.failReason ?? undefined,
+		repeatTimezone: job.repeatTimezone ?? undefined,
+		lastRunAt: job.lastRunAt ?? undefined,
+		repeatInterval: job.repeatInterval ?? undefined,
+		repeatAt: job.repeatAt ?? undefined,
+		disabled: job.disabled ?? undefined,
+		progress: job.progress ?? undefined,
+		unique: job.unique ?? undefined,
+		uniqueOpts: job.uniqueOpts ?? undefined,
+		lastModifiedBy: job.lastModifiedBy ?? undefined,
+		fork: job.fork ?? undefined,
+		debounceStartedAt: job.debounceStartedAt ?? undefined
 	};
 }
 
@@ -485,7 +485,7 @@ export class MongoJobRepository implements JobRepository {
 		const update: UpdateFilter<MongoJobDocument> = {
 			$set: {
         lockedAt: new Date(),
-        lastModifiedBy: options?.lastModifiedBy || null
+        lastModifiedBy: options?.lastModifiedBy ?? null
       }
 		};
 		const findOptions: FindOneAndUpdateOptions = {
@@ -534,7 +534,7 @@ export class MongoJobRepository implements JobRepository {
 		const JOB_PROCESS_SET_QUERY: UpdateFilter<MongoJobDocument> = {
 			$set: {
         lockedAt: lockTime,
-        lastModifiedBy: options?.lastModifiedBy || null
+        lastModifiedBy: options?.lastModifiedBy ?? null
       }
 		};
 
@@ -640,15 +640,15 @@ export class MongoJobRepository implements JobRepository {
 		}
 		const id = new ObjectId(job._id.toString());
 		const $set = {
-			lockedAt: (job.lockedAt && new Date(job.lockedAt)) || null,
-			nextRunAt: (job.nextRunAt && new Date(job.nextRunAt)) || null,
-			lastRunAt: (job.lastRunAt && new Date(job.lastRunAt)) || null,
-			progress: job.progress,
-			failReason: job.failReason,
-			failCount: job.failCount,
-			failedAt: job.failedAt && new Date(job.failedAt),
-			lastFinishedAt: (job.lastFinishedAt && new Date(job.lastFinishedAt)) || null,
-			lastModifiedBy: options?.lastModifiedBy
+			lockedAt: job.lockedAt ?? null,
+			nextRunAt: job.nextRunAt ?? null,
+			lastRunAt: job.lastRunAt ?? null,
+			progress: job.progress ?? null,
+			failReason: job.failReason ?? null,
+			failCount: job.failCount ?? null,
+			failedAt: job.failedAt ?? null,
+			lastFinishedAt: job.lastFinishedAt ?? null,
+			lastModifiedBy: options?.lastModifiedBy ?? null
 		};
 
 		log('[job %s] save job state: \n%O', job._id, $set);
@@ -685,23 +685,23 @@ export class MongoJobRepository implements JobRepository {
 			// Add lastModifiedBy and make all undefined properties to null for MongoDB storage
 			const propsWithModifier = {
 				...props,
-        lockedAt: props.lockedAt || null,
-        lastFinishedAt: props.lastFinishedAt || null,
-        failedAt: props.failedAt || null,
-        failCount: props.failCount || null,
-        failReason: props.failReason || null,
-        repeatTimezone: props.repeatTimezone || null,
-        lastRunAt: props.lastRunAt || null,
-        repeatInterval: props.repeatInterval || null,
-        repeatAt: props.repeatAt || null,
-        disabled: props.disabled || null,
-        progress: props.progress || null,
-        debounceStartedAt: props.debounceStartedAt || null,
-        fork: props.fork || null,
-        startDate: props.startDate || null,
-        endDate: props.endDate || null,
-        skipDays: props.skipDays || null,
-				lastModifiedBy: options?.lastModifiedBy || null
+        lockedAt: props.lockedAt ?? null,
+        lastFinishedAt: props.lastFinishedAt ?? null,
+        failedAt: props.failedAt ?? null,
+        failCount: props.failCount ?? null,
+        failReason: props.failReason ?? null,
+        repeatTimezone: props.repeatTimezone ?? null,
+        lastRunAt: props.lastRunAt ?? null,
+        repeatInterval: props.repeatInterval ?? null,
+        repeatAt: props.repeatAt ?? null,
+        disabled: props.disabled ?? null,
+        progress: props.progress ?? null,
+        debounceStartedAt: props.debounceStartedAt ?? null,
+        fork: props.fork ?? null,
+        startDate: props.startDate ?? null,
+        endDate: props.endDate ?? null,
+        skipDays: props.skipDays ?? null,
+				lastModifiedBy: options?.lastModifiedBy ?? null
 			};
 
 			log('[job %s] set job props: \n%O', _id, propsWithModifier);
@@ -811,7 +811,7 @@ export class MongoJobRepository implements JobRepository {
 							log('maxWait exceeded (%dms >= %dms), forcing immediate execution', timeSinceStart, debounce.maxWait);
 							newNextRunAt = now;
 							// Reset debounceStartedAt for the next cycle
-							(propsWithModifier as Partial<MongoJobDocument>).debounceStartedAt = undefined;
+							(propsWithModifier as Partial<MongoJobDocument>).debounceStartedAt = null;
 						} else {
 							// Normal debounce: schedule for delay ms from now
 							newNextRunAt = new Date(now.getTime() + debounce.delay);

--- a/packages/mongo-backend/src/MongoJobRepository.ts
+++ b/packages/mongo-backend/src/MongoJobRepository.ts
@@ -26,7 +26,7 @@ import type {
 	SortDirection
 } from 'agenda';
 import { toJobId, computeJobState } from 'agenda';
-import type { MongoJobRepositoryConfig } from './types.js';
+import type { MongoJobRepositoryConfig, OptionalKeysToNullable } from './types.js';
 import { hasMongoProtocol } from './hasMongoProtocol.js';
 
 const log = debug('agenda:mongo:repository');
@@ -80,22 +80,22 @@ function computeJobObj<DATA = unknown>(job: WithId<MongoJobDocument>): JobParame
 		nextRunAt: job.nextRunAt,
 		type: job.type,
 		data: job.data as DATA,
-		lockedAt: job.lockedAt,
-		lastFinishedAt: job.lastFinishedAt,
+		lockedAt: job.lockedAt || undefined,
+		lastFinishedAt: job.lastFinishedAt || undefined,
 		failedAt: job.failedAt || undefined,
 		failCount: job.failCount || undefined,
 		failReason: job.failReason || undefined,
-		repeatTimezone: job.repeatTimezone,
-		lastRunAt: job.lastRunAt,
-		repeatInterval: job.repeatInterval,
-		repeatAt: job.repeatAt,
-		disabled: job.disabled,
-		progress: job.progress,
-		unique: job.unique,
-		uniqueOpts: job.uniqueOpts,
-		lastModifiedBy: job.lastModifiedBy,
-		fork: job.fork,
-		debounceStartedAt: job.debounceStartedAt
+		repeatTimezone: job.repeatTimezone || undefined,
+		lastRunAt: job.lastRunAt || undefined,
+		repeatInterval: job.repeatInterval || undefined,
+		repeatAt: job.repeatAt || undefined,
+		disabled: job.disabled || undefined,
+		progress: job.progress || undefined,
+		unique: job.unique || undefined,
+		uniqueOpts: job.uniqueOpts || undefined,
+		lastModifiedBy: job.lastModifiedBy || undefined,
+		fork: job.fork || undefined,
+		debounceStartedAt: job.debounceStartedAt || undefined
 	};
 }
 
@@ -103,7 +103,7 @@ function computeJobObj<DATA = unknown>(job: WithId<MongoJobDocument>): JobParame
  * Internal MongoDB document type with ObjectId for _id
  * This is what's actually stored in MongoDB, separate from the public JobParameters interface
  */
-type MongoJobDocument = Omit<JobParameters, '_id'> & { _id?: ObjectId };
+type MongoJobDocument = Omit<OptionalKeysToNullable<JobParameters>, '_id'> & { _id?: ObjectId };
 
 /**
  * @class
@@ -483,7 +483,10 @@ export class MongoJobRepository implements JobRepository {
 
 		// Update / options for the MongoDB query
 		const update: UpdateFilter<MongoJobDocument> = {
-			$set: { lockedAt: new Date(), lastModifiedBy: options?.lastModifiedBy }
+			$set: {
+        lockedAt: new Date(),
+        lastModifiedBy: options?.lastModifiedBy || null
+      }
 		};
 		const findOptions: FindOneAndUpdateOptions = {
 			returnDocument: 'after',
@@ -529,7 +532,10 @@ export class MongoJobRepository implements JobRepository {
 		 * Query used to set a job as locked
 		 */
 		const JOB_PROCESS_SET_QUERY: UpdateFilter<MongoJobDocument> = {
-			$set: { lockedAt: lockTime, lastModifiedBy: options?.lastModifiedBy }
+			$set: {
+        lockedAt: lockTime,
+        lastModifiedBy: options?.lastModifiedBy || null
+      }
 		};
 
 		/**
@@ -634,14 +640,14 @@ export class MongoJobRepository implements JobRepository {
 		}
 		const id = new ObjectId(job._id.toString());
 		const $set = {
-			lockedAt: (job.lockedAt && new Date(job.lockedAt)) || undefined,
-			nextRunAt: (job.nextRunAt && new Date(job.nextRunAt)) || undefined,
-			lastRunAt: (job.lastRunAt && new Date(job.lastRunAt)) || undefined,
+			lockedAt: (job.lockedAt && new Date(job.lockedAt)) || null,
+			nextRunAt: (job.nextRunAt && new Date(job.nextRunAt)) || null,
+			lastRunAt: (job.lastRunAt && new Date(job.lastRunAt)) || null,
 			progress: job.progress,
 			failReason: job.failReason,
 			failCount: job.failCount,
 			failedAt: job.failedAt && new Date(job.failedAt),
-			lastFinishedAt: (job.lastFinishedAt && new Date(job.lastFinishedAt)) || undefined,
+			lastFinishedAt: (job.lastFinishedAt && new Date(job.lastFinishedAt)) || null,
 			lastModifiedBy: options?.lastModifiedBy
 		};
 
@@ -676,10 +682,26 @@ export class MongoJobRepository implements JobRepository {
 			// Extract the ID and unique fields (not persisted directly)
 			const { _id, unique, uniqueOpts, ...props } = job;
 
-			// Add lastModifiedBy
+			// Add lastModifiedBy and make all undefined properties to null for MongoDB storage
 			const propsWithModifier = {
 				...props,
-				lastModifiedBy: options?.lastModifiedBy
+        lockedAt: props.lockedAt || null,
+        lastFinishedAt: props.lastFinishedAt || null,
+        failedAt: props.failedAt || null,
+        failCount: props.failCount || null,
+        failReason: props.failReason || null,
+        repeatTimezone: props.repeatTimezone || null,
+        lastRunAt: props.lastRunAt || null,
+        repeatInterval: props.repeatInterval || null,
+        repeatAt: props.repeatAt || null,
+        disabled: props.disabled || null,
+        progress: props.progress || null,
+        debounceStartedAt: props.debounceStartedAt || null,
+        fork: props.fork || null,
+        startDate: props.startDate || null,
+        endDate: props.endDate || null,
+        skipDays: props.skipDays || null,
+				lastModifiedBy: options?.lastModifiedBy || null
 			};
 
 			log('[job %s] set job props: \n%O', _id, propsWithModifier);

--- a/packages/mongo-backend/src/index.ts
+++ b/packages/mongo-backend/src/index.ts
@@ -35,7 +35,12 @@ export { MongoJobRepository } from './MongoJobRepository.js';
 export { MongoJobLogger } from './MongoJobLogger.js';
 export { MongoChangeStreamNotificationChannel } from './MongoChangeStreamNotificationChannel.js';
 
-export type { MongoBackendConfig, MongoJobRepositoryConfig, MongoDbConfig } from './types.js';
+export type {
+	MongoBackendConfig,
+	MongoJobRepositoryConfig,
+	MongoDbConfig,
+	OptionalKeysToNullable,
+} from './types.js';
 export type { MongoChangeStreamNotificationChannelConfig } from './MongoChangeStreamNotificationChannel.js';
 
 // Re-export mongodb types that users might need

--- a/packages/mongo-backend/src/types.ts
+++ b/packages/mongo-backend/src/types.ts
@@ -2,6 +2,13 @@ import type { Db, MongoClientOptions } from 'mongodb';
 import type { SortDirection } from 'agenda';
 
 /**
+ * Adds `null` to optional properties while leaving required properties unchanged.
+ */
+export type OptionalKeysToNullable<T extends object> = {
+	[K in keyof T]: object extends Pick<T, K> ? T[K] | null : T[K];
+};
+
+/**
  * Configuration options for MongoBackend
  */
 

--- a/packages/mongo-backend/test/mongo-backend.test.ts
+++ b/packages/mongo-backend/test/mongo-backend.test.ts
@@ -1,5 +1,5 @@
-import { expect, describe, it, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
-import { Db, MongoClient, ObjectId } from 'mongodb';
+import { expect, describe, it, beforeAll, afterAll, beforeEach, afterEach, assert } from 'vitest';
+import { Db, DbOptions, MongoClient, ObjectId } from 'mongodb';
 import { randomUUID } from 'crypto';
 import { InMemoryNotificationChannel } from 'agenda';
 import { MongoBackend, MongoJobRepository, MongoJobLogger } from '../src/index.js';
@@ -15,7 +15,7 @@ import { fullAgendaTestSuite, jobLoggerTestSuite } from 'agenda/testing';
 const TEST_COLLECTION = 'agendaJobs';
 
 // Helper to create a fresh database connection (used by MongoDB-specific tests)
-async function createTestDb(): Promise<{ db: Db; client: MongoClient; disconnect: () => Promise<void> }> {
+async function createTestDb(options?: DbOptions): Promise<{ db: Db; client: MongoClient; disconnect: () => Promise<void> }> {
 	const baseUri = process.env.MONGO_URI;
 	if (!baseUri) {
 		throw new Error('MONGO_URI not set. Ensure global setup is configured.');
@@ -30,7 +30,7 @@ async function createTestDb(): Promise<{ db: Db; client: MongoClient; disconnect
 	const uri = url.toString();
 
 	const client = await MongoClient.connect(uri);
-	const db = client.db(dbName);
+	const db = client.db(dbName, options);
 
 	return {
 		db,
@@ -379,6 +379,45 @@ describe('MongoBackend', () => {
 			const collectionNames = collections.map(c => c.name);
 			expect(collectionNames).toContain(TEST_COLLECTION);
 		});
+
+    it('should explicitly set optional properties to null and avoid relying on the "ignoreUndefined" flag', async () => {
+      const {
+        db: dbWithIgnoreUndefined,
+        disconnect: disconnectDbWithIgnoreUndefined
+      } = await createTestDb({ ignoreUndefined: true });
+
+      backend = new MongoBackend({
+        mongo: dbWithIgnoreUndefined,
+        collection: TEST_COLLECTION
+      });
+
+      await backend.connect();
+      await backend.repository.saveJob({
+        name: 'concurrent-test',
+        priority: 0,
+        nextRunAt: new Date(Date.now() - 1000),
+        type: 'normal',
+        data: { id: 1, ignoredField: undefined }
+      }, undefined);
+
+      const job = await dbWithIgnoreUndefined.collection(TEST_COLLECTION).findOne();
+
+      assert(job !== null, 'Job should exist in the collection');
+      expect(job.lockedAt).toBeNull();
+      expect(job.lastFinishedAt).toBeNull();
+      expect(job.failedAt).toBeNull();
+      expect(job.failCount).toBeNull();
+      expect(job.failReason).toBeNull();
+      expect(job.repeatTimezone).toBeNull();
+      expect(job.lastRunAt).toBeNull();
+      expect(job.repeatInterval).toBeNull();
+      expect(job.repeatAt).toBeNull();
+      expect(job.disabled).toBeNull();
+      expect(job.progress).toBeNull();
+      expect(job.data.ignoredField).toBeUndefined();
+
+      await disconnectDbWithIgnoreUndefined();
+    });
 	});
 
 	describe('ensureIndex option', () => {


### PR DESCRIPTION
Made all optional Job keys `null` in the MongoDB repository so that the behaviour is not influenced by the native `ignoreUndefined` flag of the MongoDB driver

## Description

### Context
The MongoDB driver has a flag called "ignoreUndefined".
This flag ignores all the `undefined` values that are set in the provided JSON objects when serialized to the MongoDB server, instead of setting them to `null`.

This flag can be set by the consumers of the Agenda library to persist arbitrary objects in the Job data field.
The presence of the `ignoreUndefined` flag makes the Agenda MongoDB repository act in unexpected ways since it tries to save the Job native options by setting them as `undefined`.

This creates all kinds of issues with repeating jobs or jobs that aren't removed from the collection, since all the fields expected to be set to `null` are instead left unchanged in the documents persisted in the Mongo collection.

See https://github.com/agenda/agenda/issues/1710

### Changes
- Change all the optional Job fields to be declared as null in the MongoDB repository
- Change all the write operations to set null as the default value for the optional fields
- Change the mapping from the Mongo document to coerce null values to undefined
- Add test coverage

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Added changeset if needed (`pnpm changeset`)
- [x] Updated documentation if needed
