### PR TITLE
fix(postgres-backend,redis-backend): persist startDate, endDate and skipDays

### DIFF
--- a/.changeset/pg-redis-date-constraints.md
+++ b/.changeset/pg-redis-date-constraints.md
@@ -1,0 +1,6 @@
+---
+'@agendajs/postgres-backend': patch
+'@agendajs/redis-backend': patch
+---
+
+Persist and load `startDate`, `endDate` and `skipDays` so date constraints on repeating jobs are honored (previously these fields were silently dropped — a repeating job with an `endDate` would keep running forever). The PostgreSQL backend adds the `start_date`, `end_date` and `skip_days` columns automatically on connect for existing installations.

--- a/packages/postgres-backend/src/PostgresJobRepository.ts
+++ b/packages/postgres-backend/src/PostgresJobRepository.ts
@@ -21,6 +21,7 @@ import type { PostgresBackendConfig, PostgresJobRow } from './types.js';
 import {
 	getCreateTableSQL,
 	getCreateIndexesSQL,
+	getMigrationSQL,
 	getUpdateTimestampTriggerSQL
 } from './schema.js';
 
@@ -101,6 +102,12 @@ export class PostgresJobRepository implements JobRepository {
 		await client.query(getCreateTableSQL(this.tableName));
 		log('table created or already exists');
 
+		// Apply migrations for columns added after the initial schema
+		for (const sql of getMigrationSQL(this.tableName)) {
+			await client.query(sql);
+		}
+		log('migrations applied');
+
 		// Create indexes
 		for (const sql of getCreateIndexesSQL(this.tableName)) {
 			await client.query(sql);
@@ -157,7 +164,10 @@ export class PostgresJobRepository implements JobRepository {
 			progress: row.progress ?? undefined,
 			fork: row.fork ?? undefined,
 			lastModifiedBy: row.last_modified_by ?? undefined,
-			debounceStartedAt: row.debounce_started_at ?? undefined
+			debounceStartedAt: row.debounce_started_at ?? undefined,
+			startDate: row.start_date ?? undefined,
+			endDate: row.end_date ?? undefined,
+			skipDays: row.skip_days ?? undefined
 		};
 	}
 
@@ -632,7 +642,10 @@ export class PostgresJobRepository implements JobRepository {
 					 fail_reason = $12,
 					 fail_count = $13,
 					 failed_at = $14,
-					 last_modified_by = $15
+					 last_modified_by = $15,
+					 start_date = $16,
+					 end_date = $17,
+					 skip_days = $18
 				 WHERE id = $1 AND name = $2
 				 RETURNING *`,
 				[
@@ -650,7 +663,10 @@ export class PostgresJobRepository implements JobRepository {
 					props.failReason ?? null,
 					props.failCount ?? null,
 					props.failedAt || null,
-					options?.lastModifiedBy || null
+					options?.lastModifiedBy || null,
+					props.startDate || null,
+					props.endDate || null,
+					props.skipDays ? JSON.stringify(props.skipDays) : null
 				]
 			);
 
@@ -674,8 +690,9 @@ export class PostgresJobRepository implements JobRepository {
 			const result = await this.pool.query<PostgresJobRow>(
 				`INSERT INTO "${this.tableName}" (
 					name, priority, next_run_at, type, repeat_timezone,
-					repeat_interval, data, repeat_at, disabled, fork, last_modified_by
-				 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+					repeat_interval, data, repeat_at, disabled, fork, last_modified_by,
+					start_date, end_date, skip_days
+				 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 				 ON CONFLICT ((name)) WHERE type = 'single'
 				 DO UPDATE SET
 					priority = EXCLUDED.priority,
@@ -688,7 +705,10 @@ export class PostgresJobRepository implements JobRepository {
 					repeat_at = EXCLUDED.repeat_at,
 					disabled = EXCLUDED.disabled,
 					fork = EXCLUDED.fork,
-					last_modified_by = EXCLUDED.last_modified_by
+					last_modified_by = EXCLUDED.last_modified_by,
+					start_date = EXCLUDED.start_date,
+					end_date = EXCLUDED.end_date,
+					skip_days = EXCLUDED.skip_days
 				 RETURNING *`,
 				[
 					props.name,
@@ -701,7 +721,10 @@ export class PostgresJobRepository implements JobRepository {
 					props.repeatAt || null,
 					props.disabled || false,
 					props.fork || false,
-					options?.lastModifiedBy || null
+					options?.lastModifiedBy || null,
+					props.startDate || null,
+					props.endDate || null,
+					props.skipDays ? JSON.stringify(props.skipDays) : null
 				]
 			);
 
@@ -791,7 +814,10 @@ export class PostgresJobRepository implements JobRepository {
 						 disabled = $${paramIndex + 7},
 						 fork = $${paramIndex + 8},
 						 last_modified_by = $${paramIndex + 9},
-						 debounce_started_at = $${paramIndex + 10}
+						 debounce_started_at = $${paramIndex + 10},
+						 start_date = $${paramIndex + 11},
+						 end_date = $${paramIndex + 12},
+						 skip_days = $${paramIndex + 13}
 					 WHERE ${conditions.join(' AND ')}
 					 RETURNING *`,
 					[
@@ -806,7 +832,10 @@ export class PostgresJobRepository implements JobRepository {
 						props.disabled || false,
 						props.fork || false,
 						options?.lastModifiedBy || null,
-						debounceStartedAt
+						debounceStartedAt,
+						props.startDate || null,
+						props.endDate || null,
+						props.skipDays ? JSON.stringify(props.skipDays) : null
 					]
 				);
 
@@ -830,8 +859,9 @@ export class PostgresJobRepository implements JobRepository {
 				const result = await this.pool.query<PostgresJobRow>(
 					`INSERT INTO "${this.tableName}" (
 						name, priority, next_run_at, type, repeat_timezone,
-						repeat_interval, data, repeat_at, disabled, fork, last_modified_by, debounce_started_at
-					 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+						repeat_interval, data, repeat_at, disabled, fork, last_modified_by, debounce_started_at,
+						start_date, end_date, skip_days
+					 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 					 RETURNING *`,
 					[
 						props.name,
@@ -845,7 +875,10 @@ export class PostgresJobRepository implements JobRepository {
 						props.disabled || false,
 						props.fork || false,
 						options?.lastModifiedBy || null,
-						debounceStartedAt
+						debounceStartedAt,
+						props.startDate || null,
+						props.endDate || null,
+						props.skipDays ? JSON.stringify(props.skipDays) : null
 					]
 				);
 
@@ -858,8 +891,9 @@ export class PostgresJobRepository implements JobRepository {
 		const result = await this.pool.query<PostgresJobRow>(
 			`INSERT INTO "${this.tableName}" (
 				name, priority, next_run_at, type, repeat_timezone,
-				repeat_interval, data, repeat_at, disabled, fork, last_modified_by
-			 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+				repeat_interval, data, repeat_at, disabled, fork, last_modified_by,
+				start_date, end_date, skip_days
+			 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 			 RETURNING *`,
 			[
 				props.name,
@@ -872,7 +906,10 @@ export class PostgresJobRepository implements JobRepository {
 				props.repeatAt || null,
 				props.disabled || false,
 				props.fork || false,
-				options?.lastModifiedBy || null
+				options?.lastModifiedBy || null,
+				props.startDate || null,
+				props.endDate || null,
+				props.skipDays ? JSON.stringify(props.skipDays) : null
 			]
 		);
 

--- a/packages/postgres-backend/src/schema.ts
+++ b/packages/postgres-backend/src/schema.ts
@@ -25,10 +25,26 @@ export function getCreateTableSQL(tableName: string): string {
 			fork BOOLEAN DEFAULT FALSE,
 			last_modified_by VARCHAR(255),
 			debounce_started_at TIMESTAMPTZ,
+			start_date TIMESTAMPTZ,
+			end_date TIMESTAMPTZ,
+			skip_days JSONB,
 			created_at TIMESTAMPTZ DEFAULT NOW(),
 			updated_at TIMESTAMPTZ DEFAULT NOW()
 		);
 	`;
+}
+
+/**
+ * Migration statements for columns added after the initial schema.
+ * Safe to run repeatedly (ADD COLUMN IF NOT EXISTS) so existing
+ * installations pick up new columns on connect.
+ */
+export function getMigrationSQL(tableName: string): string[] {
+	return [
+		`ALTER TABLE "${tableName}" ADD COLUMN IF NOT EXISTS start_date TIMESTAMPTZ`,
+		`ALTER TABLE "${tableName}" ADD COLUMN IF NOT EXISTS end_date TIMESTAMPTZ`,
+		`ALTER TABLE "${tableName}" ADD COLUMN IF NOT EXISTS skip_days JSONB`
+	];
 }
 
 export function getCreateIndexesSQL(tableName: string): string[] {

--- a/packages/postgres-backend/src/types.ts
+++ b/packages/postgres-backend/src/types.ts
@@ -60,6 +60,9 @@ export interface PostgresJobRow {
 	fork: boolean;
 	last_modified_by: string | null;
 	debounce_started_at: Date | null;
+	start_date: Date | null;
+	end_date: Date | null;
+	skip_days: number[] | null;
 	created_at: Date;
 	updated_at: Date;
 }

--- a/packages/postgres-backend/test/postgres-backend.test.ts
+++ b/packages/postgres-backend/test/postgres-backend.test.ts
@@ -235,6 +235,78 @@ describe('PostgresBackend', () => {
 			expect(indexNames.some(n => n.includes('find_and_lock'))).toBe(true);
 			expect(indexNames.some(n => n.includes('single_job'))).toBe(true);
 		});
+
+		it('should preserve startDate, endDate and skipDays when loading jobs from the database', async () => {
+			const startDate = new Date('2026-01-01T00:00:00Z');
+			const endDate = new Date('2026-12-31T23:59:59Z');
+			const skipDays = [0, 6];
+
+			const saved = await backend.repository.saveJob({
+				name: 'date-constraint-test',
+				priority: 0,
+				nextRunAt: new Date(Date.now() - 1000),
+				type: 'normal',
+				repeatInterval: '1 day',
+				startDate,
+				endDate,
+				skipDays,
+				data: {}
+			}, undefined);
+
+			expect(saved.startDate).toEqual(startDate);
+			expect(saved.endDate).toEqual(endDate);
+			expect(saved.skipDays).toEqual(skipDays);
+
+			// Read back through every load path — the constraints must survive
+			const byId = await backend.repository.getJobById(saved._id!.toString());
+			expect(byId?.startDate).toEqual(startDate);
+			expect(byId?.endDate).toEqual(endDate);
+			expect(byId?.skipDays).toEqual(skipDays);
+
+			const { jobs } = await backend.repository.queryJobs({ name: 'date-constraint-test' });
+			expect(jobs).toHaveLength(1);
+			expect(jobs[0].startDate).toEqual(startDate);
+			expect(jobs[0].endDate).toEqual(endDate);
+			expect(jobs[0].skipDays).toEqual(skipDays);
+
+			const now = new Date();
+			const next = await backend.repository.getNextJobToRun(
+				'date-constraint-test',
+				new Date(now.getTime() + 5000),
+				new Date(now.getTime() - 600000),
+				now,
+				undefined
+			);
+			expect(next?.startDate).toEqual(startDate);
+			expect(next?.endDate).toEqual(endDate);
+			expect(next?.skipDays).toEqual(skipDays);
+		});
+
+		it('should add date constraint columns to pre-existing tables via migration', async () => {
+			// Simulate an existing installation created before the columns existed
+			await pool.query(`ALTER TABLE "${TEST_TABLE_NAME}" DROP COLUMN IF EXISTS start_date`);
+			await pool.query(`ALTER TABLE "${TEST_TABLE_NAME}" DROP COLUMN IF EXISTS end_date`);
+			await pool.query(`ALTER TABLE "${TEST_TABLE_NAME}" DROP COLUMN IF EXISTS skip_days`);
+
+			// Reconnect - initializeSchema should add the missing columns
+			const migratedBackend = new PostgresBackend({
+				connectionString: getConnectionString(),
+				tableName: TEST_TABLE_NAME,
+				channelName: TEST_CHANNEL_NAME
+			});
+			await migratedBackend.connect();
+
+			const result = await pool.query(
+				`SELECT column_name FROM information_schema.columns WHERE table_name = $1`,
+				[TEST_TABLE_NAME]
+			);
+			const columns = result.rows.map(r => r.column_name);
+			expect(columns).toContain('start_date');
+			expect(columns).toContain('end_date');
+			expect(columns).toContain('skip_days');
+
+			await migratedBackend.disconnect();
+		});
 	});
 });
 

--- a/packages/redis-backend/src/RedisJobRepository.ts
+++ b/packages/redis-backend/src/RedisJobRepository.ts
@@ -133,6 +133,13 @@ export class RedisJobRepository implements JobRepository {
 			debounceStartedAt:
 				data.debounceStartedAt && data.debounceStartedAt !== 'null'
 					? new Date(data.debounceStartedAt)
+					: undefined,
+			startDate:
+				data.startDate && data.startDate !== 'null' ? new Date(data.startDate) : undefined,
+			endDate: data.endDate && data.endDate !== 'null' ? new Date(data.endDate) : undefined,
+			skipDays:
+				data.skipDays && data.skipDays !== 'null'
+					? (JSON.parse(data.skipDays) as number[])
 					: undefined
 		};
 	}
@@ -167,6 +174,9 @@ export class RedisJobRepository implements JobRepository {
 			fork: String(job.fork ?? false),
 			lastModifiedBy: lastModifiedBy ?? 'null',
 			debounceStartedAt: job.debounceStartedAt?.toISOString() || 'null',
+			startDate: job.startDate?.toISOString() || 'null',
+			endDate: job.endDate?.toISOString() || 'null',
+			skipDays: job.skipDays ? JSON.stringify(job.skipDays) : 'null',
 			createdAt: now,
 			updatedAt: now
 		};
@@ -858,6 +868,9 @@ export class RedisJobRepository implements JobRepository {
 				disabled: String(props.disabled ?? false),
 				fork: String(props.fork ?? false),
 				lastModifiedBy: options?.lastModifiedBy ?? 'null',
+				startDate: props.startDate?.toISOString() || 'null',
+				endDate: props.endDate?.toISOString() || 'null',
+				skipDays: props.skipDays ? JSON.stringify(props.skipDays) : 'null',
 				updatedAt: now
 			};
 
@@ -902,6 +915,9 @@ export class RedisJobRepository implements JobRepository {
 						repeatAt: props.repeatAt ?? 'null',
 						disabled: String(props.disabled ?? false),
 						lastModifiedBy: options?.lastModifiedBy ?? 'null',
+						startDate: props.startDate?.toISOString() || 'null',
+						endDate: props.endDate?.toISOString() || 'null',
+						skipDays: props.skipDays ? JSON.stringify(props.skipDays) : 'null',
 						updatedAt: now.toISOString()
 					};
 
@@ -1030,6 +1046,9 @@ export class RedisJobRepository implements JobRepository {
 						disabled: String(props.disabled ?? false),
 						lastModifiedBy: options?.lastModifiedBy ?? 'null',
 						debounceStartedAt,
+						startDate: props.startDate?.toISOString() || 'null',
+						endDate: props.endDate?.toISOString() || 'null',
+						skipDays: props.skipDays ? JSON.stringify(props.skipDays) : 'null',
 						updatedAt: nowIso
 					};
 

--- a/packages/redis-backend/src/types.ts
+++ b/packages/redis-backend/src/types.ts
@@ -53,6 +53,9 @@ export interface RedisJobData {
 	fork: string;
 	lastModifiedBy: string | null;
 	debounceStartedAt: string | null;
+	startDate: string | null;
+	endDate: string | null;
+	skipDays: string | null;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/packages/redis-backend/test/redis-backend.test.ts
+++ b/packages/redis-backend/test/redis-backend.test.ts
@@ -273,6 +273,52 @@ describe('RedisBackend', () => {
 			const members = await redis.smembers(`${TEST_KEY_PREFIX}jobs:by_name:set-test`);
 			expect(members.length).toBe(1);
 		});
+
+		it('should preserve startDate, endDate and skipDays when loading jobs from the database', async () => {
+			const startDate = new Date('2026-01-01T00:00:00.000Z');
+			const endDate = new Date('2026-12-31T23:59:59.000Z');
+			const skipDays = [0, 6];
+
+			const saved = await backend.repository.saveJob({
+				name: 'date-constraint-test',
+				priority: 0,
+				nextRunAt: new Date(Date.now() - 1000),
+				type: 'normal',
+				repeatInterval: '1 day',
+				startDate,
+				endDate,
+				skipDays,
+				data: {}
+			});
+
+			expect(saved.startDate).toEqual(startDate);
+			expect(saved.endDate).toEqual(endDate);
+			expect(saved.skipDays).toEqual(skipDays);
+
+			// Read back through every load path — the constraints must survive
+			const byId = await backend.repository.getJobById(saved._id!.toString());
+			expect(byId?.startDate).toEqual(startDate);
+			expect(byId?.endDate).toEqual(endDate);
+			expect(byId?.skipDays).toEqual(skipDays);
+
+			const { jobs } = await backend.repository.queryJobs({ name: 'date-constraint-test' });
+			expect(jobs).toHaveLength(1);
+			expect(jobs[0].startDate).toEqual(startDate);
+			expect(jobs[0].endDate).toEqual(endDate);
+			expect(jobs[0].skipDays).toEqual(skipDays);
+
+			const now = new Date();
+			const next = await backend.repository.getNextJobToRun(
+				'date-constraint-test',
+				new Date(now.getTime() + 5000),
+				new Date(now.getTime() - 600000),
+				now,
+				undefined
+			);
+			expect(next?.startDate).toEqual(startDate);
+			expect(next?.endDate).toEqual(endDate);
+			expect(next?.skipDays).toEqual(skipDays);
+		});
 	});
 });
 


### PR DESCRIPTION
## Description

Companion to #1787. The mongo backend merely *dropped these fields on read* — the PostgreSQL and Redis backends don't handle `startDate`/`endDate`/`skipDays` **at all**: no columns, no serialization. Any date constraint set on a repeating job was silently discarded, so `computeFromInterval()` never saw it and a job with an `endDate` would keep running forever.

### Changes

**PostgreSQL**
- Add `start_date TIMESTAMPTZ`, `end_date TIMESTAMPTZ`, `skip_days JSONB` to the schema
- Auto-migrate existing installations on connect via `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` (new `getMigrationSQL()` in `schema.ts`, run by `initializeSchema`)
- Map the fields in `rowToJob` and all five write paths (update-by-id, single upsert, unique update, debounce insert, plain insert)

**Redis**
- Serialize/deserialize the fields in `jobToHash`/`hashToJob`
- Include them in the three partial-update paths in `saveJob`

**Tests**
- Round-trip test through every read path (`getJobById`, `queryJobs`, `getNextJobToRun`) for both backends
- PostgreSQL migration test: drops the columns to simulate a pre-existing table, reconnects, asserts they're re-added

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests pass (`pnpm test`) — postgres: 217 passed, redis: 214 passed
- [x] Linting passes (`pnpm lint`)
- [x] Added changeset if needed (`pnpm changeset`)
- [ ] Updated documentation if needed (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)