### PR TITLE
docs: document queryJobs plain-object result and Job rehydration pattern

### DIFF
--- a/docs/migration-guide-v6.md
+++ b/docs/migration-guide-v6.md
@@ -192,11 +192,63 @@ const jobs = await agenda.jobs({ name: 'my-job' }, { nextRunAt: -1 }, 10, 0);
 // Structured options object
 const { jobs, total } = await agenda.queryJobs({
   name: 'my-job',
-  sort: 'desc',
+  sort: { nextRunAt: 'desc' },
   limit: 10,
   skip: 0
 });
 ```
+
+#### Queried jobs are plain objects, not `Job` instances
+
+This is the biggest behavioral difference: `agenda.jobs()` returned **`Job` instances**
+(data under `job.attrs`, with methods like `schedule()`, `save()`, `remove()`),
+while `agenda.queryJobs()` returns **plain data objects** (`JobWithState`). The
+fields live directly on the object (no `.attrs`), a computed `state` field is
+included, and none of the `Job` methods are available.
+
+```javascript
+const { jobs } = await agenda.queryJobs({ name: 'my-job' });
+
+jobs[0]._id;       // job id (was: job.attrs._id)
+jobs[0].data;      // job data (was: job.attrs.data)
+jobs[0].state;     // computed state: 'scheduled' | 'queued' | 'running' | ...
+jobs[0].schedule;  // undefined - plain object, not a Job instance
+```
+
+To modify a queried job the way you would have in v5, rehydrate it into a
+`Job` instance with the exported `Job` class — the same mechanism agenda uses
+internally:
+
+**Before (v4/v5):**
+```javascript
+const jobs = await agenda.jobs({ name: 'my-job', 'data.prop': false });
+
+for (const job of jobs) {
+  job.attrs.data.prop = true;
+  job.schedule('in 20 minutes');
+  await job.save();
+}
+```
+
+**After (v6):**
+```javascript
+import { Agenda, Job } from 'agenda';
+
+const { jobs } = await agenda.queryJobs({ name: 'my-job', data: { prop: false } });
+
+for (const { state, ...jobData } of jobs) {
+  // strip the computed `state` field, then rehydrate into a Job instance
+  const job = new Job(agenda, jobData);
+  job.attrs.data.prop = true;
+  job.schedule('in 20 minutes');
+  await job.save();
+}
+```
+
+Note that `job.save()` intentionally does not persist processor-managed fields
+(`lockedAt`, `lastRunAt`, `failCount`, ...) to avoid racing with a running
+processor — user code updates data and scheduling, the processor owns
+execution state.
 
 ### 8. Removed Features
 

--- a/packages/mongo-backend/test/mongo-backend.test.ts
+++ b/packages/mongo-backend/test/mongo-backend.test.ts
@@ -1,7 +1,7 @@
 import { expect, describe, it, beforeAll, afterAll, beforeEach, afterEach, assert, vi } from 'vitest';
 import { Db, DbOptions, MongoClient, ObjectId } from 'mongodb';
 import { randomUUID } from 'crypto';
-import { InMemoryNotificationChannel } from 'agenda';
+import { Agenda, Job, InMemoryNotificationChannel } from 'agenda';
 import { MongoBackend, MongoJobRepository, MongoJobLogger } from '../src/index.js';
 import { fullAgendaTestSuite, jobLoggerTestSuite } from 'agenda/testing';
 import { testMongoClientOptions } from './helpers/testMongoClientOptions.js';
@@ -192,6 +192,39 @@ describe('MongoBackend', () => {
 	});
 
 	describe('MongoDB-specific features', () => {
+		it('should support the documented queryJobs -> new Job() rehydration pattern', async () => {
+			// Pattern documented in docs/migration-guide-v6.md (#1716): queryJobs
+			// returns plain objects; rehydrate with new Job(agenda, jobData) to
+			// modify and save like a v5 Job instance.
+			const agenda = new Agenda({ backend });
+			agenda.on('error', () => {});
+
+			await backend.repository.saveJob({
+				name: 'rehydrate-test',
+				priority: 0,
+				nextRunAt: new Date(),
+				type: 'normal',
+				data: { prop: false }
+			}, undefined);
+
+			const { jobs } = await agenda.queryJobs({ name: 'rehydrate-test', data: { prop: false } });
+			expect(jobs).toHaveLength(1);
+
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars -- strip the computed state field
+			const { state, ...jobData } = jobs[0];
+			const job = new Job(agenda, jobData);
+			(job.attrs.data as { prop: boolean }).prop = true;
+			job.schedule(new Date(Date.now() + 20 * 60 * 1000));
+			await job.save();
+
+			const doc = await db.collection(TEST_COLLECTION).findOne({ name: 'rehydrate-test' });
+			assert(doc !== null, 'Job should exist in the collection');
+			expect(doc.data).toEqual({ prop: true });
+			expect(doc.nextRunAt.getTime()).toBeGreaterThan(Date.now() + 19 * 60 * 1000);
+			// the computed state field must not leak into the stored document
+			expect(doc.state).toBeUndefined();
+		});
+
 		it('should support partial matching on job data', async () => {
 			const jobData = { nested: { key: 'value' }, array: [1, 2, 3], extra: 'field' };
 


### PR DESCRIPTION
## Description

Fixes #1716.

The migration guide covered the `jobs()` → `queryJobs()` rename but not the biggest behavioral change: `queryJobs` returns plain `JobWithState` objects — fields at top level (no `.attrs`), a computed `state` field, and none of the `Job` methods.

### Changes
- New subsection documenting the difference, with the exact v5→v6 example from the issue
- Documents the clean rehydration pattern — `new Job(agenda, jobData)` after stripping the computed `state` field — which is the same mechanism agenda uses internally (`runForkedJob`), restoring v5 ergonomics (`job.attrs.data`, `schedule()`, `save()`)
- Notes that `save()` intentionally excludes processor-managed fields (no racing with a running processor)
- Fixes the pre-existing incorrect `sort: 'desc'` example — `sort` is an object (`{ nextRunAt: 'desc' }`)
- Integration test proving the documented pattern end-to-end, including that `state` does not leak into the stored document

No changeset: docs + test only.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] Tests pass (`pnpm test`) — mongo-backend 261
- [x] Linting passes (`pnpm lint`)
- [ ] Added changeset if needed (n/a — docs/test only)
- [x] Updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)