### PR TITLE
fix(agenda): wait for startup before teardown

### DIFF
--- a/.changeset/lifecycle-teardown-start-race.md
+++ b/.changeset/lifecycle-teardown-start-race.md
@@ -1,5 +1,5 @@
 ---
-"agenda": patch
+'agenda': patch
 ---
 
 Fix stop() and drain() called during start() from leaving a JobProcessor running.

--- a/.changeset/lifecycle-teardown-start-race.md
+++ b/.changeset/lifecycle-teardown-start-race.md
@@ -1,0 +1,5 @@
+---
+"agenda": patch
+---
+
+Fix stop() and drain() called during start() from leaving a JobProcessor running.

--- a/packages/agenda/src/index.ts
+++ b/packages/agenda/src/index.ts
@@ -1143,6 +1143,11 @@ export class Agenda extends EventEmitter {
 	 *   false if connection was passed in by user).
 	 */
 	async stop(closeConnection?: boolean): Promise<void> {
+		if (this.startPromise) {
+			log('Agenda.stop called while start is in progress, waiting for start');
+			await this.startPromise;
+		}
+
 		if (!this.jobProcessor) {
 			log('Agenda.stop called, but agenda has never started!');
 			return;
@@ -1213,6 +1218,11 @@ export class Agenda extends EventEmitter {
 	async drain(
 		options?: number | (DrainOptions & { closeConnection?: boolean })
 	): Promise<DrainResult> {
+		if (this.startPromise) {
+			log('Agenda.drain called while start is in progress, waiting for start');
+			await this.startPromise;
+		}
+
 		if (!this.jobProcessor) {
 			log('Agenda.drain called, but agenda has never started!');
 			return { completed: 0, running: 0, timedOut: false, aborted: false };

--- a/packages/agenda/test/unit.test.ts
+++ b/packages/agenda/test/unit.test.ts
@@ -913,3 +913,41 @@ describe('start() concurrency', () => {
 		expect(channel.state).toBe('disconnected');
 	});
 });
+
+describe('teardown during start()', () => {
+	class SlowConnectBackend extends MockBackend {
+		async connect(): Promise<void> {
+			await new Promise(resolve => setTimeout(resolve, 30));
+		}
+	}
+
+	it('stop() called during start waits for startup before tearing down', async () => {
+		const agenda = new Agenda({ backend: new SlowConnectBackend() });
+		const startPromise = agenda.start();
+		const stopPromise = agenda.stop();
+
+		try {
+			await Promise.all([startPromise, stopPromise]);
+			expect(agenda.isActiveJobProcessor()).toBe(false);
+		} finally {
+			if (agenda.isActiveJobProcessor()) {
+				await agenda.stop();
+			}
+		}
+	});
+
+	it('drain() called during start waits for startup before tearing down', async () => {
+		const agenda = new Agenda({ backend: new SlowConnectBackend() });
+		const startPromise = agenda.start();
+		const drainPromise = agenda.drain();
+
+		try {
+			await Promise.all([startPromise, drainPromise]);
+			expect(agenda.isActiveJobProcessor()).toBe(false);
+		} finally {
+			if (agenda.isActiveJobProcessor()) {
+				await agenda.stop();
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Description

Fix a race when `stop()` or `drain()` is called while `start()` is still awaiting backend or notification-channel setup. Previously, teardown could return before `jobProcessor` existed, then startup would complete and leave a processor running.

Both teardown methods now await an in-flight `startPromise` before checking and shutting down the processor. Regression tests cover both `stop()` and `drain()`, including cleanup on assertion failure.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Tests pass (`pnpm test`) - not run locally; upstream CI should verify
- [ ] Linting passes (`pnpm lint`) - not run locally; upstream CI should verify
- [x] Added changeset if needed (`pnpm changeset`)
- [x] Updated documentation if needed (no user-facing documentation change required)
