### PR TITLE
fix(agenda): clear armed near-future job timers on stop()/drain()

### DIFF
--- a/.changeset/jobprocessor-timer-leak.md
+++ b/.changeset/jobprocessor-timer-leak.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+Clear armed near-future job timers on `stop()`/`drain()`. Previously the JobProcessor armed an untracked `setTimeout` for jobs due within the `processEvery` window; it was never cleared, kept the event loop alive after `stop()`, and for recurring jobs with an interval ≤ `processEvery` could re-arm itself indefinitely — so the process never exited. Timers are now tracked, cleared on teardown, and `unref`'d so an armed timer alone can never block process exit.

--- a/packages/agenda/src/JobProcessor.ts
+++ b/packages/agenda/src/JobProcessor.ts
@@ -91,6 +91,14 @@ export class JobProcessor {
 
 	private processInterval?: ReturnType<typeof setInterval>;
 
+	/**
+	 * Timers armed for jobs whose nextRunAt is in the near future. Tracked so
+	 * stop()/drain() can clear them - an uncleared timer keeps the event loop
+	 * alive and can re-arm itself for recurring jobs, preventing process exit
+	 * (see #1786).
+	 */
+	private nextRunTimers = new Set<ReturnType<typeof setTimeout>>();
+
 	private notificationChannel?: NotificationChannel;
 
 	private notificationUnsubscribe?: () => void;
@@ -117,6 +125,17 @@ export class JobProcessor {
 		}
 	}
 
