### PR TITLE
fix(agenda): resolve repeatAt relative to lastRunAt

### DIFF
--- a/packages/agenda/src/utils/nextRunAt.ts
+++ b/packages/agenda/src/utils/nextRunAt.ts
@@ -118,7 +118,10 @@ export function computeFromRepeatAt(attrs: JobParameters<unknown>): Date | null 
 		throw new Error('repeatAt is required');
 	}
 
-	const nextDate = date(repeatAt).valueOf();
+	// Resolve `repeatAt` from `lastRun`, not from `now`. When `lastRunAt` is in the
+	// future (e.g. a manually scheduled job), `date(repeatAt)` from the current
+	// clock can return an instant before `lastRun`, causing duplicate or missed runs.
+	const nextDate = date(repeatAt, lastRun).valueOf();
 
 	// If you do not specify offset date for below test it will fail for ms
 	const offset = Date.now();
@@ -130,9 +133,9 @@ export function computeFromRepeatAt(attrs: JobParameters<unknown>): Date | null 
 
 	let nextRunAt: Date;
 	if (nextDate === lastRun.valueOf()) {
-		nextRunAt = date('tomorrow at ' + repeatAt);
+		nextRunAt = date('tomorrow at ' + repeatAt, lastRun);
 	} else {
-		nextRunAt = date(repeatAt);
+		nextRunAt = date(repeatAt, lastRun);
 	}
 
 	// Apply date constraints (startDate, endDate, skipDays)

--- a/packages/agenda/test/nextRunAt.test.ts
+++ b/packages/agenda/test/nextRunAt.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { computeFromInterval } from '../src/utils/nextRunAt.js';
+import { computeFromInterval, computeFromRepeatAt } from '../src/utils/nextRunAt.js';
 import type { JobParameters } from '../src/index.js';
 
 function baseAttrs(overrides: Partial<JobParameters<unknown>>): JobParameters<unknown> {
@@ -16,6 +16,28 @@ function baseAttrs(overrides: Partial<JobParameters<unknown>>): JobParameters<un
 		...overrides
 	} as JobParameters<unknown>;
 }
+
+describe('computeFromRepeatAt', () => {
+	it('resolves repeatAt relative to lastRunAt so the next run is never in the past', () => {
+		const lastRunAt = new Date(Date.now() + 120_000);
+		const result = computeFromRepeatAt(baseAttrs({ repeatAt: 'in 1 minute', lastRunAt }));
+		expect(result).not.toBeNull();
+		expect(result!.getTime()).toBeGreaterThan(lastRunAt.getTime());
+	});
+
+	it('advances to the next occurrence when repeatAt matches lastRunAt exactly', () => {
+		const lastRunAt = new Date('2026-01-01T12:00:00.000Z');
+		const result = computeFromRepeatAt(baseAttrs({ repeatAt: '12:00pm', lastRunAt }));
+		expect(result).not.toBeNull();
+		expect(result!.getTime()).toBeGreaterThan(lastRunAt.getTime());
+	});
+
+	it('throws for an invalid repeatAt format', () => {
+		expect(() => computeFromRepeatAt(baseAttrs({ repeatAt: 'not-a-time' }))).toThrow(
+			'failed to calculate repeatAt time due to invalid format'
+		);
+	});
+});
 
 describe('computeFromInterval - numeric millisecond repeatInterval', () => {
 	it('treats a numeric repeatInterval as milliseconds', () => {


### PR DESCRIPTION
## Description

`computeFromRepeatAt` in `packages/agenda/src/utils/nextRunAt.ts` now resolves `repeatAt` strings relative to `lastRunAt` instead of the current wall-clock time.

Previously, `date(repeatAt)` was computed from `new Date()`. When `lastRunAt` was in the future (for example, a manually scheduled job or a skipped run), the resulting `nextRunAt` could be an instant before `lastRunAt`, causing the job to be scheduled in the past and run repeatedly.

This change:
- Uses `lastRun` as the reference date for every `date.js` call.
- Keeps the existing "tomorrow at" advance when `repeatAt` exactly matches `lastRunAt`.
- Adds regression tests in `packages/agenda/test/nextRunAt.test.ts` covering the past-time case and the exact-match case.

## Relation to open PRs

This is orthogonal to #1780 (repeatTimezone handling in the same function). I checked that PR's diff and it only adds a timezone reinterpretation block after the `nextRunAt` assignment, so whichever merges first should be a straightforward rebase for the other.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [ ] Added changeset if needed (`pnpm changeset`)
- [ ] Updated documentation if needed

I did not add a changeset because this is a pure bug fix with no public API change.
