### PR TITLE
docs: fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2142,8 +2142,8 @@ process.on('message', message => {
 ```
 
 Ensure to only define job definitions during this step, otherwise you create some
-overhead (e.g. if you create new jobs inside the defintion files). That's why I call
-the defintion file with agenda and a second paramter that is set to true. If this
+overhead (e.g. if you create new jobs inside the definition files). That's why I call
+the definition file with agenda and a second parameter that is set to true. If this
 parameter is true, I do not initialize any jobs (create jobs etc..)
 
 2.) to use this, you have to enable it on a job. Set forkMode to true:


### PR DESCRIPTION
## Summary

- fix two `defintion` typos in the README sandboxed worker section
- fix one `paramter` typo in the same paragraph

## Verification

- `if grep -nE "\\b(defintion|paramter)\\b" README.md; then echo "FAIL: README contains spelling typos"; exit 1; else echo "PASS: README typo check clean"; fi`
- `git diff --check`

No runtime tests were run because this is a README-only documentation typo fix.
