### PR TITLE
fix(agenda): clamp near-future setTimeout delays to signed 32-bit max

### DIFF
--- a/.changeset/settimeout-overflow.md
+++ b/.changeset/settimeout-overflow.md
@@ -1,0 +1,5 @@
+---
+'agenda': patch
+---
+
+Clamp near-future `setTimeout` delays to `2^31 - 1` ms. Node.js treats delays larger than a signed 32-bit integer as an overflow and clamps them to 1 ms, causing the JobProcessor to immediately reprocess a far-future job. The new ceiling matches Node's actual limit and prevents immediate reprocessing when `processEvery` is configured larger than that job's delay.

--- a/packages/agenda/src/JobProcessor.ts
+++ b/packages/agenda/src/JobProcessor.ts
@@ -14,7 +14,7 @@ const log = debug('agenda:jobProcessor');
 
 const agendaVersion = packageJson.version;
 
-const MAX_SAFE_32BIT_INTEGER = 2 ** 31; // Math.pow(2,31);
+const MAX_SAFE_32BIT_INTEGER = 2 ** 31 - 1; // Math.pow(2,31) - 1;
 
 /**
  * @class

--- a/packages/agenda/test/jobprocessor-settimeout-overflow.test.ts
+++ b/packages/agenda/test/jobprocessor-settimeout-overflow.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Regression test for setTimeout 32-bit signed-integer overflow.
+ *
+ * Node.js clamps delays > 2^31 - 1 to 1 ms and emits TimeoutOverflowWarning.
+ * When processEvery is large enough (e.g. a human-interval such as "30 days"),
+ * a near-future job can have a runIn that exceeds 2^31 - 1 and reach the
+ * setTimeout branch in JobProcessor. JobProcessor must clamp that delay to
+ * 2^31 - 1, not 2^31, otherwise the timer fires immediately and the job is
+ * reprocessed in a tight loop.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Agenda, toJobId } from '../src/index.js';
+import type { AgendaBackend, JobRepository, JobParameters } from '../src/index.js';
+
+const MAX_SIGNED_32BIT = 2 ** 31 - 1;
+const OVER_MAX_SIGNED_32BIT = 2 ** 31 + 500;
+
+class FutureJobRepo implements JobRepository {
+	public handedOut = false;
+
+	public runAt: Date = new Date();
+
+	async connect() {}
+
+	async queryJobs() {
+		return { jobs: [], total: 0 };
+	}
+
+	async getJobsOverview() {
+		return [];
+	}
+
+	async getDistinctJobNames() {
+		return [];
+	}
+
+	async getJobById() {
+		return null;
+	}
+
+	async getQueueSize() {
+		return 0;
+	}
+
+	async removeJobs() {
+		return 0;
+	}
+
+	async saveJob<DATA = unknown>(job: JobParameters<DATA>): Promise<JobParameters<DATA>> {
+		return { ...job, _id: job._id || toJobId('mock-id') };
+	}
+
+	async saveJobState() {}
+
+	async lockJob() {
+		return undefined;
+	}
+
+	async unlockJob() {}
+
+	async unlockJobs() {}
+
+	async getNextJobToRun(): Promise<JobParameters | undefined> {
+		if (this.handedOut) {
+			return undefined;
+		}
+		this.handedOut = true;
+		return {
+			_id: toJobId('overflow-test'),
+			name: 'overflow-test',
+			priority: 0,
+			type: 'normal',
+			nextRunAt: this.runAt,
+			lockedAt: new Date(),
+			data: {}
+		};
+	}
+
+	async disableJobs() {
+		return 0;
+	}
+
+	async enableJobs() {
+		return 0;
+	}
+
+	async purgeAllJobs() {
+		return 0;
+	}
+}
+
+class FutureJobBackend implements AgendaBackend {
+	readonly name = 'FutureJobBackend';
+
+	readonly repository = new FutureJobRepo();
+
+	async connect() {}
+
+	async disconnect() {}
+}
+
+describe('JobProcessor setTimeout overflow clamp', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('clamps near-future timers to the maximum signed 32-bit delay', async () => {
+		const backend = new FutureJobBackend();
+		// processEvery is larger than the job's runIn, so the processor takes the
+		// arm-a-timer branch instead of freeing the job for the next scan.
+		backend.repository.runAt = new Date(Date.now() + OVER_MAX_SIGNED_32BIT);
+
+		const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+		const agenda = new Agenda({
+			backend,
+			// processEvery larger than runIn; human-interval "30 days" is realistic.
+			processEvery: OVER_MAX_SIGNED_32BIT + 1000
+		});
+		agenda.on('error', () => {});
+
+		agenda.define('overflow-test', async () => {});
+
+		await agenda.start();
+
+		// Let the initial async job queue filling settle.
+		await vi.advanceTimersByTimeAsync(1);
+
+		const timerDelays = setTimeoutSpy.mock.calls
+			.map(args => (typeof args[1] === 'number' ? args[1] : -1))
+			.filter(delay => delay > 1000);
+
+		expect(timerDelays).toContain(MAX_SIGNED_32BIT);
+		expect(timerDelays).not.toContain(2 ** 31);
+
+		await agenda.stop();
+	});
+});


### PR DESCRIPTION
## Problem

`JobProcessor` arms a `setTimeout` for near-future jobs with:

```ts
runIn > MAX_SAFE_32BIT_INTEGER ? MAX_SAFE_32BIT_INTEGER : runIn
```

`MAX_SAFE_32BIT_INTEGER` was `2 ** 31` (2147483648). Node.js treats delays larger than a signed 32-bit integer (`2 ** 31 - 1`) as an overflow and clamps them to `1` ms, so a timer armed with `2 ** 31` fires almost immediately and reprocesses the job in a tight loop.

This is reachable when `processEvery` is configured larger than the job's delay (for example, a human-interval like `processEvery: '30 days'` ≈ 2.59 billion ms). A job due in, say, 10 days would have `runIn` ≈ 864 million ms — larger than `2 ** 31 - 1` and within `processEvery`, so the processor arms the timer instead of releasing the lock.

## Fix

Change the ceiling to `2 ** 31 - 1`, which is the maximum delay Node.js accepts without overflowing.

- `packages/agenda/src/JobProcessor.ts`: `MAX_SAFE_32BIT_INTEGER = 2 ** 31 - 1`
- `packages/agenda/test/jobprocessor-settimeout-overflow.test.ts`: regression test that arms a near-future timer with `runIn` above `2 ** 31` and asserts the clamped delay equals `2 ** 31 - 1`, not `2 ** 31`.
- `.changeset/settimeout-overflow.md`: patch changeset for `agenda`.

## Verification

```bash
cd packages/agenda && bun run test
# Test Files  12 passed (12)
# Tests       187 passed (187)

cd ../..
bun run lint   # clean
bun run typecheck  # clean
```

Also verified the regression test fails when the constant is reverted to `2 ** 31`:

```
expected [ 2147483648 ] to include 2147483647
```
