### PR TITLE
fix(mongo-backend): harden null-value handling from #1783

### DIFF
--- a/.changeset/mongo-null-followup.md
+++ b/.changeset/mongo-null-followup.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/mongo-backend': patch
+---
+
+Follow-up to #1783: restore defensive `new Date()` coercion for date fields in `saveJobState` so untyped callers passing ISO strings cannot persist strings in date fields, and remove the internal `OptionalKeysToNullable` helper type from the public exports

--- a/packages/mongo-backend/src/MongoJobRepository.ts
+++ b/packages/mongo-backend/src/MongoJobRepository.ts
@@ -484,9 +484,9 @@ export class MongoJobRepository implements JobRepository {
 		// Update / options for the MongoDB query
 		const update: UpdateFilter<MongoJobDocument> = {
 			$set: {
-        lockedAt: new Date(),
-        lastModifiedBy: options?.lastModifiedBy ?? null
-      }
+				lockedAt: new Date(),
+				lastModifiedBy: options?.lastModifiedBy ?? null
+			}
 		};
 		const findOptions: FindOneAndUpdateOptions = {
 			returnDocument: 'after',
@@ -533,9 +533,9 @@ export class MongoJobRepository implements JobRepository {
 		 */
 		const JOB_PROCESS_SET_QUERY: UpdateFilter<MongoJobDocument> = {
 			$set: {
-        lockedAt: lockTime,
-        lastModifiedBy: options?.lastModifiedBy ?? null
-      }
+				lockedAt: lockTime,
+				lastModifiedBy: options?.lastModifiedBy ?? null
+			}
 		};
 
 		/**
@@ -640,14 +640,14 @@ export class MongoJobRepository implements JobRepository {
 		}
 		const id = new ObjectId(job._id.toString());
 		const $set = {
-			lockedAt: job.lockedAt ?? null,
-			nextRunAt: job.nextRunAt ?? null,
-			lastRunAt: job.lastRunAt ?? null,
+			lockedAt: job.lockedAt ? new Date(job.lockedAt) : null,
+			nextRunAt: job.nextRunAt ? new Date(job.nextRunAt) : null,
+			lastRunAt: job.lastRunAt ? new Date(job.lastRunAt) : null,
 			progress: job.progress ?? null,
 			failReason: job.failReason ?? null,
 			failCount: job.failCount ?? null,
-			failedAt: job.failedAt ?? null,
-			lastFinishedAt: job.lastFinishedAt ?? null,
+			failedAt: job.failedAt ? new Date(job.failedAt) : null,
+			lastFinishedAt: job.lastFinishedAt ? new Date(job.lastFinishedAt) : null,
 			lastModifiedBy: options?.lastModifiedBy ?? null
 		};
 
@@ -685,22 +685,22 @@ export class MongoJobRepository implements JobRepository {
 			// Add lastModifiedBy and make all undefined properties to null for MongoDB storage
 			const propsWithModifier = {
 				...props,
-        lockedAt: props.lockedAt ?? null,
-        lastFinishedAt: props.lastFinishedAt ?? null,
-        failedAt: props.failedAt ?? null,
-        failCount: props.failCount ?? null,
-        failReason: props.failReason ?? null,
-        repeatTimezone: props.repeatTimezone ?? null,
-        lastRunAt: props.lastRunAt ?? null,
-        repeatInterval: props.repeatInterval ?? null,
-        repeatAt: props.repeatAt ?? null,
-        disabled: props.disabled ?? null,
-        progress: props.progress ?? null,
-        debounceStartedAt: props.debounceStartedAt ?? null,
-        fork: props.fork ?? null,
-        startDate: props.startDate ?? null,
-        endDate: props.endDate ?? null,
-        skipDays: props.skipDays ?? null,
+				lockedAt: props.lockedAt ?? null,
+				lastFinishedAt: props.lastFinishedAt ?? null,
+				failedAt: props.failedAt ?? null,
+				failCount: props.failCount ?? null,
+				failReason: props.failReason ?? null,
+				repeatTimezone: props.repeatTimezone ?? null,
+				lastRunAt: props.lastRunAt ?? null,
+				repeatInterval: props.repeatInterval ?? null,
+				repeatAt: props.repeatAt ?? null,
+				disabled: props.disabled ?? null,
+				progress: props.progress ?? null,
+				debounceStartedAt: props.debounceStartedAt ?? null,
+				fork: props.fork ?? null,
+				startDate: props.startDate ?? null,
+				endDate: props.endDate ?? null,
+				skipDays: props.skipDays ?? null,
 				lastModifiedBy: options?.lastModifiedBy ?? null
 			};
 

--- a/packages/mongo-backend/src/index.ts
+++ b/packages/mongo-backend/src/index.ts
@@ -35,12 +35,7 @@ export { MongoJobRepository } from './MongoJobRepository.js';
 export { MongoJobLogger } from './MongoJobLogger.js';
 export { MongoChangeStreamNotificationChannel } from './MongoChangeStreamNotificationChannel.js';
 
-export type {
-	MongoBackendConfig,
-	MongoJobRepositoryConfig,
-	MongoDbConfig,
-	OptionalKeysToNullable,
-} from './types.js';
+export type { MongoBackendConfig, MongoJobRepositoryConfig, MongoDbConfig } from './types.js';
 export type { MongoChangeStreamNotificationChannelConfig } from './MongoChangeStreamNotificationChannel.js';
 
 // Re-export mongodb types that users might need

--- a/packages/mongo-backend/src/types.ts
+++ b/packages/mongo-backend/src/types.ts
@@ -3,6 +3,7 @@ import type { SortDirection } from 'agenda';
 
 /**
  * Adds `null` to optional properties while leaving required properties unchanged.
+ * @internal
  */
 export type OptionalKeysToNullable<T extends object> = {
 	[K in keyof T]: object extends Pick<T, K> ? T[K] | null : T[K];

--- a/packages/mongo-backend/test/mongo-backend.test.ts
+++ b/packages/mongo-backend/test/mongo-backend.test.ts
@@ -380,44 +380,118 @@ describe('MongoBackend', () => {
 			expect(collectionNames).toContain(TEST_COLLECTION);
 		});
 
-    it('should explicitly set optional properties to null and avoid relying on the "ignoreUndefined" flag', async () => {
-      const {
-        db: dbWithIgnoreUndefined,
-        disconnect: disconnectDbWithIgnoreUndefined
-      } = await createTestDb({ ignoreUndefined: true });
+		it('should explicitly set optional properties to null and avoid relying on the "ignoreUndefined" flag', async () => {
+			const {
+				db: dbWithIgnoreUndefined,
+				disconnect: disconnectDbWithIgnoreUndefined
+			} = await createTestDb({ ignoreUndefined: true });
 
-      backend = new MongoBackend({
-        mongo: dbWithIgnoreUndefined,
-        collection: TEST_COLLECTION
-      });
+			backend = new MongoBackend({
+				mongo: dbWithIgnoreUndefined,
+				collection: TEST_COLLECTION
+			});
 
-      await backend.connect();
-      await backend.repository.saveJob({
-        name: 'concurrent-test',
-        priority: 0,
-        nextRunAt: new Date(Date.now() - 1000),
-        type: 'normal',
-        data: { id: 1, ignoredField: undefined }
-      }, undefined);
+			await backend.connect();
+			await backend.repository.saveJob({
+				name: 'concurrent-test',
+				priority: 0,
+				nextRunAt: new Date(Date.now() - 1000),
+				type: 'normal',
+				data: { id: 1, ignoredField: undefined }
+			}, undefined);
 
-      const job = await dbWithIgnoreUndefined.collection(TEST_COLLECTION).findOne();
+			const job = await dbWithIgnoreUndefined.collection(TEST_COLLECTION).findOne();
 
-      assert(job !== null, 'Job should exist in the collection');
-      expect(job.lockedAt).toBeNull();
-      expect(job.lastFinishedAt).toBeNull();
-      expect(job.failedAt).toBeNull();
-      expect(job.failCount).toBeNull();
-      expect(job.failReason).toBeNull();
-      expect(job.repeatTimezone).toBeNull();
-      expect(job.lastRunAt).toBeNull();
-      expect(job.repeatInterval).toBeNull();
-      expect(job.repeatAt).toBeNull();
-      expect(job.disabled).toBeNull();
-      expect(job.progress).toBeNull();
-      expect(job.data.ignoredField).toBeUndefined();
+			assert(job !== null, 'Job should exist in the collection');
+			expect(job.lockedAt).toBeNull();
+			expect(job.lastFinishedAt).toBeNull();
+			expect(job.failedAt).toBeNull();
+			expect(job.failCount).toBeNull();
+			expect(job.failReason).toBeNull();
+			expect(job.repeatTimezone).toBeNull();
+			expect(job.lastRunAt).toBeNull();
+			expect(job.repeatInterval).toBeNull();
+			expect(job.repeatAt).toBeNull();
+			expect(job.disabled).toBeNull();
+			expect(job.progress).toBeNull();
+			expect(job.data.ignoredField).toBeUndefined();
 
-      await disconnectDbWithIgnoreUndefined();
-    });
+			await disconnectDbWithIgnoreUndefined();
+		});
+
+		it('should clear nextRunAt via saveJobState so completed one-time jobs are not re-run (#1710)', async () => {
+			const {
+				db: dbWithIgnoreUndefined,
+				disconnect: disconnectDbWithIgnoreUndefined
+			} = await createTestDb({ ignoreUndefined: true });
+
+			backend = new MongoBackend({
+				mongo: dbWithIgnoreUndefined,
+				collection: TEST_COLLECTION
+			});
+
+			await backend.connect();
+			const saved = await backend.repository.saveJob({
+				name: 'one-time-job',
+				priority: 0,
+				nextRunAt: new Date(Date.now() - 1000),
+				type: 'normal',
+				data: {}
+			}, undefined);
+
+			// Simulate what the job processor does on completion of a one-time job:
+			// computeNextRunAt() sets nextRunAt to null, then saveJobState persists it
+			await backend.repository.saveJobState({
+				...saved,
+				lockedAt: undefined,
+				nextRunAt: null,
+				lastRunAt: new Date(),
+				lastFinishedAt: new Date()
+			}, undefined);
+
+			const doc = await dbWithIgnoreUndefined.collection(TEST_COLLECTION).findOne({ name: 'one-time-job' });
+			assert(doc !== null, 'Job should exist in the collection');
+			expect(doc.nextRunAt).toBeNull();
+			expect(doc.lockedAt).toBeNull();
+			expect(doc.lastRunAt).toBeInstanceOf(Date);
+			expect(doc.lastFinishedAt).toBeInstanceOf(Date);
+
+			// The completed job must no longer match the runnable-job query
+			const now = new Date();
+			const next = await backend.repository.getNextJobToRun(
+				'one-time-job',
+				new Date(now.getTime() + 5000),
+				new Date(now.getTime() - 600000),
+				now,
+				undefined
+			);
+			expect(next).toBeUndefined();
+
+			await disconnectDbWithIgnoreUndefined();
+		});
+
+		it('should coerce date-like values to Date in saveJobState', async () => {
+			const saved = await backend.repository.saveJob({
+				name: 'date-coercion-test',
+				priority: 0,
+				nextRunAt: new Date(Date.now() - 1000),
+				type: 'normal',
+				data: {}
+			}, undefined);
+
+			// Untyped (plain JS) callers may pass ISO strings for date fields;
+			// saveJobState must coerce them so MongoDB stores real dates
+			await backend.repository.saveJobState({
+				...saved,
+				nextRunAt: new Date().toISOString() as unknown as Date,
+				lastRunAt: new Date().toISOString() as unknown as Date
+			}, undefined);
+
+			const doc = await db.collection(TEST_COLLECTION).findOne({ name: 'date-coercion-test' });
+			assert(doc !== null, 'Job should exist in the collection');
+			expect(doc.nextRunAt).toBeInstanceOf(Date);
+			expect(doc.lastRunAt).toBeInstanceOf(Date);
+		});
 	});
 
 	describe('ensureIndex option', () => {


### PR DESCRIPTION
## Description

Follow-up to #1783, addressing the review notes there. Fixes #1710.

### Changes
- **Restore defensive `new Date()` coercion in `saveJobState`** — the previous code wrapped date fields in `new Date(...)` before writing; #1783 dropped that. Untyped (plain JS) callers passing ISO strings would have persisted strings in date fields, silently breaking the `$lte` comparisons in the runnable-job query — the same class of bug #1783 fixed. Now: `job.lockedAt ? new Date(job.lockedAt) : null`.
- **Regression test for the original #1710 scenario** — a completed one-time job (`saveJobState` with `nextRunAt: null`, driver `ignoreUndefined: true`) persists `nextRunAt` as `null` and no longer matches `getNextJobToRun`. The test in #1783 only covered the insert path (`saveJob`).
- **Remove `OptionalKeysToNullable` from public exports** — internal serialization helper; unexporting now is free since it never shipped in a release.
- **Fix indentation** (spaces → tabs) in the blocks added by #1783.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests pass (`pnpm test`) — 247 passed
- [x] Linting passes (`pnpm lint`)
- [x] Added changeset if needed (`pnpm changeset`)
- [ ] Updated documentation if needed (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)