### PR TITLE
fix(mongo-backend): conform to MongoDB Stable API

### DIFF
--- a/.changeset/mongo-stable-api.md
+++ b/.changeset/mongo-stable-api.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/mongo-backend': patch
+---
+
+Conform to the MongoDB Stable API: replace the `distinct` command in `getDistinctJobNames()` with a `$group` aggregation, so the backend works with clients configured with `apiStrict: true`

--- a/packages/mongo-backend/src/MongoJobRepository.ts
+++ b/packages/mongo-backend/src/MongoJobRepository.ts
@@ -313,7 +313,12 @@ export class MongoJobRepository implements JobRepository {
 	 * Get all distinct job names
 	 */
 	async getDistinctJobNames(): Promise<string[]> {
-		return this.collection.distinct('name');
+		// Uses $group instead of the distinct command, which is not part of
+		// the MongoDB Stable API and fails with apiStrict: true
+		const results = await this.collection
+			.aggregate<{ _id: string }>([{ $group: { _id: '$name' } }])
+			.toArray();
+		return results.map(result => result._id);
 	}
 
 	async getQueueSize(): Promise<number> {

--- a/packages/mongo-backend/test/helpers/forkHelper.ts
+++ b/packages/mongo-backend/test/helpers/forkHelper.ts
@@ -1,5 +1,6 @@
 import { Agenda } from 'agenda';
 import { MongoBackend } from '../../src/index.js';
+import { testMongoClientOptions } from './testMongoClientOptions.js';
 
 process.on('message', message => {
 	if (message === 'cancel') {
@@ -20,7 +21,8 @@ try {
 	const agenda = new Agenda({
 		backend: new MongoBackend({
 			address: process.env.DB_CONNECTION!,
-			collection: process.env.DB_COLLECTION || 'agendaJobs'
+			collection: process.env.DB_COLLECTION || 'agendaJobs',
+			options: testMongoClientOptions
 		}),
 		name: `subworker-${name}`,
 		forkedWorker: true

--- a/packages/mongo-backend/test/helpers/testMongoClientOptions.ts
+++ b/packages/mongo-backend/test/helpers/testMongoClientOptions.ts
@@ -1,0 +1,16 @@
+import { ServerApiVersion, type MongoClientOptions } from 'mongodb';
+
+/**
+ * MongoDB client options used by all test connections.
+ *
+ * Enforces strict Stable API conformance, so that any command not included
+ * in Stable API V1 (e.g. `distinct`) fails immediately with an
+ * APIStrictError instead of slipping through unnoticed.
+ */
+export const testMongoClientOptions: MongoClientOptions = {
+	serverApi: {
+		version: ServerApiVersion.v1,
+		strict: true,
+		deprecationErrors: true
+	}
+};

--- a/packages/mongo-backend/test/mongo-backend.test.ts
+++ b/packages/mongo-backend/test/mongo-backend.test.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'crypto';
 import { InMemoryNotificationChannel } from 'agenda';
 import { MongoBackend, MongoJobRepository, MongoJobLogger } from '../src/index.js';
 import { fullAgendaTestSuite, jobLoggerTestSuite } from 'agenda/testing';
+import { testMongoClientOptions } from './helpers/testMongoClientOptions.js';
 
 /**
  * MongoDB backend tests.
@@ -29,7 +30,7 @@ async function createTestDb(options?: DbOptions): Promise<{ db: Db; client: Mong
 	url.pathname = `/${dbName}`;
 	const uri = url.toString();
 
-	const client = await MongoClient.connect(uri);
+	const client = await MongoClient.connect(uri, testMongoClientOptions);
 	const db = client.db(dbName, options);
 
 	return {
@@ -63,7 +64,7 @@ beforeAll(async () => {
 	url.pathname = `/${dbName}`;
 	sharedDbUri = url.toString();
 
-	const client = await MongoClient.connect(sharedDbUri);
+	const client = await MongoClient.connect(sharedDbUri, testMongoClientOptions);
 	sharedDb = client.db(dbName);
 	disconnectShared = async () => {
 		await sharedDb.dropDatabase();

--- a/packages/mongo-backend/test/mongo-changestream.test.ts
+++ b/packages/mongo-backend/test/mongo-changestream.test.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto';
 import type { JobNotification, NotificationChannelState } from 'agenda';
 import { toJobId } from 'agenda';
 import { MongoChangeStreamNotificationChannel } from '../src/index.js';
+import { testMongoClientOptions } from './helpers/testMongoClientOptions.js';
 
 /**
  * Interface for accessing private/protected properties in tests.
@@ -40,7 +41,7 @@ async function createTestDb(): Promise<{ db: Db; client: MongoClient; disconnect
 	url.pathname = `/${dbName}`;
 	const uri = url.toString();
 
-	const client = await MongoClient.connect(uri);
+	const client = await MongoClient.connect(uri, testMongoClientOptions);
 	const db = client.db(dbName);
 
 	return {
@@ -264,7 +265,7 @@ describe('MongoChangeStreamNotificationChannel change stream tests', () => {
 		url.pathname = `/${dbName}`;
 		const uri = url.toString();
 
-		client = await MongoClient.connect(uri);
+		client = await MongoClient.connect(uri, testMongoClientOptions);
 		db = client.db(dbName);
 	});
 


### PR DESCRIPTION
## Description

Makes `@agendajs/mongo-backend` fully conform to the [MongoDB Stable API](https://www.mongodb.com/docs/manual/reference/stable-api/), so it works with clients configured with `apiStrict: true` and `deprecationErrors: true`.

- Replace the `distinct` command in `MongoJobRepository.getDistinctJobNames()` with an equivalent `$group` aggregation. `distinct` is not part of Stable API V1 and fails with an `APIStrictError` on strictly configured clients; `aggregate` is included.
- Guard against future regressions: all test connections (including the fork-mode worker) now use a shared `testMongoClientOptions` helper that enables `serverApi: { version: '1', strict: true, deprecationErrors: true }`. Since the tests run against a real `mongod` (via `mongodb-memory-server`), any non-conforming command introduced later fails the test suite immediately.

All other commands issued by the package (`find`, `findAndModify`, `insert`, `update`, `delete`, `aggregate`, `createIndexes`, change streams, etc.) were verified to be Stable API V1 conformant.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Added changeset if needed (`pnpm changeset`)
- [x] Updated documentation if needed