### PR TITLE
fix(mongo-backend): include startDate, endDate, skipDays in computeJo…

### DIFF
--- a/.changeset/mongo-date-constraint-fields.md
+++ b/.changeset/mongo-date-constraint-fields.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/mongo-backend': patch
+---
+
+Map `startDate`, `endDate` and `skipDays` from MongoDB documents to job objects so date constraints on repeating jobs survive a reload from the database (previously a repeating job with an `endDate` would keep running forever after its first execution)

--- a/packages/mongo-backend/src/MongoJobRepository.ts
+++ b/packages/mongo-backend/src/MongoJobRepository.ts
@@ -95,7 +95,10 @@ function computeJobObj<DATA = unknown>(job: WithId<MongoJobDocument>): JobParame
 		uniqueOpts: job.uniqueOpts ?? undefined,
 		lastModifiedBy: job.lastModifiedBy ?? undefined,
 		fork: job.fork ?? undefined,
-		debounceStartedAt: job.debounceStartedAt ?? undefined
+		debounceStartedAt: job.debounceStartedAt ?? undefined,
+		startDate: job.startDate ?? undefined,
+		endDate: job.endDate ?? undefined,
+		skipDays: job.skipDays ?? undefined
 	};
 }
 

--- a/packages/mongo-backend/test/mongo-backend.test.ts
+++ b/packages/mongo-backend/test/mongo-backend.test.ts
@@ -492,6 +492,50 @@ describe('MongoBackend', () => {
 			expect(doc.nextRunAt).toBeInstanceOf(Date);
 			expect(doc.lastRunAt).toBeInstanceOf(Date);
 		});
+
+		it('should preserve startDate, endDate and skipDays when loading jobs from the database', async () => {
+			const startDate = new Date('2026-01-01T00:00:00Z');
+			const endDate = new Date('2026-12-31T23:59:59Z');
+			const skipDays = [0, 6];
+
+			const saved = await backend.repository.saveJob({
+				name: 'date-constraint-test',
+				priority: 0,
+				nextRunAt: new Date(Date.now() - 1000),
+				type: 'normal',
+				repeatInterval: '1 day',
+				startDate,
+				endDate,
+				skipDays,
+				data: {}
+			}, undefined);
+
+			// Read back through every load path — the constraints must survive
+			const byId = await backend.repository.getJobById(saved._id!.toString());
+			assert(byId !== null, 'Job should be found by id');
+			expect(byId.startDate).toEqual(startDate);
+			expect(byId.endDate).toEqual(endDate);
+			expect(byId.skipDays).toEqual(skipDays);
+
+			const { jobs } = await backend.repository.queryJobs({ name: 'date-constraint-test' });
+			expect(jobs).toHaveLength(1);
+			expect(jobs[0].startDate).toEqual(startDate);
+			expect(jobs[0].endDate).toEqual(endDate);
+			expect(jobs[0].skipDays).toEqual(skipDays);
+
+			const now = new Date();
+			const next = await backend.repository.getNextJobToRun(
+				'date-constraint-test',
+				new Date(now.getTime() + 5000),
+				new Date(now.getTime() - 600000),
+				now,
+				undefined
+			);
+			assert(next !== undefined, 'Job should be returned by getNextJobToRun');
+			expect(next.startDate).toEqual(startDate);
+			expect(next.endDate).toEqual(endDate);
+			expect(next.skipDays).toEqual(skipDays);
+		});
 	});
 
 	describe('ensureIndex option', () => {


### PR DESCRIPTION
`computeJobObj` in `MongoJobRepository` does not map `startDate`, `endDate`, or `skipDays` from MongoDB documents to job objects.

These fields are written to MongoDB by `Job.save()` via `toJson()`, and are expected by `computeFromInterval()` in `utils/nextRunAt.js` to enforce date constraints. However, when jobs are loaded from the database (via `getNextJobToRun`, `getJobById`, `queryJobs`, `lockJob`), these fields are dropped.

## Impact

Any job with an `endDate` set will never stop running. After the first execution, `computeNextRunAt()` cannot see the `endDate` constraint because `attrs.endDate` is `undefined`.

## Type of Change

- [x] Bug fix

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Added changeset if needed (`pnpm changeset`)
- [x] Updated documentation if needed