+	/**
+	 * Clear all armed near-future job timers so nothing keeps the event loop
+	 * alive (or restarts processing) after the processor is stopped/drained.
+	 */
+	private clearNextRunTimers(): void {
+		for (const timer of this.nextRunTimers) {
+			clearTimeout(timer);
+		}
+		this.nextRunTimers.clear();
+	}
+
 	stop(): JobWithId[] {
 		log.extend('stop')('stop job processor', this.isRunning);
 		this.isRunning = false;
@@ -125,6 +144,8 @@ export class JobProcessor {
 			clearInterval(this.processInterval);
 			this.processInterval = undefined;
 		}
+
+		this.clearNextRunTimers();
 
 		// Unsubscribe from notifications
 		if (this.notificationUnsubscribe) {
@@ -158,6 +179,8 @@ export class JobProcessor {
 			clearInterval(this.processInterval);
 			this.processInterval = undefined;
 		}
+
+		this.clearNextRunTimers();
 
 		// Unsubscribe from notifications to stop receiving new job notifications
 		if (this.notificationUnsubscribe) {
@@ -531,15 +554,23 @@ export class JobProcessor {
 						// re add to queue (puts it at the right position in the queue)
 						this.jobQueue.insert(job);
 						// ensure every job gets a timer to run at the near future time (but also ensure this time is set only once)
-						if (!job.gotTimerToExecute) {
+						// Only arm while the processor is active (processInterval is cleared
+						// by stop()/drain()), so completing jobs cannot re-arm timers during
+						// teardown.
+						if (!job.gotTimerToExecute && this.processInterval) {
 							job.gotTimerToExecute = true;
-							setTimeout(
+							const timer = setTimeout(
 								() => {
+									this.nextRunTimers.delete(timer);
 									this.jobProcessing();
 								},
 								runIn > MAX_SAFE_32BIT_INTEGER ? MAX_SAFE_32BIT_INTEGER : runIn
 							); // check if runIn is higher than unsined 32 bit int, if so, use this time to recheck,
 							// because setTimeout will run in an overflow otherwise and reprocesses immediately
+							// Track the timer so stop()/drain() can clear it, and unref it so
+							// an armed timer alone never blocks process exit (#1786).
+							timer.unref?.();
+							this.nextRunTimers.add(timer);
 						}
 					}
 				}

--- a/packages/agenda/test/jobprocessor-timer-leak.test.ts
+++ b/packages/agenda/test/jobprocessor-timer-leak.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Regression test for #1786: JobProcessor armed a setTimeout for jobs whose
+ * nextRunAt is in the near future without tracking it, so stop()/drain() never
+ * cleared it. The timer kept the event loop alive (and could re-arm itself for
+ * recurring jobs), preventing the process from exiting after agenda.stop().
+ */
+import { describe, it, expect } from 'vitest';
+import { Agenda, toJobId } from '../src/index.js';
+import type { AgendaBackend, JobRepository, JobParameters } from '../src/index.js';
+
+const delay = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+/**
+ * Minimal repository whose getNextJobToRun hands out a single job with a
+ * nextRunAt in the near future (within the processEvery window), which is
+ * exactly the shape that makes the processor arm a near-future timer.
+ */
+class FutureJobRepo implements JobRepository {
+	public handedOut = false;
+
+	public runAt: Date = new Date();
+
+	async connect() {}
+
+	async queryJobs() {
+		return { jobs: [], total: 0 };
+	}
+
+	async getJobsOverview() {
+		return [];
+	}
+
+	async getDistinctJobNames() {
+		return [];
+	}
+
+	async getJobById() {
+		return null;
+	}
+
+	async getQueueSize() {
+		return 0;
+	}
+
+	async removeJobs() {
+		return 0;
+	}
+
+	async saveJob<DATA = unknown>(job: JobParameters<DATA>): Promise<JobParameters<DATA>> {
+		return { ...job, _id: job._id || toJobId('mock-id') };
+	}
+
+	async saveJobState() {}
+
+	async lockJob() {
+		return undefined;
+	}
+
+	async unlockJob() {}
+
+	async unlockJobs() {}
+
+	async getNextJobToRun(): Promise<JobParameters | undefined> {
+		if (this.handedOut) {
+			return undefined;
+		}
+		this.handedOut = true;
+		return {
+			_id: toJobId('future-job'),
+			name: 'timer-leak-test',
+			priority: 0,
+			type: 'normal',
+			nextRunAt: this.runAt,
+			lockedAt: new Date(),
+			data: {}
+		};
+	}
+
+	async disableJobs() {
+		return 0;
+	}
+
+	async enableJobs() {
+		return 0;
+	}
+
+	async purgeAllJobs() {
+		return 0;
+	}
+}
+
+class FutureJobBackend implements AgendaBackend {
+	readonly name = 'FutureJobBackend';
+
+	readonly repository = new FutureJobRepo();
+
+	async connect() {}
+
+	async disconnect() {}
+}
+
+describe('JobProcessor near-future timer cleanup (#1786)', () => {
+	it('clears armed near-future timers on stop() so nothing runs or lingers afterwards', async () => {
+		const backend = new FutureJobBackend();
+		// The job is due ~1s from now, well within the 5s processEvery window,
+		// so the processor takes the arm-a-timer branch instead of running it.
+		backend.repository.runAt = new Date(Date.now() + 1000);
+
+		const agenda = new Agenda({ backend, processEvery: 5000 });
+		agenda.on('error', () => {});
+
+		let ran = 0;
+		agenda.define('timer-leak-test', async () => {
+			ran += 1;
+		});
+
+		await agenda.start();
+		// Give the initial scan a moment to pick up the job and arm the timer
+		await delay(200);
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- white-box access to the processor internals
+		const processor = (agenda as any).jobProcessor;
+		expect(processor).toBeDefined();
+		expect(processor.nextRunTimers.size).toBe(1);
+
+		await agenda.stop();
+		expect(processor.nextRunTimers.size).toBe(0);
+
+		// Wait past the job's due time: the cleared timer must not fire the job
+		await delay(1200);
+		expect(ran).toBe(0);
+	});
+});


### PR DESCRIPTION
## Description

Fixes #1786.

`jobProcessing` arms a `setTimeout` for jobs whose `nextRunAt` falls within the `processEvery` window. The timer was never stored, never `unref`'d, and never cleared — `stop()` only tears down `processInterval`. After `agenda.stop(true)` the armed timer keeps the event loop alive, and for a recurring job with interval ≤ `processEvery` the fired callback re-processes and re-arms indefinitely, so the process never exits (surfaces as hung test suites / short-lived workers).

### Changes
- Track armed timers in a `Set`; clear them in both `stop()` and `drain()` (drain duplicates teardown rather than calling stop, so both paths are covered)
- Guard the arm site on `this.processInterval` — completing jobs trigger `jobProcessing()` again during a drain, which could otherwise re-arm timers mid-teardown
- `unref()` armed timers as defense in depth: an armed timer alone can never block process exit (safe — the non-unref'd `processInterval` keeps a running processor alive)
- Timer callbacks remove themselves from the set, so it can't grow unboundedly

### Test
Regression test drives the real processor through the arm-a-timer branch via a mock backend handing out a job due in ~1s (within a 5s `processEvery`), then asserts: one timer armed → `stop()` → zero timers → past due time → the job never ran. **Verified failing-first** against the unfixed code.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests pass (`pnpm test`) — agenda 186, mongo-backend 260
- [x] Linting passes (`pnpm lint`)
- [x] Added changeset if needed (`pnpm changeset`)
- [ ] Updated documentation if needed (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)