### PR TITLE
fix(backends): don't double-count disabled jobs in getJobsOverview

### DIFF
--- a/packages/agenda/test/shared/repository-test-suite.ts
+++ b/packages/agenda/test/shared/repository-test-suite.ts
@@ -703,6 +703,29 @@ export function repositoryTestSuite(config: RepositoryTestConfig): void {
 				expect(overviewJob).toBeDefined();
 				expect(overviewJob!.total).toBe(2);
 			});
+
+			it('should not double-count disabled jobs as paused and their computed state', async () => {
+				// A disabled job with a future nextRunAt is reported only as paused,
+				// not as both paused and scheduled (see issue #1768).
+				const saved = await repo.saveJob({
+					name: 'paused-overview-job',
+					priority: 0,
+					nextRunAt: new Date(Date.now() + 60000),
+					disabled: true,
+					type: 'normal',
+					data: {}
+				}, undefined);
+				expect(saved.disabled).toBe(true);
+
+				const overview = await repo.getJobsOverview();
+				const overviewJob = overview.find(o => o.name === 'paused-overview-job');
+				expect(overviewJob).toBeDefined();
+				expect(overviewJob!.total).toBe(1);
+				expect(overviewJob!.paused).toBe(1);
+				expect(overviewJob!.scheduled).toBe(0);
+				expect(overviewJob!.queued).toBe(0);
+				expect(overviewJob!.completed).toBe(0);
+			});
 		});
 	});
 }

--- a/packages/mongo-backend/src/MongoJobRepository.ts
+++ b/packages/mongo-backend/src/MongoJobRepository.ts
@@ -356,10 +356,11 @@ export class MongoJobRepository implements JobRepository {
 				};
 
 				for (const job of jobs) {
-					const state = computeJobState(job as unknown as JobParameters, now);
-					overview[state]++;
 					if (job.disabled === true) {
 						overview.paused++;
+					} else {
+						const state = computeJobState(job as unknown as JobParameters, now);
+						overview[state]++;
 					}
 				}
 

--- a/packages/postgres-backend/src/PostgresJobRepository.ts
+++ b/packages/postgres-backend/src/PostgresJobRepository.ts
@@ -371,10 +371,11 @@ export class PostgresJobRepository implements JobRepository {
 
 				for (const row of result.rows) {
 					const job = this.rowToJob(row);
-					const state = computeJobState(job, now);
-					overview[state as keyof typeof overview]++;
 					if (job.disabled === true) {
 						overview.paused++;
+					} else {
+						const state = computeJobState(job, now);
+						overview[state as keyof typeof overview]++;
 					}
 				}
 

--- a/packages/redis-backend/src/RedisJobRepository.ts
+++ b/packages/redis-backend/src/RedisJobRepository.ts
@@ -352,10 +352,11 @@ export class RedisJobRepository implements JobRepository {
 					if (!jobData || Object.keys(jobData).length === 0) continue;
 
 					const job = this.hashToJob(jobData);
-					const state = computeJobState(job, now);
-					overview[state as keyof typeof overview]++;
 					if (job.disabled === true) {
 						overview.paused++;
+					} else {
+						const state = computeJobState(job, now);
+						overview[state as keyof typeof overview]++;
 					}
 				}
 


### PR DESCRIPTION
## Problem

`getJobsOverview()` double-counts disabled jobs. A disabled job with a future `nextRunAt` was counted once under `scheduled` (its computed state) and again under `paused` (because `job.disabled === true`).

Fixes #1768.

## Fix

In all three backend implementations (`mongo-backend`, `redis-backend`, `postgres-backend`), count a disabled job only under `paused` and do not increment its computed state.

- `MongoJobRepository.ts`
- `RedisJobRepository.ts`
- `PostgresJobRepository.ts`

## Verification

Added a shared test covering a disabled job with a future `nextRunAt` and verified it is reported as `paused: 1, scheduled: 0, queued: 0, completed: 0`.

- `pnpm --filter mongo-backend typecheck` passed
- `pnpm --filter mongo-backend test` passed (262 tests, 3 skipped)
