### PR TITLE
fix(mongo-backend): create additional indexes for common queries

### DIFF
--- a/.changeset/mongo-indexes.md
+++ b/.changeset/mongo-indexes.md
@@ -1,0 +1,5 @@
+---
+'@agendajs/mongo-backend': patch
+---
+
+Create additional MongoDB indexes on connect for `getDistinctJobNames()`, `getQueueSize()`, and single-type `saveJob()` upserts.

--- a/packages/mongo-backend/README.md
+++ b/packages/mongo-backend/README.md
@@ -160,7 +160,7 @@ const agenda = new Agenda({
 
 ## Database Index
 
-By default, MongoBackend automatically creates the `findAndLockNextJobIndex` index on connect for optimal job query performance. The index includes:
+By default, MongoBackend automatically creates the following indexes on connect for optimal job query performance:
 
 ```javascript
 {
@@ -171,6 +171,10 @@ By default, MongoBackend automatically creates the `findAndLockNextJobIndex` ind
   "disabled": 1
 }
 ```
+
+- `nameIdx` for `getDistinctJobNames()` / `getJobsOverview()`
+- `nextRunAtIdx` for `getQueueSize()`
+- `nameTypeIdx` for `saveJob()` single-type upserts
 
 To disable automatic index creation (e.g., if you manage indexes separately):
 

--- a/packages/mongo-backend/src/MongoJobRepository.ts
+++ b/packages/mongo-backend/src/MongoJobRepository.ts
@@ -671,6 +671,21 @@ export class MongoJobRepository implements JobRepository {
 					{ name: 'findAndLockNextJobIndex' }
 				);
 				log('index succesfully created', result);
+
+				// Index for getDistinctJobNames / getJobsOverview
+				await this.collection.createIndex({ name: 1 }, { name: 'nameIdx' });
+
+				// Index for getQueueSize (query on nextRunAt without name)
+				await this.collection.createIndex(
+					{ nextRunAt: 1 },
+					{ name: 'nextRunAtIdx' }
+				);
+
+				// Index for saveJob single-type upsert (query on name + type)
+				await this.collection.createIndex(
+					{ name: 1, type: 1 },
+					{ name: 'nameTypeIdx' }
+				);
 			} catch (error) {
 				log('db index creation failed', error);
 				throw error;

--- a/packages/mongo-backend/test/mongo-backend.test.ts
+++ b/packages/mongo-backend/test/mongo-backend.test.ts
@@ -674,11 +674,14 @@ describe('MongoBackend', () => {
 			expect(jobs.total).toBe(1);
 
 			const indexes = await db.collection(testCollection).indexes();
-			// Should have _id and findAndLockNextJobIndex
-			expect(indexes.length).toBeGreaterThanOrEqual(2);
+			// Should have _id and the indexes created by MongoBackend
+			expect(indexes.length).toBeGreaterThanOrEqual(5);
 			const indexNames = indexes.map(i => i.name);
 			expect(indexNames).toContain('_id_');
 			expect(indexNames).toContain('findAndLockNextJobIndex');
+			expect(indexNames).toContain('nameIdx');
+			expect(indexNames).toContain('nextRunAtIdx');
+			expect(indexNames).toContain('nameTypeIdx');
 
 			await backendWithIndex.disconnect();
 			await db.collection(testCollection).drop();


### PR DESCRIPTION
Closes #1714

Adds the missing MongoDB indexes that the backend queries rely on:

- `nameIdx` (`{ name: 1 }`) for `getDistinctJobNames()` and `getJobsOverview()`.
- `nextRunAtIdx` (`{ nextRunAt: 1 }`) for `getQueueSize()`.
- `nameTypeIdx` (`{ name: 1, type: 1 }`) for the single-type `saveJob()` upsert path.

These are created alongside the existing `findAndLockNextJobIndex` when `ensureIndex` is true (the default).

## Verification

- `pnpm --filter @agendajs/mongo-backend exec vitest run test/mongo-backend.test.ts` passed (237 tests, 3 skipped).
- `pnpm lint` passed.
- Added a changeset for `@agendajs/mongo-backend`.