### PR TITLE
fix(agenda): make Job.unique() merge with existing uniqueOpts

### DIFF
--- a/packages/agenda/src/Job.ts
+++ b/packages/agenda/src/Job.ts
@@ -238,7 +238,7 @@ export class Job<DATA = unknown | void> {
 		opts?: JobParameters['uniqueOpts']
 	): this {
 		this.attrs.unique = unique;
-		this.attrs.uniqueOpts = opts;
+		this.attrs.uniqueOpts = { ...this.attrs.uniqueOpts, ...opts };
 		return this;
 	}
 

--- a/packages/agenda/test/unit.test.ts
+++ b/packages/agenda/test/unit.test.ts
@@ -261,6 +261,18 @@ describe('Job Unit Tests', () => {
 			const job = new Job(agenda, { name: 'demo', type: 'normal' });
 			expect(job.unique({})).toBe(job);
 		});
+
+		it('merges with previously-set uniqueOpts instead of replacing them', () => {
+			const job = new Job(agenda, { name: 'demo', type: 'normal' });
+			job.debounce(5000, { maxWait: 30000 });
+			job.unique({ 'data.id': '1' }, { insertOnly: true });
+
+			expect(job.attrs.unique).toEqual({ 'data.id': '1' });
+			expect(job.attrs.uniqueOpts).toMatchObject({
+				insertOnly: true,
+				debounce: { delay: 5000, maxWait: 30000, strategy: 'trailing' }
+			});
+		});
 	});
 
 	describe('repeatEvery', () => {


### PR DESCRIPTION
## Problem

`Job.unique()` replaces `this.attrs.uniqueOpts` with the new `opts` object. If the fluent chain called `.debounce()` first, the debounce options are silently discarded when `.unique()` runs.

Fixes #1762.

## Fix

Change `Job.unique()` to merge `opts` into the existing `this.attrs.uniqueOpts` instead of overwriting it.

## Verification

Added a unit test that calls `.debounce()` then `.unique()` and asserts that both `debounce` and `insertOnly` survive in `uniqueOpts`.

- `pnpm --filter agenda test` passed (187 tests).
