### PR TITLE
test: fix flaky 'ensure concurrency is filled up' with deadline loop

### DIFF
--- a/packages/agenda/test/shared/jobprocessor-test-suite.ts
+++ b/packages/agenda/test/shared/jobprocessor-test-suite.ts
@@ -240,26 +240,21 @@ export function jobProcessorTestSuite(config: JobProcessorTestConfig): void {
 
 			await agenda.start();
 
+			// Deadline loop instead of a fixed 2.5s race: the ramp-up speed depends
+			// on runner performance (the 2.5s variant flaked repeatedly in CI with
+			// ~80/90 running). The generous deadline only matters on failure; on a
+			// healthy run the loop exits as soon as the target is reached.
 			let runningJobs = 0;
-			const allJobsStarted = (async () => {
-				do {
-					runningJobs = (await agenda.getRunningStats()).runningJobs as number;
-					await delay(50);
-				} while (runningJobs < 90);
-				return 'all started';
-			})();
+			const deadline = Date.now() + 15000;
+			do {
+				runningJobs = (await agenda.getRunningStats()).runningJobs as number;
+				if (runningJobs >= 90) {
+					break;
+				}
+				await delay(50);
+			} while (Date.now() < deadline);
 
-			const result = await Promise.race([
-				allJobsStarted,
-				new Promise(resolve => {
-					setTimeout(
-						() => resolve(`not all jobs started, currently running: ${runningJobs}`),
-						2500
-					);
-				})
-			]);
-
-			expect(result).toBe('all started');
+			expect(runningJobs, `not all jobs started, currently running: ${runningJobs}`).toBeGreaterThanOrEqual(90);
 		});
 	});
 }


### PR DESCRIPTION
## Description

The shared JobProcessor test `ensure concurrency is filled up` queues 250 jobs and required ≥90 running within a **fixed 2.5s** `Promise.race` window. Ramp-up speed depends on runner performance, and the test flaked twice in two days on CI (stuck at 80/90 on Node 18 yesterday, 83/90 on Node 24 today — both passed on rerun with identical code).

Replaced with a 15s deadline loop that breaks as soon as the target is reached — on a healthy run it exits in ~300ms (verified locally against the redis backend, the flake site), so the generous deadline only matters when something is actually wrong. All per-package vitest `testTimeout`s are ≥25s, so the deadline fits everywhere the shared suite runs.

No changeset: test infrastructure only.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests pass (`pnpm test`) — redis suite 219 passed locally, fixed test at 306ms
- [x] Linting passes (`pnpm lint`)
- [ ] Added changeset if needed (n/a — test-only)
- [ ] Updated documentation if needed (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)